### PR TITLE
fix: Notification crash on Android 9 and use correct cache

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/utils/CoilBitmapLoader.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/CoilBitmapLoader.kt
@@ -4,8 +4,9 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
+import androidx.core.graphics.createBitmap
 import androidx.media3.common.util.BitmapLoader
-import coil3.ImageLoader
+import coil3.imageLoader
 import coil3.request.ErrorResult
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
@@ -15,7 +16,6 @@ import com.google.common.util.concurrent.ListenableFuture
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.guava.future
-import androidx.core.graphics.createBitmap
 
 class CoilBitmapLoader(
     private val context: Context,
@@ -31,13 +31,12 @@ class CoilBitmapLoader(
 
     override fun loadBitmap(uri: Uri): ListenableFuture<Bitmap> =
         scope.future(Dispatchers.IO) {
-            val imageLoader = ImageLoader(context)
             val request = ImageRequest.Builder(context)
                 .data(uri)
                 .allowHardware(false)
                 .build()
 
-            val result = imageLoader.execute(request)
+            val result = context.imageLoader.execute(request)
 
             // In case of error, returns an empty bitmap
             when (result) {
@@ -53,4 +52,4 @@ class CoilBitmapLoader(
                 }
             }
         }
-} 
+}


### PR DESCRIPTION
Changed the dimensions of the empty bitmap from 1x1 to 64x64 to prevent a crash on Android 9. 
Changed the cache to use the same cache as the thumbnail.

Closes #1321