### PR TITLE
feat: Add ability for seek skip duration to be added up progressively

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -18,6 +18,7 @@ val SliderStyleKey = stringPreferencesKey("sliderStyle")
 val SwipeToSongKey = booleanPreferencesKey("SwipeToSong")
 val UseNewPlayerDesignKey= booleanPreferencesKey("useNewPlayerDesign")
 val UseNewMiniPlayerDesignKey = booleanPreferencesKey("useNewMiniPlayerDesign")
+val SeekExtraSeconds = booleanPreferencesKey("seekExtraSeconds")
 
 enum class SliderStyle {
     DEFAULT,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
@@ -48,6 +48,7 @@ import com.metrolist.music.constants.SimilarContent
 import com.metrolist.music.constants.SkipSilenceKey
 import com.metrolist.music.constants.StopMusicOnTaskClearKey
 import com.metrolist.music.constants.HistoryDuration
+import com.metrolist.music.constants.SeekExtraSeconds
 import com.metrolist.music.ui.component.EnumListPreference
 import com.metrolist.music.ui.component.IconButton
 import com.metrolist.music.ui.component.PreferenceGroupTitle
@@ -80,6 +81,12 @@ fun PlayerSettings(
         AudioNormalizationKey,
         defaultValue = true
     )
+
+    val (seekExtraSeconds, onSeekExtraSeconds) = rememberPreference(
+        SeekExtraSeconds,
+        defaultValue = false
+    )
+
     val (autoLoadMore, onAutoLoadMoreChange) = rememberPreference(
         AutoLoadMoreKey,
         defaultValue = true
@@ -155,6 +162,14 @@ fun PlayerSettings(
             icon = { Icon(painterResource(R.drawable.volume_up), null) },
             checked = audioNormalization,
             onCheckedChange = onAudioNormalizationChange
+        )
+
+        SwitchPreference(
+            title = { Text(stringResource(R.string.seek_seconds_addup)) },
+            description = stringResource(R.string.seek_seconds_addup_description),
+            icon = { Icon(painterResource(R.drawable.arrow_forward), null) },
+            checked = seekExtraSeconds,
+            onCheckedChange = onSeekExtraSeconds
         )
 
         PreferenceGroupTitle(

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -67,8 +67,8 @@
         <item quantity="other">%d times</item>
     </plurals>
 
-    <string name="seek_backward">5 seconds backward</string>
-    <string name="seek_forward">5 seconds forward</string>
+    <string name="seek_forward_dynamic">+%1$d seconds forwards</string>
+    <string name="seek_backward_dynamic">-%1$d seconds backwards</string>
 
     <string name="similar_content">Similar content</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -284,6 +284,8 @@
     <string name="auto_load_more_desc">Automatically add more songs when the end of the queue is reached, if possible</string>
     <string name="skip_silence">Skip silence</string>
     <string name="audio_normalization">Audio normalization</string>
+    <string name="seek_seconds_addup">Progressive seek</string>
+    <string name="seek_seconds_addup_description">If enabled,  Adds up 5 extra seconds incrementally on each seek skip</string>
     <string name="auto_skip_next_on_error">Auto skip to next song when error occurs</string>
     <string name="auto_skip_next_on_error_desc">Ensure your continuous playback experience</string>
     <string name="stop_music_on_task_clear">Stop music on task clear</string>


### PR DESCRIPTION
Needed this myself because i find the static 5s limit to be low 

Adds a new option on player settings which when enabled, adds 5 seconds to each seek skip incrementally on each tap until the clicking stops found this myself when listening to long songs but it could be useful for other use-cases too