### PR TITLE
Prevent deletion of non-editable lists

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/shimmer/ListItemPlaceholder.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/shimmer/ListItemPlaceholder.kt
@@ -1,12 +1,14 @@
 package com.metrolist.music.ui.component.shimmer
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -48,6 +50,26 @@ fun ListItemPlaceHolder(
         ) {
             TextPlaceholder()
             TextPlaceholder()
+        }
+        
+        // إضافة placeholder للأزرار في الجانب الأيمن
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(end = 6.dp)
+        ) {
+            Spacer(
+                modifier = Modifier
+                    .size(24.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f))
+            )
+            Spacer(
+                modifier = Modifier
+                    .size(24.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f))
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/shimmer/ListItemPlaceholder.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/shimmer/ListItemPlaceholder.kt
@@ -51,25 +51,5 @@ fun ListItemPlaceHolder(
             TextPlaceholder()
             TextPlaceholder()
         }
-        
-        // إضافة placeholder للأزرار في الجانب الأيمن
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(end = 6.dp)
-        ) {
-            Spacer(
-                modifier = Modifier
-                    .size(24.dp)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f))
-            )
-            Spacer(
-                modifier = Modifier
-                    .size(24.dp)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f))
-            )
-        }
     }
 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/AlbumScreen.kt
@@ -497,14 +497,14 @@ private fun AlbumActionControls(
                 onClick = onMenuClick,
                 modifier = Modifier.size(40.dp)
             ) {
-                Icon(painterResource(R.drawable.more_vert), "More options")
+                Icon(painterResource(R.drawable.more_vert), "More options", modifier = Modifier.size(24.dp))
             }
             when (downloadState) {
                 Download.STATE_COMPLETED -> BorderedIconButton(
                     onClick = onRemoveDownloadClick,
                     modifier = Modifier.size(40.dp)
                 ) {
-                    Icon(painterResource(R.drawable.offline), "Downloaded", tint = MaterialTheme.colorScheme.primary)
+                    Icon(painterResource(R.drawable.offline), "Downloaded", tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(24.dp))
                 }
                 Download.STATE_DOWNLOADING -> BorderedIconButton(
                     onClick = onRemoveDownloadClick,
@@ -516,7 +516,7 @@ private fun AlbumActionControls(
                     onClick = onDownloadClick,
                     modifier = Modifier.size(40.dp)
                 ) {
-                    Icon(painterResource(R.drawable.download), "Download")
+                    Icon(painterResource(R.drawable.download), "Download", modifier = Modifier.size(24.dp))
                 }
             }
             BorderedIconButton(
@@ -526,7 +526,8 @@ private fun AlbumActionControls(
                 Icon(
                     painter = painterResource(if (isLiked) R.drawable.favorite else R.drawable.favorite_border),
                     contentDescription = "Like",
-                    tint = if (isLiked) MaterialTheme.colorScheme.error else LocalContentColor.current
+                    tint = if (isLiked) MaterialTheme.colorScheme.error else LocalContentColor.current,
+                    modifier = Modifier.size(24.dp)
                 )
             }
         }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -553,13 +553,13 @@ private fun AutoPlaylistActionControls(
             BorderedIconButton(
                 onClick = onQueueClick,
                 modifier = Modifier.size(40.dp)
-            ) { Icon(painterResource(R.drawable.queue_music), "Queue") }
+            ) { Icon(painterResource(R.drawable.queue_music), "Queue", modifier = Modifier.size(24.dp)) }
             when (downloadState) {
                 Download.STATE_COMPLETED -> BorderedIconButton(
                     onClick = onDownloadClick,
                     modifier = Modifier.size(40.dp)
                 ) {
-                    Icon(painterResource(R.drawable.offline), "Downloaded", tint = MaterialTheme.colorScheme.primary)
+                    Icon(painterResource(R.drawable.offline), "Downloaded", tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(24.dp))
                 }
                 Download.STATE_DOWNLOADING -> BorderedIconButton(
                     onClick = onDownloadClick,
@@ -571,7 +571,7 @@ private fun AutoPlaylistActionControls(
                     onClick = onDownloadClick,
                     modifier = Modifier.size(40.dp)
                 ) {
-                    Icon(painterResource(R.drawable.download), "Download")
+                    Icon(painterResource(R.drawable.download), "Download", modifier = Modifier.size(24.dp))
                 }
             }
         }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -647,7 +647,7 @@ fun LocalPlaylistScreen(
                                         )
                                     }
 
