### PR TITLE
Audio Normalization: Amplify low-volume tracks

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -229,6 +229,8 @@ class MusicService :
 
     private var consecutivePlaybackErr = 0
 
+    val maxSafeGainFactor = 1.414f // +3 dB    
+
     override fun onCreate() {
         super.onCreate()
         setMediaNotificationProvider(
@@ -369,7 +371,11 @@ class MusicService :
         }.collectLatest(scope) { (format, normalizeAudio) ->
             normalizeFactor.value =
                 if (normalizeAudio && format?.loudnessDb != null) {
-                    min(10f.pow(-format.loudnessDb.toFloat() / 20), 1f)
+                    var factor = 10f.pow(-format.loudnessDb.toFloat() / 20)
+                    if (factor > 1f) {
+                        factor = min(factor, maxSafeGainFactor)
+                    }
+                    factor
                 } else {
                     1f
                 }


### PR DESCRIPTION
When normalizing audio, if the track has a low volume, apply a maximum gain of +3dB.

I think it's a fairly acceptable value; increasing it too much could be counterproductive.

Perhaps it should be accompanied by a switch for those who don't want to amplify?

Please review. There may be better ways to do this...

Closes #1146 