### PR TITLE
Fix duplicate key issues in LazyColumn/LazyRow implementations

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Queue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Queue.kt
@@ -677,11 +677,11 @@ fun Queue(
 
                 itemsIndexed(
                     items = mutableQueueWindows,
-                    key = { _, item -> item.uid.hashCode() },
+                    key = { index, item -> "${item.uid.hashCode()}_$index" },
                 ) { index, window ->
                     ReorderableItem(
                         state = reorderableState,
-                        key = window.uid.hashCode(),
+                        key = "${window.uid.hashCode()}_$index",
                     ) {
                         val currentItem by rememberUpdatedState(window)
                         val dismissBoxState =

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/HistoryScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/HistoryScreen.kt
@@ -222,7 +222,7 @@ fun HistoryScreen(
 
                     items(
                         items = section.songs,
-                        key = { "${section.title}_${it.id}" }
+                        key = { "${section.title}_${it.id}_${section.songs.indexOf(it)}" }
                     ) { song ->
                         YouTubeListItem(
                             item = song,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistScreen.kt
@@ -468,7 +468,7 @@ fun ArtistScreen(
                         }
                         itemsIndexed(
                             items = filteredLibrarySongs,
-                            key = { _, item -> "local_song_${item.id}" }
+                            key = { index, item -> "local_song_${item.id}_$index" }
                         ) { index, song ->
                             SongListItem(
                                 song = song,
@@ -544,7 +544,7 @@ fun ArtistScreen(
                             LazyRow {
                                 items(
                                     items = filteredLibraryAlbums,
-                                    key = { "local_album_${it.id}" }
+                                    key = { "local_album_${it.id}_${filteredLibraryAlbums.indexOf(it)}" }
                                 ) { album ->
                                     AlbumGridItem(
                                         album = album,
@@ -593,7 +593,7 @@ fun ArtistScreen(
                         if ((section.items.firstOrNull() as? SongItem)?.album != null) {
                             items(
                                 items = section.items.distinctBy { it.id },
-                                key = { it.id },
+                                key = { "youtube_song_${it.id}" },
                             ) { song ->
                                 YouTubeListItem(
                                     item = song as SongItem,
@@ -650,7 +650,7 @@ fun ArtistScreen(
                                 LazyRow {
                                     items(
                                         items = section.items.distinctBy { it.id },
-                                        key = { it.id },
+                                        key = { "youtube_album_${it.id}" },
                                     ) { item ->
                                         YouTubeGridItem(
                                             item = item,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchResult.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchResult.kt
@@ -200,7 +200,7 @@ fun OnlineSearchResult(
 
                 items(
                     items = summary.items,
-                    key = { "${summary.title}/${it.id}" },
+                    key = { "${summary.title}/${it.id}/${summary.items.indexOf(it)}" },
                     itemContent = ytItemContent,
                 )
             }
@@ -216,7 +216,7 @@ fun OnlineSearchResult(
         } else {
             items(
                 items = itemsPage?.items.orEmpty().distinctBy { it.id },
-                key = { it.id },
+                key = { "filtered_${it.id}" },
                 itemContent = ytItemContent,
             )
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchScreen.kt
@@ -88,7 +88,7 @@ fun OnlineSearchScreen(
             .fillMaxSize()
             .background(if (pureBlack) Color.Black else MaterialTheme.colorScheme.background)
     ) {
-        items(viewState.history, key = { it.query }) { history ->
+        items(viewState.history, key = { "history_${it.query}" }) { history ->
             SuggestionItem(
                 query = history.query,
                 online = false,
@@ -109,7 +109,7 @@ fun OnlineSearchScreen(
             )
         }
 
-        items(viewState.suggestions, key = { it }) { query ->
+        items(viewState.suggestions, key = { "suggestion_$it" }) { query ->
             SuggestionItem(
                 query = query,
                 online = true,
@@ -131,7 +131,7 @@ fun OnlineSearchScreen(
             }
         }
 
-        items(viewState.items.distinctBy { it.id }, key = { it.id }) { item ->
+        items(viewState.items.distinctBy { it.id }, key = { "item_${it.id}" }) { item ->
             YouTubeListItem(
                 item = item,
                 isActive = when (item) {

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/KeyUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/KeyUtils.kt
@@ -1,0 +1,50 @@
+package com.metrolist.music.ui.utils
+
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Utility object for generating unique keys in LazyColumn/LazyRow to prevent duplicate key errors
+ */
+object KeyUtils {
+    private val counter = AtomicLong(0)
+    
+    /**
+     * Generates a unique key by combining a base identifier with a unique counter
+     * This prevents duplicate keys in LazyColumn/LazyRow implementations
+     */
+    fun generateUniqueKey(baseId: String, prefix: String = ""): String {
+        val uniqueId = counter.incrementAndGet()
+        return if (prefix.isNotEmpty()) {
+            "${prefix}_${baseId}_$uniqueId"
+        } else {
+            "${baseId}_$uniqueId"
+        }
+    }
+    
+    /**
+     * Generates a unique key for items in a list with their index
+     * Useful for preventing duplicate keys when items might have the same ID
+     */
+    fun generateIndexedKey(baseId: String, index: Int, prefix: String = ""): String {
+        val uniqueId = counter.incrementAndGet()
+        return if (prefix.isNotEmpty()) {
+            "${prefix}_${baseId}_${index}_$uniqueId"
+        } else {
+            "${baseId}_${index}_$uniqueId"
+        }
+    }
+    
+    /**
+     * Generates a timestamp-based unique key for dynamic content
+     * Useful for content that changes frequently
+     */
+    fun generateTimestampKey(baseId: String, prefix: String = ""): String {
+        val timestamp = System.currentTimeMillis()
+        val uniqueId = counter.incrementAndGet()
+        return if (prefix.isNotEmpty()) {
+            "${prefix}_${baseId}_${timestamp}_$uniqueId"
+        } else {
+            "${baseId}_${timestamp}_$uniqueId"
+        }
+    }
+}


### PR DESCRIPTION
- Fixed composite key generation in OnlineSearchResult to prevent duplicates by adding index
- Fixed potential key conflicts in OnlineSearchScreen by adding prefixes for different item types
- Enhanced Queue implementation with index-based unique keys to prevent hashCode collisions
- Added index suffixes to ArtistScreen local songs and albums to ensure uniqueness
- Updated HistoryScreen key generation to include position index
- Created KeyUtils utility for future unique key generation needs

This resolves IllegalArgumentException errors related to duplicate keys in Jetpack Compose lazy lists.