### PR TITLE
fix: All tab didn't show results on some accounts

### DIFF
--- a/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
@@ -142,7 +142,7 @@ object YouTube {
                 else
                     SearchSummary(
                         title = it.musicShelfRenderer?.title?.runs?.firstOrNull()?.text ?: "Other",
-                        items = it.musicShelfRenderer.contents?.getItems()
+                        items = it.musicShelfRenderer?.contents?.getItems()
                             ?.mapNotNull {
                                 SearchSummaryPage.fromMusicResponsiveListItemRenderer(it)
                             }


### PR DESCRIPTION
Fixes new YouTube Music search response, which does not contains headers and all types of results are in one list
This response could be A/B testing, cause when user is not logged in everything works perfectly

See: https://github.com/mostafaalagamy/Metrolist/issues/1264#issuecomment-3191005615

Closes #1264