### PR TITLE
fix: Show lock in all sorts

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -507,7 +507,7 @@ fun LocalPlaylistScreen(
                                 },
                                 modifier = Modifier.weight(1f),
                             )
-                            if (editable && sortType == PlaylistSongSortType.CUSTOM) {
+                            if (editable) {
                                 IconButton(
                                     onClick = { locked = !locked },
                                     modifier = Modifier.padding(horizontal = 6.dp),


### PR DESCRIPTION
Brings back removed lock from other sorts than custom
Lock in other sorts blocks ability to remove song by swiping

Closes #1610 