### PR TITLE
fix: refactor Gradle signing to support dynamic keystore selection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,12 +41,13 @@ jobs:
           
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
- 
+
       - name: Build Release APK
         run: ./gradlew assemble${{ matrix.abi }}Release
         env:
           PULL_REQUEST: 'false'
- 
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+
       - name: Sign APK
         uses: ilharp/sign-android-release@v1.0.4
         with:
@@ -97,6 +98,7 @@ jobs:
         run: ./gradlew assembleUniversalDebug
         env:
           PULL_REQUEST: 'false'
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
 
       - name: Upload Debug APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -10,12 +10,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: set up JDK 21
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           java-version: 21
           distribution: "temurin"
           cache: 'gradle'
+
+      - name: Generate debug.keystore if not exists
+        run: |
+          mkdir -p ~/.android
+          keytool -genkey -v \
+            -keystore ~/.android/debug.keystore \
+            -storepass android \
+            -alias androiddebugkey \
+            -keypass android \
+            -keyalg RSA \
+            -keysize 2048 \
+            -validity 10000 \
+            -dname "CN=Android Debug,O=Android,C=US"
 
       - name: Build debug APK and run JVM tests
         run: ./gradlew assembleDebug

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -1,4 +1,5 @@
 name: Build PR
+
 on:
   pull_request:
     branches:
@@ -7,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
 
@@ -30,13 +32,11 @@ jobs:
             -validity 10000 \
             -dname "CN=Android Debug,O=Android,C=US"
 
-      - name: Build debug APK and run JVM tests
-        run: ./gradlew assembleDebug
-        env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
+      - name: Build universal debug APK
+        run: ./gradlew assembleUniversalDebug
 
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
-          name: debug-apk
-          path: app/build/outputs/apk/debug/*.apk
+          name: app-universal-debug
+          path: app/build/outputs/apk/universal/debug/*.apk

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Build universal debug APK
         run: ./gradlew assembleUniversalDebug
+        env:
+           GITHUB_EVENT_NAME: ${{ github.event_name }}
 
       - name: Upload APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Build debug APK and run JVM tests
         run: ./gradlew assembleDebug
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
 
       - name: Upload APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,8 @@ jobs:
         run: ./gradlew assemble${{ matrix.abi }}Release
         env:
           PULL_REQUEST: 'false'
- 
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+
       - name: Sign APK
         uses: ilharp/sign-android-release@v1.0.4
         with:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,7 +88,11 @@ android {
         debug {
             applicationIdSuffix = ".debug"
             isDebuggable = true
-            signingConfig = signingConfigs.getByName("persistentDebug")
+            signingConfig = if (System.getenv("GITHUB_EVENT_NAME") == "pull_request") {
+                signingConfigs.getByName("debug")
+            } else {
+                signingConfigs.getByName("persistentDebug")
+            }
         }
     }
 


### PR DESCRIPTION
- Used debug.keystore for pull_request workflows
- Used persistent-debug.keystore for normal builds
- Added GITHUB_EVENT_NAME to workflow environments
- Unified APK build and signing behavior across workflows