### PR TITLE
Fix Android client; Prioritize clients that usually work

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -38,11 +38,11 @@ object YTPlayerUtils {
      */
     private val STREAM_FALLBACK_CLIENTS: Array<YouTubeClient> = arrayOf(
         ANDROID_VR_NO_AUTH,
+        MOBILE,
         TVHTML5_SIMPLY_EMBEDDED_PLAYER,
         IOS,
         WEB,
-        WEB_CREATOR,
-        MOBILE
+        WEB_CREATOR
     )
     data class PlaybackData(
         val audioConfig: PlayerResponse.PlayerConfig.AudioConfig?,

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/YouTubeClient.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/YouTubeClient.kt
@@ -87,9 +87,9 @@ data class YouTubeClient(
 
         val MOBILE = YouTubeClient(
             clientName = "ANDROID",
-            clientVersion = "18.13.37",
+            clientVersion = "20.10.38",
             clientId = "3",
-            userAgent = "com.google.android.youtube/18.13.37 (Linux; U; Android 13; Pixel 6)",
+            userAgent = "com.google.android.youtube/20.10.38 (Linux; U; Android 11) gzip",
             loginSupported = true,
             useSignatureTimestamp = true
         )


### PR DESCRIPTION
No more "Unknown error" using Android Client.

There may still be cases where you see an "`Unknown error`", such as "`Please log in to confirm your age.`"

This is because we're not using this in that client:

```
loginSupported = true,
loginRequired = true
```

But we can't use it because NewPipeExtractor needs to be fixed (YoutubeSignatureUtils.java)