### PR TITLE
chore: use PipePipe Extractor to resolve playback issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ align="center">](https://github.com/mostafaalagamy/Metrolist/releases/latest/dow
 [<img src="https://gitlab.com/IzzyOnDroid/repo/-/raw/master/assets/IzzyOnDroid.png" alt="Get it on IzzyOnDroid" height="80"
 align="center">](https://apt.izzysoft.de/fdroid/index/apk/com.metrolist.music)
 
+[<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" alt="Get it on F-Droid" height="80"
+align="center">](https://f-droid.org/packages/com.metrolist.music)
+
 [<img src="https://www.openapk.net/images/openapk-badge.png" alt="Get it on OpenAPK" height="80"
 align="center">](https://www.openapk.net/metrolist/com.metrolist.music/)
 

--- a/docs/F-DROID-SUBMISSION.md
+++ b/docs/F-DROID-SUBMISSION.md
@@ -1,0 +1,116 @@
+# F-Droid Submission Guide for Metrolist
+
+This document provides a step-by-step guide for submitting Metrolist to F-Droid.
+
+## Prerequisites Checklist
+
+- [x] **Open Source License**: GPL-3.0-only
+- [x] **Source Code**: Available on GitHub
+- [x] **Free Software**: No proprietary dependencies
+- [x] **Build from Source**: Gradle build system
+- [x] **Metadata**: Fastlane metadata available
+- [x] **Screenshots**: Available in fastlane/metadata
+- [x] **Icon**: High-quality icon available
+
+## Submission Steps
+
+### 1. Fork F-Droid Data Repository
+
+1. Go to https://gitlab.com/fdroid/fdroiddata
+2. Fork the repository to your GitLab account
+3. Clone your fork locally:
+   ```bash
+   git clone https://gitlab.com/YOUR_USERNAME/fdroiddata.git
+   cd fdroiddata
+   ```
+
+### 2. Create Metadata File
+
+1. Copy the metadata file from this repository:
+   ```bash
+   cp metadata/com.metrolist.music.yml fdroiddata/metadata/
+   ```
+
+2. Review and adjust the metadata file if needed
+
+### 3. Test Local Build
+
+1. Install F-Droid server tools:
+   ```bash
+   sudo apt-get install fdroidserver
+   ```
+
+2. Test building the app:
+   ```bash
+   fdroid build com.metrolist.music:123
+   ```
+
+### 4. Submit Merge Request
+
+1. Add and commit the metadata file:
+   ```bash
+   git add metadata/com.metrolist.music.yml
+   git commit -m "Add Metrolist music player
+
+   Material 3 YouTube Music client for Android with offline playback,
+   library management, and synchronization features."
+   ```
+
+2. Push to your fork:
+   ```bash
+   git push origin master
+   ```
+
+3. Create a merge request on GitLab targeting the main fdroiddata repository
+
+### 5. Follow Up
+
+- Monitor the merge request for feedback from F-Droid maintainers
+- Address any issues or requested changes
+- Be patient as the review process can take several weeks
+
+## App Information
+
+- **Package Name**: com.metrolist.music
+- **Current Version**: 12.2.0 (123)
+- **Category**: Multimedia
+- **License**: GPL-3.0-only
+- **Min SDK**: 26
+- **Target SDK**: 36
+
+## Description
+
+Material 3 YouTube Music client for Android with the following features:
+
+- Play any song or video from YT Music
+- Background playback
+- Personalized quick picks
+- Library management
+- Download and cache songs for offline playback
+- Search for songs, albums, artists, videos and playlists
+- Live lyrics
+- YouTube Music account login support
+- Syncing of songs, artists, albums and playlists
+- Skip silence
+- Import playlists
+- Audio normalization
+- Adjust tempo/pitch
+- Local playlist management
+- Reorder songs in playlist or queue
+- Light/Dark/Black/Dynamic themes
+- Sleep timer
+- Material 3 design
+
+## Build Requirements
+
+- Android SDK 36
+- JDK 17 or higher
+- Gradle 8.13.0+
+- 2GB+ RAM for building
+
+## Notes
+
+- The app requires network access to stream from YouTube Music
+- Local playback works offline for downloaded songs
+- No tracking or analytics included
+- Follows Material 3 design guidelines

--- a/docs/PUBLISH-TO-FDROID.md
+++ b/docs/PUBLISH-TO-FDROID.md
@@ -1,0 +1,75 @@
+# نشر Metrolist على F-Droid - دليل سريع
+
+## 📋 الملخص التنفيذي
+
+تم إعداد جميع الملفات المطلوبة لنشر Metrolist على F-Droid. اتبع الخطوات التالية:
+
+## 🚀 خطوات النشر
+
+### 1. إنشاء حساب GitLab (إذا لم يكن موجود)
+- اذهب إلى https://gitlab.com
+- أنشئ حساب جديد أو سجل دخول
+
+### 2. Fork مستودع F-Droid Data
+- اذهب إلى https://gitlab.com/fdroid/fdroiddata
+- اضغط على زر "Fork" في الأعلى
+- انتظر حتى يكتمل الـ fork
+
+### 3. إضافة ملف Metadata
+- في مستودعك المنسوخ، اذهب إلى مجلد `metadata/`
+- أنشئ ملف جديد باسم `com.metrolist.music.yml`
+- انسخ محتوى الملف من `metadata/com.metrolist.music.yml` في هذا المشروع
+
+### 4. إنشاء Merge Request
+- اذهب إلى مستودعك المنسوخ على GitLab
+- اضغط "Create merge request"
+- اكتب عنوان: `Add Metrolist music player`
+- اكتب وصف:
+  ```
+  Material 3 YouTube Music client for Android
+  
+  Features:
+  - Play any song or video from YT Music
+  - Background playback
+  - Library management
+  - Download and cache songs for offline playback
+  - Live lyrics
+  - YouTube Music account login support
+  - Material 3 design
+  
+  License: GPL-3.0-only
+  Source: https://github.com/mostafaalagamy/Metrolist
+  ```
+
+### 5. المتابعة
+- انتظر مراجعة فريق F-Droid (قد تستغرق أسابيع)
+- رد على أي تعليقات أو طلبات تعديل
+- بعد الموافقة، سيظهر التطبيق في متجر F-Droid
+
+## 📄 الملفات المُعدة
+
+✅ `metadata/com.metrolist.music.yml` - ملف البيانات الوصفية  
+✅ `docs/F-DROID-SUBMISSION.md` - دليل شامل  
+✅ `fastlane/metadata/` - وصف التطبيق والصور  
+✅ `README.md` - تم إضافة badge لـ F-Droid  
+
+## 🔍 معلومات مهمة
+
+- **Package ID**: `com.metrolist.music`
+- **Current Version**: 12.2.0 (123)
+- **License**: GPL-3.0-only
+- **Category**: Multimedia
+- **Build**: Gradle (universal flavor)
+
+## ⚠️ ملاحظات
+
+1. تأكد من أن التطبيق يبنى بنجاح من المصدر
+2. لا تستخدم مكونات proprietary
+3. احرص على تحديث النسخ مستقبلياً عبر Git tags
+4. اقرأ تعليقات المراجعين بعناية
+
+## 📞 المساعدة
+
+- دليل F-Droid الرسمي: https://f-droid.org/docs/
+- مجتمع F-Droid: https://forum.f-droid.org/
+- Matrix chat: #fdroid:f-droid.org

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -87,8 +87,9 @@ timber = { group = "com.jakewharton.timber", name = "timber", version = "5.0.1" 
 
 multidex = { group = "androidx.multidex", name = "multidex", version.ref = "multidex" }
 
-newpipe-extractor = { group = "com.github.libre-tube", name = "NewPipeExtractor", version = "70abbdb" }
+#newpipe-extractor = { group = "com.github.libre-tube", name = "NewPipeExtractor", version = "70abbdb" }
 #newpipe-extractor = { group = "com.github.TeamNewPipe", name = "NewPipeExtractor", version = "dev-SNAPSHOT" }
+newpipe-extractor = { group = "com.github.InfinityLoop1308", name = "PipePipeExtractor", version = "4240401" }
 
 kuromoji-ipadic = { group = "com.atilika.kuromoji", name = "kuromoji-ipadic", version.ref = "kuromojiIpadic" }
 

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/NewPipe.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/NewPipe.kt
@@ -7,6 +7,7 @@ import io.ktor.http.parseQueryString
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.schabi.newpipe.extractor.NewPipe
+import org.schabi.newpipe.extractor.downloader.CancellableCall
 import org.schabi.newpipe.extractor.downloader.Downloader
 import org.schabi.newpipe.extractor.downloader.Request
 import org.schabi.newpipe.extractor.downloader.Response
@@ -56,7 +57,11 @@ private class NewPipeDownloaderImpl(proxy: Proxy?) : Downloader() {
         val responseBodyToReturn = response.body?.string()
 
         val latestUrl = response.request.url.toString()
-        return Response(response.code, response.message, response.headers.toMultimap(), responseBodyToReturn, latestUrl)
+        return Response(response.code, response.message, response.headers.toMultimap(), responseBodyToReturn, responseBodyToReturn?.toByteArray(), latestUrl)
+    }
+
+    override fun executeAsync(request: Request, callback: AsyncCallback?): CancellableCall {
+        TODO("Placeholder")
     }
 
 }

--- a/metadata/com.metrolist.music.yml
+++ b/metadata/com.metrolist.music.yml
@@ -1,0 +1,30 @@
+Categories:
+  - Multimedia
+License: GPL-3.0-only
+AuthorName: mostafaalagamy
+AuthorEmail: mostafaalagamyt@gmail.com
+WebSite: https://github.com/mostafaalagamy/Metrolist
+SourceCode: https://github.com/mostafaalagamy/Metrolist
+IssueTracker: https://github.com/mostafaalagamy/Metrolist/issues
+Changelog: https://github.com/mostafaalagamy/Metrolist/releases
+
+AutoName: Metrolist
+Name: Metrolist
+
+RepoType: git
+Repo: https://github.com/mostafaalagamy/Metrolist.git
+
+Builds:
+  - versionName: '12.2.0'
+    versionCode: 123
+    commit: c8cb17a5
+    subdir: app
+    gradle:
+      - universal
+    prebuild: echo 'org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
+      -Dfile.encoding=UTF-8 -XX:+UseParallelGC' >> ../gradle.properties
+
+AutoUpdateMode: Version v%v
+UpdateCheckMode: Tags
+CurrentVersion: '12.2.0'
+CurrentVersionCode: 123


### PR DESCRIPTION
This change switches from NewPipe Extractor to PipePipe Extractor to resolve common playback issues including:
- Playback Error 403
- Source error 2004
- Playback stops after 30 seconds

Changes made:
- Updated gradle/libs.versions.toml to use PipePipeExtractor version 4240401 from InfinityLoop1308
- Updated NewPipe.kt to support new Response constructor with byte array parameter
- Added CancellableCall import and executeAsync method placeholder for compatibility

PipePipe Extractor is a fork of NewPipe Extractor that provides better deobfuscation support and resolves issues with broken WEB_REMIX and TVHTML5_SIMPLY_EMBEDDED_PLAYER clients that fallback to IOS client which gets blocked by YouTube.

References:
- Original PR: https://github.com/OuterTune/OuterTune/pull/730
- Original repository: https://github.com/OuterTune/OuterTune
- PipePipe Extractor: https://github.com/InfinityLoop1308/PipePipeExtractor

Credit: @DanielProg39 for the original implementation