### PR TITLE
Improve Auto Scroll Lyrics Setting

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Lyrics.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Lyrics.kt
@@ -343,11 +343,12 @@ fun Lyrics(
                 lazyListState.scrollToItem(
                     currentLineIndex,
                     with(density) { 36.dp.toPx().toInt() } + calculateOffset())
-            } else if (lastPreviewTime == 0L || currentLineIndex != previousLineIndex) {
+            } else if ((lastPreviewTime == 0L || currentLineIndex != previousLineIndex) && scrollLyrics) {
                 val visibleItemsInfo = lazyListState.layoutInfo.visibleItemsInfo
                 val isCurrentLineVisible = visibleItemsInfo.any { it.index == currentLineIndex }
+                val isPreviousLineVisible = visibleItemsInfo.any { it.index == previousLineIndex }
 
-                if (scrollLyrics || isCurrentLineVisible) {
+                if (isCurrentLineVisible && isPreviousLineVisible) {
                     val viewportStartOffset = lazyListState.layoutInfo.viewportStartOffset
                     val viewportEndOffset = lazyListState.layoutInfo.viewportEndOffset
                     val currentLineOffset = visibleItemsInfo.find { it.index == currentLineIndex }?.offset ?: 0


### PR DESCRIPTION
Currently, turning off the "Auto Scroll Lyrics" setting doesn't fully disable lyric scrolling. It still scrolls to the current lyrics when they are on screen and stop only if the user manually scrolls away (the default behavior before the setting was implemented). When turned on, it would always scroll to the current lyrics. 

With this update, disabling the setting now completely stops all automatic lyric scrolling. When enabled, lyrics will scroll automatically only when the current line is visible, and will pause if the user scrolls manually.

I also fixed a little bug where it scrolled even when it shouldn't by adding a new check