### PR TITLE
Fix artist names on home page

### DIFF
--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/HomePage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/HomePage.kt
@@ -64,7 +64,7 @@ data class HomePage(
                         SongItem(
                             id = renderer.navigationEndpoint.watchEndpoint?.videoId ?: return null,
                             title = renderer.title.runs?.firstOrNull()?.text ?: return null,
-                            artists = listOfNotNull(renderer.subtitle?.runs?.firstOrNull()?.let {
+                            artists = listOfNotNull(renderer.subtitle?.runs?.oddElements()?.drop(1)?.firstOrNull()?.let {
                                 Artist(
                                     name = it.text,
                                     id = it.navigationEndpoint?.browseEndpoint?.browseId


### PR DESCRIPTION
Fixes #882 

For the artist name the first value is selected which turns out to be "Song"
![image](https://github.com/user-attachments/assets/bfc18db5-a5a1-4a92-a52a-b23269249f91)

| Before | After |
| --------- | ------ |
| ![Screenshot_20250701_232108_Metrolist Debug](https://github.com/user-attachments/assets/67920e51-2170-4ee5-a868-b762593349d3) |  ![Screenshot_20250701_232354_Metrolist Debug](https://github.com/user-attachments/assets/c58952ce-3cd5-4767-b534-28e093a0aab6) |