### PR TITLE
Use ABI-aware download URL for in-app updates

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AccountSettings.kt
@@ -67,6 +67,7 @@ import com.metrolist.music.ui.component.PreferenceEntry
 import com.metrolist.music.ui.component.ReleaseNotesCard
 import com.metrolist.music.ui.component.SwitchPreference
 import com.metrolist.music.ui.component.TextFieldDialog
+import com.metrolist.music.utils.Updater
 import com.metrolist.music.utils.rememberPreference
 import com.metrolist.music.viewmodels.HomeViewModel
 
@@ -332,7 +333,7 @@ fun AccountSettings(
                         }
                     },
                     onClick = {
-                        uriHandler.openUri("https://github.com/mostafaalagamy/Metrolist/releases/latest/download/Metrolist.apk")
+                        uriHandler.openUri(Updater.getLatestDownloadUrl())
                     }
                 )
             }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/SettingsScreen.kt
@@ -28,6 +28,7 @@ import com.metrolist.music.ui.component.IconButton
 import com.metrolist.music.ui.component.PreferenceEntry
 import com.metrolist.music.ui.component.ReleaseNotesCard
 import com.metrolist.music.ui.utils.backToMain
+import com.metrolist.music.utils.Updater
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -145,9 +146,7 @@ fun SettingsScreen(
                         Icon(painterResource(R.drawable.update), null)
                     }
                 },
-                onClick = {
-                    uriHandler.openUri("https://github.com/mostafaalagamy/Metrolist/releases/latest/download/Metrolist.apk")
-                }
+                onClick = { uriHandler.openUri(Updater.getLatestDownloadUrl()) }
             )
             ReleaseNotesCard()
         }

--- a/app/src/main/kotlin/com/metrolist/music/utils/Updater.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/Updater.kt
@@ -1,5 +1,6 @@
 package com.metrolist.music.utils
 
+import com.metrolist.music.BuildConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
@@ -20,4 +21,14 @@ object Updater {
             lastCheckTime = System.currentTimeMillis()
             versionName
         }
+
+    fun getLatestDownloadUrl(): String {
+        val baseUrl = "https://github.com/mostafaalagamy/Metrolist/releases/latest/download/"
+        val architecture = BuildConfig.ARCHITECTURE
+        return if (architecture == "universal") {
+            baseUrl + "Metrolist.apk"
+        } else {
+            baseUrl + "app-${architecture}-release.apk"
+        }
+    }
 }


### PR DESCRIPTION
### Summary
Use ABI-aware download URL for in-app updates. If `BuildConfig.ARCHITECTURE` is `universal`, open `Metrolist.apk`; otherwise open `app-{abi}-release.apk`.

### Changes
- Add `Updater.getLatestDownloadUrl()` to construct the correct asset URL from `BuildConfig.ARCHITECTURE`.
- Replace hardcoded `Metrolist.apk` links in `SettingsScreen.kt` and `AccountSettings.kt` with the helper.

### Rationale
Users who installed a specific ABI (arm64/armeabi/x86/x86_64) should be directed to the matching APK instead of the universal one. This avoids unnecessary larger downloads and matches the installed flavor.

### Alignment with releases
The CI publishes artifacts as:
- universal → `Metrolist.apk`
- arm64/armeabi/x86/x86_64 → `app-{abi}-release.apk`
These names match the URLs created by this change.

### Testing
- Install any ABI flavor and navigate to Settings (or Account settings). When the update banner shows, tapping it should open the corresponding asset URL.
- Optional: log `Updater.getLatestDownloadUrl()` with `Timber.d` to verify the URL.

### Edge cases
- If a specific ABI asset is missing in a release, the link would 404. A follow-up could HEAD-check GitHub Releases assets and fall back to `Metrolist.apk`.

### Impact
Only the URL opened on tap changes; no installer behavior or other logic affected.