### PR TITLE
Improve Lyric Auto-Scrolling Behavior

### DIFF
--- a/app/src/main/java/com/metrolist/music/ui/component/Lyrics.kt
+++ b/app/src/main/java/com/metrolist/music/ui/component/Lyrics.kt
@@ -154,6 +154,10 @@ fun Lyrics(
         mutableStateOf(false)
     }
 
+    var shouldScrollToFirstLine by rememberSaveable {
+        mutableStateOf(true)
+    }
+
     LaunchedEffect(lyrics) {
         if (lyrics.isNullOrEmpty() || !lyrics.startsWith("[")) {
             currentLineIndex = -1
@@ -200,7 +204,12 @@ fun Lyrics(
         }
 
         if (!isSynced) return@LaunchedEffect
-        if (currentLineIndex != -1) {
+        if(currentLineIndex == 0 && shouldScrollToFirstLine) {
+            shouldScrollToFirstLine = false
+            lazyListState.animateScrollToItem(
+                currentLineIndex,
+                with(density) { 36.dp.toPx().toInt() } + calculateOffset())
+        } else if (currentLineIndex != -1) {
             deferredCurrentLineIndex = currentLineIndex
             if (lastPreviewTime == 0L || currentLineIndex != previousLineIndex) {
                 if (isSeeking) {
@@ -227,6 +236,9 @@ fun Lyrics(
                 }
                 previousLineIndex = currentLineIndex
             }
+        }
+        if(currentLineIndex > 0) {
+            shouldScrollToFirstLine = true
         }
     }
 

--- a/app/src/main/java/com/metrolist/music/ui/component/Lyrics.kt
+++ b/app/src/main/java/com/metrolist/music/ui/component/Lyrics.kt
@@ -222,12 +222,14 @@ fun Lyrics(
 
                     val viewportStartOffset = lazyListState.layoutInfo.viewportStartOffset
                     val viewportEndOffset = lazyListState.layoutInfo.viewportEndOffset
-                    val currentLineOffset = visibleItemsInfo.find { it.index == previousLineIndex }?.offset ?: 0
+                    val currentLineOffset = visibleItemsInfo.find { it.index == currentLineIndex }?.offset ?: 0
+                    val previousLineOffset = visibleItemsInfo.find { it.index == previousLineIndex }?.offset ?: 0
 
                     val centerRangeStart = viewportStartOffset + (viewportEndOffset - viewportStartOffset) / 2
                     val centerRangeEnd = viewportEndOffset - (viewportEndOffset - viewportStartOffset) / 8
 
-                    if (currentLineOffset in centerRangeStart..centerRangeEnd) {
+                    if (currentLineOffset in centerRangeStart..centerRangeEnd ||
+                        previousLineOffset in centerRangeStart..centerRangeEnd) {
                         lazyListState.animateScrollToItem(
                             currentLineIndex,
                             with(density) { 36.dp.toPx().toInt() } + calculateOffset())

--- a/app/src/main/java/com/metrolist/music/ui/component/Lyrics.kt
+++ b/app/src/main/java/com/metrolist/music/ui/component/Lyrics.kt
@@ -203,7 +203,6 @@ fun Lyrics(
         if (currentLineIndex != -1) {
             deferredCurrentLineIndex = currentLineIndex
             if (lastPreviewTime == 0L || currentLineIndex != previousLineIndex) {
-                previousLineIndex = currentLineIndex
                 if (isSeeking) {
                     lazyListState.scrollToItem(currentLineIndex,
                         with(density) { 36.dp.toPx().toInt() } + calculateOffset())
@@ -214,7 +213,7 @@ fun Lyrics(
 
                     val viewportStartOffset = lazyListState.layoutInfo.viewportStartOffset
                     val viewportEndOffset = lazyListState.layoutInfo.viewportEndOffset
-                    val currentLineOffset = visibleItemsInfo.find { it.index == currentLineIndex }?.offset ?: 0
+                    val currentLineOffset = visibleItemsInfo.find { it.index == previousLineIndex }?.offset ?: 0
 
                     val centerRangeStart = viewportStartOffset + (viewportEndOffset - viewportStartOffset) / 2
                     val centerRangeEnd = viewportEndOffset - (viewportEndOffset - viewportStartOffset) / 8
@@ -226,6 +225,7 @@ fun Lyrics(
                         initialScrollDone = true
                     }
                 }
+                previousLineIndex = currentLineIndex
             }
         }
     }


### PR DESCRIPTION
**This PR enhances the way lyrics auto-scroll to make it feel more intuitive and similar to Spotify.**

What Changed?
- **Smarter syncing behavior:** Instead of blindly jumping to the current line after 4 seconds of inactivity, auto-scroll now only re-engages when the lyrics are positioned within a specific sync zone between 1/2 and 7/8 of the screen.
- If the user scrolls away and the line isn't in the sync zone anymore, it won’t automatically pull them back.
- If the user scrolls to the lyrics but they appear in the top half, it will wait until the lyrics reach the middle before following along.
- If the lyrics are at the bottom, they will move back to the middle after a short delay.
- **Immediate Sync on New Line:** When the lyrics are synced to a new line (i.e. the current line is within the sync zone), the view now scrolls to that line immediately instead of waiting for the fallback delay. This ensures the view quickly follows the synced line when a new one is reached. The fallback delay (now reduced to 2 seconds) is still in place, but this change smooths the transition when syncing to new lines.

Why?
- Makes scrolling feel more natural and less jarring.
- Prevents unwanted jumps when manually navigating lyrics.