### PR TITLE
Add MediaButtonReceiver to support external media control

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -151,6 +151,14 @@
             </intent-filter>
         </service>
 
+        <receiver
+            android:name="androidx.media3.session.MediaButtonReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON" />
+            </intent-filter>
+        </receiver>        
+
         <meta-data
             android:name="com.google.android.gms.car.application"
             android:resource="@xml/automotive_app_desc" />


### PR DESCRIPTION
This pull request adds the MediaButtonReceiver declaration in the AndroidManifest.xml to allow the app to respond to external media button events (e.g., Bluetooth headsets, Tasker, car controls, etc.).

This does not modify any other part of the app's logic, just enables compatibility with system-level playback controls.

Tested and working with Bluetooth headset and Tasker.