### PR TITLE
feat: Add proxy auth support

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/App.kt
+++ b/app/src/main/kotlin/com/metrolist/music/App.kt
@@ -37,6 +37,10 @@ import timber.log.Timber
 import java.net.Proxy
 import java.util.*
 
+import java.net.Authenticator
+import okhttp3.Credentials
+import java.net.PasswordAuthentication
+
 @HiltAndroidApp
 class App : Application(), SingletonImageLoader.Factory {
     // Create a proper application scope that will be cancelled when the app is destroyed
@@ -64,6 +68,20 @@ class App : Application(), SingletonImageLoader.Factory {
         }
 
         if (dataStore[ProxyEnabledKey] == true) {
+            if (dataStore[ProxyUsernameKey] != "" || dataStore[ProxyPasswordKey] != "") {
+                if (dataStore[ProxyTypeKey].toEnum(defaultValue = Proxy.Type.HTTP) == Proxy.Type.HTTP) {
+                    YouTube.proxyAuth = Credentials.basic(
+                        dataStore[ProxyUsernameKey] ?: "",
+                        dataStore[ProxyPasswordKey] ?: ""
+                    )
+                } else {
+                    val authenticator = object : Authenticator() {
+                        override fun getPasswordAuthentication() =
+                            PasswordAuthentication(dataStore[ProxyUsernameKey] ?: "", (dataStore[ProxyPasswordKey] ?: "").toCharArray())
+                    }
+                    Authenticator.setDefault(authenticator)
+                }
+            }
             try {
                 YouTube.proxy = Proxy(
                     dataStore[ProxyTypeKey].toEnum(defaultValue = Proxy.Type.HTTP),

--- a/app/src/main/kotlin/com/metrolist/music/App.kt
+++ b/app/src/main/kotlin/com/metrolist/music/App.kt
@@ -34,12 +34,11 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import timber.log.Timber
+import java.net.Authenticator
+import java.net.PasswordAuthentication
 import java.net.Proxy
 import java.util.*
-
-import java.net.Authenticator
 import okhttp3.Credentials
-import java.net.PasswordAuthentication
 
 @HiltAndroidApp
 class App : Application(), SingletonImageLoader.Factory {

--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -36,6 +36,8 @@ val HideExplicitKey = booleanPreferencesKey("hideExplicit")
 val ProxyEnabledKey = booleanPreferencesKey("proxyEnabled")
 val ProxyUrlKey = stringPreferencesKey("proxyUrl")
 val ProxyTypeKey = stringPreferencesKey("proxyType")
+val ProxyUsernameKey = stringPreferencesKey("proxyUsername")
+val ProxyPasswordKey = stringPreferencesKey("proxyPassword")
 val YtmSyncKey = booleanPreferencesKey("ytmSync")
 
 val AudioQualityKey = stringPreferencesKey("audioQuality")

--- a/app/src/main/kotlin/com/metrolist/music/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/DownloadUtil.kt
@@ -54,7 +54,14 @@ constructor(
                 .setCache(playerCache)
                 .setUpstreamDataSourceFactory(
                     OkHttpDataSource.Factory(
-                        OkHttpClient.Builder().proxy(YouTube.proxy).build(),
+                        OkHttpClient.Builder()
+                            .proxy(YouTube.proxy)
+                            .proxyAuthenticator { _, response ->
+                                response.request.newBuilder()
+                                    .header("Proxy-Authorization", YouTube.proxyAuth!!)
+                                    .build()
+                            }
+                            .build(),
                     ),
                 ),
         ) { dataSpec ->

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -1055,6 +1055,11 @@ class MusicService :
                                 OkHttpClient
                                     .Builder()
                                     .proxy(YouTube.proxy)
+                                    .proxyAuthenticator { _, response ->
+                                        response.request.newBuilder()
+                                            .header("Proxy-Authorization", YouTube.proxyAuth!!)
+                                            .build()
+                                    }
                                     .build(),
                             ),
                         ),

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/ContentSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/ContentSettings.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
@@ -155,8 +156,7 @@ fun ContentSettings(
                         value = tempProxyUrl,
                         onValueChange = { tempProxyUrl = it },
                         label = { Text(stringResource(R.string.proxy_url)) },
-                        modifier = Modifier.fillMaxWidth(),
-                        isError = errorUrl
+                        modifier = Modifier.fillMaxWidth()
                     )
 
                     Row(
@@ -183,15 +183,13 @@ fun ContentSettings(
                                 value = tempProxyUsername,
                                 onValueChange = { tempProxyUsername = it },
                                 label = { Text(stringResource(R.string.proxy_username)) },
-                                modifier = Modifier.fillMaxWidth(),
-                                isError = errorAuth
+                                modifier = Modifier.fillMaxWidth()
                             )
                             OutlinedTextField(
                                 value = tempProxyPassword,
                                 onValueChange = { tempProxyPassword = it },
                                 label = { Text(stringResource(R.string.proxy_password)) },
-                                modifier = Modifier.fillMaxWidth(),
-                                isError = errorAuth
+                                modifier = Modifier.fillMaxWidth()
                             )
                         }
                     }
@@ -200,7 +198,6 @@ fun ContentSettings(
             confirmButton = {
                 TextButton(
                     onClick = {
-                        
                         onProxyUrlChange(tempProxyUrl)
                         onProxyUsernameChange(if (authEnabled) tempProxyUsername else "")
                         onProxyPasswordChange(if (authEnabled) tempProxyPassword else "")

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/ContentSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/ContentSettings.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.capitalize
 import androidx.compose.ui.text.toLowerCase
+import androidx.compose.ui.unit.dp
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/ContentSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/ContentSettings.kt
@@ -109,7 +109,7 @@ fun ContentSettings(
         AlertDialog(
             onDismissRequest = { showProxyConfigurationDialog = false },
             title = {
-                Text(stringResource(R.string.configure_proxy))
+                Text(stringResource(R.string.config_proxy))
             },
             text = {
                 Column(

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/ContentSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/ContentSettings.kt
@@ -63,7 +63,6 @@ import com.metrolist.music.utils.rememberPreference
 import java.net.Proxy
 import java.util.Locale
 
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ContentSettings(
@@ -72,7 +71,6 @@ fun ContentSettings(
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
-
 
     val (contentLanguage, onContentLanguageChange) = rememberPreference(key = ContentLanguageKey, defaultValue = "system")
     val (contentCountry, onContentCountryChange) = rememberPreference(key = ContentCountryKey, defaultValue = "system")

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -132,7 +132,7 @@
     <string name="config_proxy">Configure proxy</string>
     <string name="proxy_username">Proxy username</string>
     <string name="proxy_password">Proxy password</string>
-    <string name="enable_authentication">Enable Authentication</string>
+    <string name="enable_authentication">Enable authentication</string>
 
     <string name="audio_quality_max">Max (beta)</string>
     <string name="enable_similar_content">Enable similar content</string>
@@ -197,7 +197,7 @@
     <string name="disable_load_more_when_repeat_all_desc">Don\'t auto load more songs and similar content when repeat all mode is enabled</string>
     
     <!-- Material 3 Settings Sections -->
-    <string name="settings_section_ui">User Interface</string>
+    <string name="settings_section_ui">Interface</string>
     <string name="settings_section_privacy">Privacy &amp; Security</string>
     <string name="settings_section_player">Player &amp; Media</string>
     <string name="settings_section_player_content">Player &amp; Content</string>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -129,6 +129,10 @@
     <string name="configure_supported_links">Configure supported links</string>
     <string name="intent_supported_links_not_found">Couldn\'t find supported links settings, please configure them manually</string>
     <string name="set_first_lyrics_provider">Preferred lyrics provider</string>
+    <string name="config_proxy">Configure proxy</string>
+    <string name="proxy_username">Proxy username</string>
+    <string name="proxy_password">Proxy password</string>
+    <string name="enable_authentication">Enable Authentication</string>
 
     <string name="audio_quality_max">Max (beta)</string>
     <string name="enable_similar_content">Enable similar content</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -268,11 +268,12 @@
     <string name="content_country">Default content country</string>
     <string name="system_default">System default</string>
     <string name="enable_proxy">Enable proxy</string>
-    <string name="config_proxy">Configure proxy</string>
+    <string name="configure_proxy">Configure proxy</string>
     <string name="proxy_type">Proxy type</string>
     <string name="proxy_url">Proxy URL</string>
     <string name="proxy_username">Proxy Username</string>
     <string name="proxy_password">Proxy Password</string>
+    <string name="enable_authentication">Enable Authentication</string>
     <string name="restart_to_take_effect">Restart to take effect</string>
 
     <string name="player_and_audio">Player and audio</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -268,12 +268,8 @@
     <string name="content_country">Default content country</string>
     <string name="system_default">System default</string>
     <string name="enable_proxy">Enable proxy</string>
-    <string name="config_proxy">Configure proxy</string>
     <string name="proxy_type">Proxy type</string>
     <string name="proxy_url">Proxy URL</string>
-    <string name="proxy_username">Proxy Username</string>
-    <string name="proxy_password">Proxy Password</string>
-    <string name="enable_authentication">Enable Authentication</string>
     <string name="restart_to_take_effect">Restart to take effect</string>
 
     <string name="player_and_audio">Player and audio</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -268,8 +268,11 @@
     <string name="content_country">Default content country</string>
     <string name="system_default">System default</string>
     <string name="enable_proxy">Enable proxy</string>
+    <string name="config_proxy">Configure proxy</string>
     <string name="proxy_type">Proxy type</string>
     <string name="proxy_url">Proxy URL</string>
+    <string name="proxy_username">Proxy Username</string>
+    <string name="proxy_password">Proxy Password</string>
     <string name="restart_to_take_effect">Restart to take effect</string>
 
     <string name="player_and_audio">Player and audio</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -268,7 +268,7 @@
     <string name="content_country">Default content country</string>
     <string name="system_default">System default</string>
     <string name="enable_proxy">Enable proxy</string>
-    <string name="configure_proxy">Configure proxy</string>
+    <string name="config_proxy">Configure proxy</string>
     <string name="proxy_type">Proxy type</string>
     <string name="proxy_url">Proxy URL</string>
     <string name="proxy_username">Proxy Username</string>

--- a/innertube/src/main/kotlin/com/metrolist/innertube/InnerTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/InnerTube.kt
@@ -52,6 +52,8 @@ class InnerTube {
             httpClient.close()
             httpClient = createClient()
         }
+    
+    var proxyAuth: String? = null
 
     var useLoginForBrowse: Boolean = false
 
@@ -78,9 +80,18 @@ class InnerTube {
             socketTimeoutMillis = 15000
         }
 
-        if (proxy != null) {
+        proxy?.let {
             engine {
                 proxy = this@InnerTube.proxy
+                proxyAuth?.let {
+                    config {
+                        proxyAuthenticator { _, response ->
+                            response.request.newBuilder()
+                                .header("Proxy-Authorization", proxyAuth!!)
+                                .build()
+                        }
+                    }
+                }
             }
         }
 

--- a/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
@@ -102,6 +102,12 @@ object YouTube {
         set(value) {
             innerTube.proxy = value
         }
+
+    var proxyAuth: String?
+        get() = innerTube.proxyAuth
+        set(value) {
+            innerTube.proxyAuth = value
+        }
     var useLoginForBrowse: Boolean
         get() = innerTube.useLoginForBrowse
         set(value) {

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/NewPipe.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/NewPipe.kt
@@ -17,10 +17,15 @@ import org.schabi.newpipe.extractor.services.youtube.YoutubeJavaScriptPlayerMana
 import java.io.IOException
 import java.net.Proxy
 
-private class NewPipeDownloaderImpl(proxy: Proxy?) : Downloader() {
+private class NewPipeDownloaderImpl(proxy: Proxy?, proxyAuth: String?) : Downloader() {
 
     private val client = OkHttpClient.Builder()
         .proxy(proxy)
+        .proxyAuthenticator { _, response ->
+            response.request.newBuilder()
+                .header("Proxy-Authorization", proxyAuth!!)
+                .build()
+        }
         .build()
 
     @Throws(IOException::class, ReCaptchaException::class)
@@ -69,7 +74,7 @@ private class NewPipeDownloaderImpl(proxy: Proxy?) : Downloader() {
 object NewPipeUtils {
 
     init {
-        NewPipe.init(NewPipeDownloaderImpl(YouTube.proxy))
+        NewPipe.init(NewPipeDownloaderImpl(YouTube.proxy, YouTube.proxyAuth))
     }
 
     fun getSignatureTimestamp(videoId: String): Result<Int> = runCatching {


### PR DESCRIPTION
This pull request adds support for proxy authentication in the application, allowing users to configure proxy credentials (username and password) and use them for HTTP and SOCKS proxies throughout the app.

Tested on HTTP proxy with auth, and SOCKS5 proxy with auth
**Proxy Authentication Support**

* Added `ProxyUsernameKey` and `ProxyPasswordKey` preferences, and updated the app logic to handle proxy credentials when a proxy is enabled, including setting HTTP Basic authentication or a system authenticator depending on proxy type.
* Added a proxy configuration dialog in the settings screen, allowing users to input proxy type, URL, username, and password. Replaced the previous inline proxy settings with a single "Configure proxy" entry.

## TODO:
- [X] Fix/Change UI setting
- [X] Test if all endpoints uses proxy with auth

## Known Issues:
- [X] TextFields are updated on change, causing input problems

Closes: #618 
![Screenshot_20250820_202857_Metrolist Debug.jpg](https://github.com/user-attachments/assets/d2942e07-e5df-4703-9a60-6a832639a347)

