### PR TITLE
Refactors artist extraction for better reliability

### DIFF
--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/LibraryPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/LibraryPage.kt
@@ -38,12 +38,7 @@ data class LibraryPage(
                 renderer.isPlaylist -> PlaylistItem(
                     id = renderer.navigationEndpoint.browseEndpoint?.browseId?.removePrefix("VL") ?: return null,
                     title = renderer.title.runs?.firstOrNull()?.text ?: return null,
-                    author = renderer.subtitle?.runs?.getOrNull(2)?.let {
-                        Artist(
-                            name = it.text,
-                            id = it.navigationEndpoint?.browseEndpoint?.browseId
-                        )
-                    },
+                    author = null,
                     songCountText = renderer.subtitle?.runs?.lastOrNull()?.text,
                     thumbnail = renderer.thumbnailRenderer.musicThumbnailRenderer?.getThumbnailUrl() ?: return null,
                     playEndpoint = renderer.thumbnailOverlay

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/RelatedPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/RelatedPage.kt
@@ -69,12 +69,12 @@ data class RelatedPage(
                             renderer.title.runs
                                 ?.firstOrNull()
                                 ?.text ?: return null,
-                        artists = renderer.subtitle?.runs?.oddElements()?.drop(1)?.map {
-                            Artist(
-                                name = it.text,
-                                id = it.navigationEndpoint?.browseEndpoint?.browseId
-                            )
-                        },
+                        artists = listOfNotNull(Artist(
+                                name = "",
+                                id = renderer.menu?.menuRenderer?.items?.find {
+                                    it.menuNavigationItemRenderer?.icon?.iconType == "ARTIST"
+                                }?.menuNavigationItemRenderer?.navigationEndpoint?.browseEndpoint?.browseId,
+                            )),
                         year =
                             renderer.subtitle
                                 ?.runs
@@ -97,11 +97,8 @@ data class RelatedPage(
                             renderer.title.runs
                                 ?.firstOrNull()
                                 ?.text ?: return null,
-                        author = Artist(
-                            name = renderer.subtitle?.runs?.lastOrNull()?.text ?: return null,
-                            id = null
-                        ),
-                        songCountText = renderer.subtitle.runs.getOrNull(4)?.text,
+                        author = null,
+                        songCountText = renderer.subtitle?.runs?.lastOrNull()?.text,
                         thumbnail = renderer.thumbnailRenderer.musicThumbnailRenderer?.getThumbnailUrl() ?: return null,
                         playEndpoint =
                             renderer.thumbnailOverlay


### PR DESCRIPTION
Fixes #899 

Playlist in "Your YouTube playlists" section

> Removed playlist author from "Your YouTube playlists" section. 
Previously it showed `songCountText` twice.
**Now it only shows the number of songs in the playlist.**

Playlist in "RelatedPage"

> Similarly removed playlist author from `RelatedPage.kt`. 
**Now it only shows the number of views**

Album in "RelatedPage"

> Removed album author name because this information is not present in the Related section
> Added proper redirect to album author, which prevents app crashing
> **Now it only shows the album release date**
