### PR TITLE
perf: progressively load YT items

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -175,6 +176,18 @@ fun HomeScreen(
             backStackEntry?.savedStateHandle?.set("scrollToTop", false)
         }
     }
+
+    LaunchedEffect(Unit) {
+        snapshotFlow { lazylistState.layoutInfo.visibleItemsInfo.lastOrNull()?.index }
+            .collect { lastVisibleIndex ->
+                val len = lazylistState.layoutInfo.totalItemsCount
+                if (lastVisibleIndex != null && lastVisibleIndex >= len - 3) {
+                    viewModel.loadMoreYouTubeItems(homePage?.originalPage?.continuation)
+                }
+            }
+    }
+
+
 
     val localGridItem: @Composable (LocalItem) -> Unit = {
         when (it) {
@@ -735,7 +748,7 @@ fun HomeScreen(
                     }
                 }
             }
-            if (isLoading) {
+            if (isLoading || homePage?.originalPage?.continuation != null) {
                 item {
                     ShimmerHost(
                         modifier = Modifier.animateItem()

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/HomeViewModel.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
 import javax.inject.Inject
+import kotlin.collections.map
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
@@ -205,6 +206,31 @@ class HomeViewModel @Inject constructor(
                 val relatedSongs = database.getRelatedSongs(song.id).first().shuffled().take(20)
                 quickPicks.value = relatedSongs
             }
+        }
+    }
+
+    private val _isLoadingMore = MutableStateFlow(false)
+    fun loadMoreYouTubeItems(continuation: String?) {
+        if (continuation == null || _isLoadingMore.value) return
+        val hideExplicit = context.dataStore.get(HideExplicitKey, false)
+
+        viewModelScope.launch(Dispatchers.IO) {
+            _isLoadingMore.value = true
+            val nextSections = YouTube.home(continuation).getOrNull() ?: run {
+                _isLoadingMore.value = false
+                return@launch
+            }
+
+            val page = homePage.value?.originalPage
+            homePage.value = HomePageWithBrowseCheck(
+                nextSections.copy(
+                    sections = (page?.sections.orEmpty() + nextSections.sections).map { section ->
+                        section.copy(items = section.items.filterExplicit(hideExplicit))
+                    }
+                ),
+                homePage.value?.browseContentAvailable ?: emptyMap()
+            )
+            _isLoadingMore.value = false
         }
     }
 


### PR DESCRIPTION
Uses the continuations to progressively load YT items, decreasing the overall loading time, as only a very small section of the total home screen needs to be loaded.

Port of https://github.com/OuterTune/OuterTune/pull/448

I'm also a bit confused, as to why, when loading the home page, all available section endpoints are loaded immediately, feels like something that should rather be done on demand?