### PR TITLE
fix: set SearchBar height dynamically

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/SearchBar.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/SearchBar.kt
@@ -76,6 +76,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
 import androidx.compose.ui.util.lerp
+import com.metrolist.music.constants.AppBarHeight
 import kotlin.math.max
 
 @ExperimentalMaterial3Api
@@ -172,7 +173,7 @@ fun TopSearch(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(88.dp)
+                .height(topInset + AppBarHeight)
                 .background(color = MaterialTheme.colorScheme.surface)
         )
 


### PR DESCRIPTION
Instead of fixed value 88.dp (24.dp + 64.dp, where 24.dp is for system bar, and 64.dp is for AppBarHeight) now system bar is calculated dynamically

Closes #1353 