### PR TITLE
Prevent deletion of non-editable lists

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/shimmer/ListItemPlaceholder.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/shimmer/ListItemPlaceholder.kt
@@ -1,12 +1,14 @@
 package com.metrolist.music.ui.component.shimmer
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -48,6 +50,26 @@ fun ListItemPlaceHolder(
         ) {
             TextPlaceholder()
             TextPlaceholder()
+        }
+        
+        // إضافة placeholder للأزرار في الجانب الأيمن
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(end = 6.dp)
+        ) {
+            Spacer(
+                modifier = Modifier
+                    .size(24.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f))
+            )
+            Spacer(
+                modifier = Modifier
+                    .size(24.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f))
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -647,7 +647,7 @@ fun LocalPlaylistScreen(
                                         )
                                     }
 
-                                    if (sortType == PlaylistSongSortType.CUSTOM && !locked && !inSelectMode && !isSearching) {
+                                    if (sortType == PlaylistSongSortType.CUSTOM && !locked && !inSelectMode && !isSearching && editable) {
                                         IconButton(
                                             onClick = { },
                                             modifier = Modifier.draggableHandle(),
@@ -687,7 +687,7 @@ fun LocalPlaylistScreen(
                             )
                         }
 
-                        if (locked || inSelectMode) {
+                        if (locked || inSelectMode || !editable) {
                             content()
                         } else {
                             SwipeToDismissBox(
@@ -788,7 +788,7 @@ fun LocalPlaylistScreen(
                                             contentDescription = null,
                                         )
                                     }
-                                        if (sortType == PlaylistSongSortType.CUSTOM && !locked && !inSelectMode && !isSearching) {
+                                        if (sortType == PlaylistSongSortType.CUSTOM && !locked && !inSelectMode && !isSearching && editable) {
                                             IconButton(
                                                 onClick = { },
                                                 modifier = Modifier.draggableHandle(),

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -592,13 +592,15 @@ private fun OnlinePlaylistScreenSkeleton() {
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
-                    Row(horizontalArrangement = Arrangement.spacedBy(16.dp), verticalAlignment = Alignment.CenterVertically) {
-                        Spacer(Modifier.size(48.dp).clip(CircleShape).background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)))
-                        Spacer(Modifier.size(48.dp).clip(CircleShape).background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)))
+                    // Left side: Menu and Import buttons (larger buttons)
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                        Spacer(Modifier.size(40.dp).clip(CircleShape).background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)))
+                        Spacer(Modifier.size(40.dp).clip(CircleShape).background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)))
                     }
+                    // Right side: Radio and Shuffle buttons (smaller buttons)
                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        Spacer(Modifier.size(24.dp).clip(CircleShape).background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)))
-                        Spacer(Modifier.size(24.dp).clip(CircleShape).background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)))
+                        Spacer(Modifier.size(40.dp).clip(CircleShape).background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)))
+                        Spacer(Modifier.size(44.dp).clip(CircleShape).background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)))
                     }
                 }
             }


### PR DESCRIPTION
Fixes drag/swipe controls appearing in read-only playlists and aligns online playlist shimmer/placeholder UI with actual designs.

The drag handles and swipe-to-dismiss functionality were incorrectly displayed in read-only playlists (e.g., imported YouTube playlists) because they did not consistently check the `editable` property. Additionally, the `ListItemPlaceHolder` was missing placeholders for trailing buttons, and the `OnlinePlaylistScreenSkeleton` had incorrect button sizes and positions in its header shimmer, leading to visual inconsistencies.

---

[Open in Web](https://www.cursor.com/agents?id=bc-a010ac49-a4d6-4e0a-ad15-18ba33c38f4a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a010ac49-a4d6-4e0a-ad15-18ba33c38f4a)