### PR TITLE
fix: search loading issue: Make MusicCardShelfRenderer header field

### DIFF
--- a/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
@@ -128,7 +128,7 @@ object YouTube {
             summaries = response.contents?.tabbedSearchResultsRenderer?.tabs?.firstOrNull()?.tabRenderer?.content?.sectionListRenderer?.contents?.mapNotNull { it ->
                 if (it.musicCardShelfRenderer != null)
                     SearchSummary(
-                        title = it.musicCardShelfRenderer.header.musicCardShelfHeaderBasicRenderer.title.runs?.firstOrNull()?.text ?: return@mapNotNull null,
+                        title = it.musicCardShelfRenderer.header?.musicCardShelfHeaderBasicRenderer?.title?.runs?.firstOrNull()?.text ?: return@mapNotNull null,
                         items = listOfNotNull(SearchSummaryPage.fromMusicCardShelfRenderer(it.musicCardShelfRenderer))
                             .plus(
                                 it.musicCardShelfRenderer.contents

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/MusicCardShelfRenderer.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/MusicCardShelfRenderer.kt
@@ -7,7 +7,7 @@ data class MusicCardShelfRenderer(
     val title: Runs,
     val subtitle: Runs,
     val thumbnail: ThumbnailRenderer,
-    val header: Header,
+    val header: Header?,
     val contents: List<Content>?,
     val buttons: List<Button>,
     val onTap: NavigationEndpoint,

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/SearchSummaryPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/SearchSummaryPage.kt
@@ -141,7 +141,7 @@ data class SearchSummaryPage(
                             renderer.onTap.browseEndpoint.browseId
                                 .removePrefix("VL"),
                         title =
-                            renderer.header.musicCardShelfHeaderBasicRenderer.title.runs
+                            renderer.header?.musicCardShelfHeaderBasicRenderer?.title?.runs
                                 ?.joinToString(separator = "") { it.text }
                                 ?: return null,
                         author =


### PR DESCRIPTION
- YouTube Music API changed and sometimes doesn't include the 'header' field
- Made header field nullable in MusicCardShelfRenderer model
- Updated all usages to handle nullable header field safely
- Fixes issue #1264 where search 'All' tab keeps loading

This change ensures the app can handle API responses that don't include the header field without crashing the search functionality.