### PR TITLE
Icons invisible in App Shortcuts

### DIFF
--- a/app/src/main/res/drawable/shortcut_explore.xml
+++ b/app/src/main/res/drawable/shortcut_explore.xml
@@ -5,7 +5,7 @@
     android:viewportHeight="24">
 
     <path
-        android:fillColor="#ffffff"
+        android:fillColor="#000000"
         android:pathData="M12,10.9c-0.61,0 -1.1,0.49 -1.1,1.1s0.49,1.1 1.1,1.1c0.61,0 1.1,-0.49 1.1,-1.1s-0.49,-1.1 -1.1,-1.1zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM14.19,14.19L6,18l3.81,-8.19L18,6l-3.81,8.19z" />
 
 </vector>

--- a/app/src/main/res/drawable/shortcut_library.xml
+++ b/app/src/main/res/drawable/shortcut_library.xml
@@ -1,16 +1,15 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24.0dip"
-    android:height="24.0dip"
-    android:tint="@android:color/white"
-    android:viewportWidth="24.0"
-    android:viewportHeight="24.0">
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
     <path
-        android:fillColor="@android:color/white"
+        android:fillColor="#000000"
         android:pathData="M18,21H3V6h1v14h14V21z"
         android:strokeWidth="1.0"
-        android:strokeColor="#ffffff"
+        android:strokeColor="#000000"
         android:strokeLineCap="butt" />
     <path
-        android:fillColor="@android:color/white"
+        android:fillColor="#000000"
         android:pathData="M21,3v15H6V3H21zM16,6h-3v5.28C12.7,11.11 12.37,11 12,11c-1.1,0 -2,0.9 -2,2s0.9,2 2,2s2,-0.9 2,-2V8h2V6z" />
 </vector>

--- a/app/src/main/res/drawable/shortcut_search.xml
+++ b/app/src/main/res/drawable/shortcut_search.xml
@@ -5,10 +5,10 @@
     android:viewportWidth="1024.0"
     android:viewportHeight="1024.0">
     <path
-        android:fillColor="#ffffffff"
+        android:fillColor="#000000"
         android:pathData="m795.9,750.7 l125,124.9a32,32 0,0 0,-45.2 45.2L750.7,795.9a416,416 0,1 1,45.2 -45.2zM900.485,877.071l2.829,2.828 -20.415,20.415 -2.828,-2.829 1.414,-1.414zM480,832a352,352 0,1 0,0 -704,352 352,0 0,0 0,704z"
         android:strokeWidth="20.0"
-        android:strokeColor="#ffffffff"
+        android:strokeColor="#000000"
         android:strokeLineCap="butt"
         android:strokeLineJoin="miter" />
 </vector>


### PR DESCRIPTION
Issue: https://github.com/mostafaalagamy/Metrolist/issues/325
Fix: Change the color of the icons to black
