### PR TITLE
fix: App crash when opening Appearance settings

### DIFF
--- a/app/src/main/res/values-ja/metrolist_strings.xml
+++ b/app/src/main/res/values-ja/metrolist_strings.xml
@@ -144,5 +144,5 @@
     <string name="history_duration">履歴期間</string>
     <string name="subscribe">定期購読</string>
     <string name="subscribed">定期購読済み</string>
-    <string name="sensitivity_percentage">%1$d%</string>
+    <string name="sensitivity_percentage">%1$d%%</string>
 </resources>


### PR DESCRIPTION
Fixes: #1260 
The string has been changed to be identical to the other language versions
The crash occurred when the app language was set to Japanese.