### PR TITLE
fix(MusicService): restore Queue on application restart

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -1114,11 +1114,6 @@ class MusicService :
     }
 
     private fun saveQueueToDisk() {
-        if (player.playbackState == STATE_IDLE) {
-            filesDir.resolve(PERSISTENT_AUTOMIX_FILE).delete()
-            filesDir.resolve(PERSISTENT_QUEUE_FILE).delete()
-            return
-        }
         val persistQueue =
             PersistQueue(
                 title = queueTitle,


### PR DESCRIPTION
Fixes an issue, whereupon application restart, the queue would fail to be restored. This is likely due to the player not yet being correctly initialized, and thus the queue file is deleted.

Closes: https://github.com/mostafaalagamy/Metrolist/issues/775

Marked as a draft, as it still requires more testing.