### PR TITLE
Filter artist page sections and explicit content

### DIFF
--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/HomePage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/HomePage.kt
@@ -64,7 +64,7 @@ data class HomePage(
                         SongItem(
                             id = renderer.navigationEndpoint.watchEndpoint?.videoId ?: return null,
                             title = renderer.title.runs?.firstOrNull()?.text ?: return null,
-                            artists = listOfNotNull(renderer.subtitle?.runs?.oddElements()?.drop(1)?.firstOrNull()?.let {
+                            artists = listOfNotNull(renderer.subtitle?.runs?.firstOrNull()?.let {
                                 Artist(
                                     name = it.text,
                                     id = it.navigationEndpoint?.browseEndpoint?.browseId


### PR DESCRIPTION
Correctly extract artist name for `SongItem` in `HomePage` to prevent view counts from appearing alongside artist names.

The previous logic `oddElements()?.drop(1)` for extracting the artist name from `subtitle.runs` was inadvertently including additional text like view counts. By changing it to `firstOrNull()`, only the primary artist name is extracted, aligning with the behavior in OuterTune.

---
<a href="https://cursor.com/background-agent?bcId=bc-818d8c1d-ea7b-4714-8431-9c6c1a55ec65">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-818d8c1d-ea7b-4714-8431-9c6c1a55ec65">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

