### PR TITLE
lang: fixed Greek strings.xml

### DIFF
--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -103,7 +103,7 @@
     <string name="share">Κοινοποίηση</string>
     <string name="delete">Διαγραφή</string>
     <string name="remove_from_history">Κατάργηση από το ιστορικό</string>
-    <string name="search_online">Αναζήτηση online</string>
+    <string name="search_online">Αναζ. online</string>
     <string name="sync">Συγχρονισμός</string>
     <string name="advanced">Για προχωρημένους</string>
     <string name="select">Επιλογή όλων</string>


### PR DESCRIPTION
Error: OK buttons showed flowing downwards on the lyrics search dialog.
Fix: Shortened the word "Αναζήτηση online" (Search online) by cutting some letters, it is normal for Greek.

More fixes may come.
![Screenshot_2025-01-19-20-15-32-374_com metrolist music](https://github.com/user-attachments/assets/420262c3-aedd-4345-bcaa-145e66abfe59)
