### PR TITLE
feat: Discord RPC improvements

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/utils/DiscordRPC.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/DiscordRPC.kt
@@ -11,6 +11,7 @@ class DiscordRPC(
     token: String,
 ) : KizzyRPC(token) {
     suspend fun updateSong(song: Song) = runCatching {
+        val currentTime = System.currentTimeMillis()
         setActivity(
             name = context.getString(R.string.app_name).removeSuffix(" Debug"),
             details = song.song.title,
@@ -24,7 +25,9 @@ class DiscordRPC(
                 "Visit Metrolist" to "https://github.com/mostafaalagamy/Metrolist"
             ),
             type = Type.LISTENING,
-            since = System.currentTimeMillis(),
+            since = currentTime,
+            startTime = currentTime,
+            endTime = currentTime + song.song.duration * 1000L,
             applicationId = APPLICATION_ID
         )
     }

--- a/kizzy/src/main/kotlin/com/my/kizzy/gateway/entities/presence/Timestamps.kt
+++ b/kizzy/src/main/kotlin/com/my/kizzy/gateway/entities/presence/Timestamps.kt
@@ -5,8 +5,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class Timestamps(
-    @SerialName("end")
-    val end: Long? = null,
     @SerialName("start")
     val start: Long? = null,
+    @SerialName("end")
+    val end: Long? = null,
 )


### PR DESCRIPTION
**Added progress bar to discord activity**

<img width="282" height="119" alt="image" src="https://github.com/user-attachments/assets/db78b821-0907-4b24-8190-a0102adbd961" />


> PR is temporary and needs improvement

**TODO:**
- Update the preview in settings to display the progress bar
- Change the `startTime` and `endTime` to reflect the song's listened time
- Add a feature when pausing a song to hide activity on Discord (similar to Spotify)

### Features related to the Discord update

https://discord.com/developers/docs/change-log#clickable-links-and-customizable-statuses-in-rich-presence

- Add the ability to change the `Listening to Metrolist` text to `Listening to {name}`
- Add clickable text, e.g., author, song name

Closes:
#966 
#311 