### PR TITLE
fix(layout): prevent ChipsRow overlap, better approach

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/SearchBar.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/SearchBar.kt
@@ -172,7 +172,7 @@ fun TopSearch(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(100.dp)
+                .height(88.dp)
                 .background(color = MaterialTheme.colorScheme.surface)
         )
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchResult.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchResult.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.metrolist.innertube.YouTube.SearchFilter.Companion.FILTER_ALBUM
@@ -275,8 +274,7 @@ fun OnlineSearchResult(
         modifier =
         Modifier
             .background(MaterialTheme.colorScheme.surface)
-            .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top))
-            .padding(top = AppBarHeight + 4.dp)
+            .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top).add(WindowInsets(top = AppBarHeight)))
             .fillMaxWidth()
     )
 }


### PR DESCRIPTION
Better solution for #898 bug

I don't know why the SearchBar height value was set to 100.dp
The correct value should be 88.dp

**24.dp** - Android status bar height + **64.dp** - App Bar height