-                                    if (sortType == PlaylistSongSortType.CUSTOM && !locked && !inSelectMode && !isSearching) {
+                                    if (sortType == PlaylistSongSortType.CUSTOM && !locked && !inSelectMode && !isSearching && editable) {
                                         IconButton(
                                             onClick = { },
                                             modifier = Modifier.draggableHandle(),
@@ -687,7 +687,7 @@ fun LocalPlaylistScreen(
                             )
                         }
 
-                        if (locked || inSelectMode) {
+                        if (locked || inSelectMode || !editable) {
                             content()
                         } else {
                             SwipeToDismissBox(
@@ -788,7 +788,7 @@ fun LocalPlaylistScreen(
                                             contentDescription = null,
                                         )
                                     }
-                                        if (sortType == PlaylistSongSortType.CUSTOM && !locked && !inSelectMode && !isSearching) {
+                                        if (sortType == PlaylistSongSortType.CUSTOM && !locked && !inSelectMode && !isSearching && editable) {
                                             IconButton(
                                                 onClick = { },
                                                 modifier = Modifier.draggableHandle(),

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -592,13 +592,15 @@ private fun OnlinePlaylistScreenSkeleton() {
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
-                    Row(horizontalArrangement = Arrangement.spacedBy(16.dp), verticalAlignment = Alignment.CenterVertically) {
-                        Spacer(Modifier.size(48.dp).clip(CircleShape).background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)))
-                        Spacer(Modifier.size(48.dp).clip(CircleShape).background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)))
+                    // Left side: Menu and Import buttons (larger buttons)
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                        Spacer(Modifier.size(40.dp).clip(CircleShape).background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)))
+                        Spacer(Modifier.size(40.dp).clip(CircleShape).background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)))
                     }
+                    // Right side: Radio and Shuffle buttons (smaller buttons)
                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        Spacer(Modifier.size(24.dp).clip(CircleShape).background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)))
-                        Spacer(Modifier.size(24.dp).clip(CircleShape).background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)))
+                        Spacer(Modifier.size(40.dp).clip(CircleShape).background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)))
+                        Spacer(Modifier.size(44.dp).clip(CircleShape).background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)))
                     }
                 }
             }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -447,7 +447,7 @@ private fun PlaylistActionControls(
                     Icon(
                         painterResource(R.drawable.more_vert), 
                         "Menu",
-                        modifier = Modifier.size(20.dp)
+                        modifier = Modifier.size(24.dp)
                     ) 
                 }
             }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/TopPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/TopPlaylistScreen.kt
@@ -499,13 +499,13 @@ private fun TopPlaylistActionControls(
             BorderedIconButton(
                 onClick = onQueueClick,
                 modifier = Modifier.size(40.dp)
-            ) { Icon(painterResource(R.drawable.queue_music), "Queue") }
+            ) { Icon(painterResource(R.drawable.queue_music), "Queue", modifier = Modifier.size(24.dp)) }
             when (downloadState) {
                 Download.STATE_COMPLETED -> BorderedIconButton(
                     onClick = onDownloadClick,
                     modifier = Modifier.size(40.dp)
                 ) {
-                    Icon(painterResource(R.drawable.offline), "Downloaded", tint = MaterialTheme.colorScheme.primary)
+                    Icon(painterResource(R.drawable.offline), "Downloaded", tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(24.dp))
                 }
                 Download.STATE_DOWNLOADING -> BorderedIconButton(
                     onClick = onDownloadClick,
@@ -517,7 +517,7 @@ private fun TopPlaylistActionControls(
                     onClick = onDownloadClick,
                     modifier = Modifier.size(40.dp)
                 ) {
-                    Icon(painterResource(R.drawable.download), "Download")
+                    Icon(painterResource(R.drawable.download), "Download", modifier = Modifier.size(24.dp))
                 }
             }
         }

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/OnlinePlaylistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/OnlinePlaylistViewModel.kt
@@ -30,7 +30,6 @@ class OnlinePlaylistViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.Lazily, null)
 
     var continuation: String? = null
-        private set
 
     init {
         viewModelScope.launch(Dispatchers.IO) {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes drag/swipe controls in read-only playlists, standardizes icon sizes, and refines online playlist placeholder visuals.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Drag and swipe controls were incorrectly appearing in non-editable playlists (e.g., imported YouTube playlists) due to missing `editable` checks. This PR also standardizes the size of outlined icons to 24dp in various action controls (Album, AutoPlaylist, TopPlaylist, OnlinePlaylist) for visual consistency, and corrects the layout of the `OnlinePlaylistScreenSkeleton` to match the actual UI's button arrangement and sizes, while removing temporary placeholder elements.

---

[Open in Web](https://www.cursor.com/agents?id=bc-a010ac49-a4d6-4e0a-ad15-18ba33c38f4a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a010ac49-a4d6-4e0a-ad15-18ba33c38f4a)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)