### PR TITLE
Changing the size of radio icon to match the others

### DIFF
--- a/app/src/main/res/drawable/radio.xml
+++ b/app/src/main/res/drawable/radio.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="20.0dip"
-    android:height="20.0dip"
+    android:width="24.0dip"
+    android:height="24.0dip"
     android:viewportWidth="20.0"
     android:viewportHeight="20.0">
     <path


### PR DESCRIPTION
Change the size of the radio icon from `20dip` to `24dip` like the other icons. 
This makes the text aligned.

| Before | After |
| --------- | ------ |
| ![image](https://github.com/user-attachments/assets/0c760e70-ba92-489a-b6f8-6a8ea027a80c) | ![image](https://github.com/user-attachments/assets/abbf0c43-5afa-46e0-b6be-6ab0f50bdef7) |