### PR TITLE
build: fix NewPipeExtractor timeout issues with JitPack

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,10 @@ android.enableJetifier=true
 org.gradle.unsafe.configuration-cache=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+
+# Increase timeouts for JitPack downloads (fixes timeout issues with NewPipeExtractor)
+systemProp.org.gradle.internal.http.connectionTimeout=180000
+systemProp.org.gradle.internal.http.socketTimeout=180000
+
+# Disable caching for SNAPSHOT dependencies to avoid timeout issues
+org.gradle.caching=false


### PR DESCRIPTION
- Increase HTTP timeout settings for JitPack downloads to 180 seconds
- Disable gradle caching to avoid SNAPSHOT dependency issues

This fixes the 'Read timed out' error when downloading timeago-parser:dev-SNAPSHOT from JitPack during release builds.