### PR TITLE
fix: replace Row with FlowRow for button layout in Dialog

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Dialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Dialog.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
@@ -112,7 +113,7 @@ fun DefaultDialog(
                 if (buttons != null) {
                     Spacer(Modifier.height(24.dp))
 
-                    Row(
+                    FlowRow(
                         modifier = Modifier.align(Alignment.End),
                     ) {
                         CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.primary) {


### PR DESCRIPTION
Replaced Row with FlowRow for button layout in Dialog component to lay the buttons with proper width.

Fixes #1043 

Have tested with other uses of Dialog and it works fine, have attached screenshots(blurry because of screen sharing :)).

<img width="378" height="298" alt="image" src="https://github.com/user-attachments/assets/71890ad3-b6c8-41be-a13f-239b1ec709e1" />
<img width="370" height="425" alt="image" src="https://github.com/user-attachments/assets/fa4b4918-bd7d-40f2-ad60-ed3ad6ddc328" />
<img width="366" height="198" alt="image" src="https://github.com/user-attachments/assets/01907c10-27d5-4098-8380-334f7ff4fd0c" />

Please let me your feedbacks, Thanks