### PR TITLE
feat: Force original audio language

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -238,7 +238,7 @@ object YTPlayerUtils {
         Timber.tag(logTag).d("Finding format with audioQuality: $audioQuality, network metered: ${connectivityManager.isActiveNetworkMetered}")
 
         val format = playerResponse.streamingData?.adaptiveFormats
-            ?.filter { it.isAudio }
+            ?.filter { it.isAudio && it.isOriginal }
             ?.maxByOrNull {
                 it.bitrate * when (audioQuality) {
                     AudioQuality.AUTO -> if (connectivityManager.isActiveNetworkMetered) -1 else 1

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/response/PlayerResponse.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/response/PlayerResponse.kt
@@ -61,9 +61,19 @@ data class PlayerResponse(
             val loudnessDb: Double?,
             val lastModified: Long?,
             val signatureCipher: String?,
+            val audioTrack: AudioTrack?
         ) {
             val isAudio: Boolean
                 get() = width == null
+            val isOriginal: Boolean
+                get() = audioTrack?.isAutoDubbed == null
+
+            @Serializable
+            data class AudioTrack(
+                val displayName: String?,
+                val id: String?,
+                val isAutoDubbed: Boolean?,
+            )
         }
     }
 


### PR DESCRIPTION
This PR forces to select only the original audio tracks, thereby removing dubbed videos.
I believe this option should remain the default, as YouTube's auto-dubbing doesn't work well with music. 

If there are any other reasons why you would want to choose between different language versions, please let me know.

`isAutoDubbed` - `true` when format is with non-original language, `null` when is original
Closes #1550 