### PR TITLE
Analyze crash logs for root cause

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Queue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Queue.kt
@@ -682,11 +682,15 @@ fun Queue(
 
                 itemsIndexed(
                     items = mutableQueueWindows,
-                    key = { _, item -> item.uid.hashCode() },
+                    key = { index, item -> 
+                        // Use a combination of uid and index to ensure uniqueness
+                        val uid = item.uid.hashCode()
+                        "${uid}_$index"
+                    },
                 ) { index, window ->
                     ReorderableItem(
                         state = reorderableState,
-                        key = window.uid.hashCode(),
+                        key = "${window.uid.hashCode()}_$index",
                     ) {
                         val currentItem by rememberUpdatedState(window)
                         val dismissBoxState =
@@ -837,7 +841,11 @@ fun Queue(
 
                     itemsIndexed(
                         items = automix,
-                        key = { _, it -> it.mediaId },
+                        key = { index, item -> 
+                            // Use a combination of mediaId and index to ensure uniqueness
+                            val mediaId = item.mediaId.ifEmpty { "unknown_${item.hashCode()}" }
+                            "${mediaId}_$index"
+                        },
                     ) { index, item ->
                         Row(
                             horizontalArrangement = Arrangement.Center,

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Thumbnail.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Thumbnail.kt
@@ -238,7 +238,11 @@ fun Thumbnail(
                 ) {
                     items(
                         items = mediaItems,
-                        key = { it.mediaId }
+                        key = { item -> 
+                            // Use a combination of mediaId and index to ensure uniqueness
+                            val mediaId = item.mediaId.ifEmpty { "unknown_${item.hashCode()}" }
+                            "${mediaId}_${mediaItems.indexOf(item)}"
+                        }
                     ) { item ->
                         Box(
                             modifier = Modifier


### PR DESCRIPTION
Fix `IllegalArgumentException` caused by duplicate keys in `LazyColumn` and `LazyRow`.

The application was crashing due to `Key was already used` errors when rendering lists. This PR ensures unique keys by combining existing item identifiers (like `mediaId` or `uid.hashCode()`) with the item's index, and handles cases where `mediaId` might be empty.

---
<a href="https://cursor.com/background-agent?bcId=bc-87fe0af7-08fd-4cc7-b904-3859db3837f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-87fe0af7-08fd-4cc7-b904-3859db3837f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>