### PR TITLE
New player buttons follow correct md3e button radius and spacing

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
@@ -613,13 +613,13 @@ fun BottomSheetPlayer(
 
                 if (useNewPlayerDesign) {
                     val shareShape = RoundedCornerShape(
-                        topStart = 25.dp, bottomStart = 25.dp,
+                        topStart = 50.dp, bottomStart = 50.dp,
                         topEnd = 5.dp, bottomEnd = 5.dp
                     )
 
                     val favShape = RoundedCornerShape(
                         topStart = 5.dp, bottomStart = 5.dp,
-                        topEnd = 25.dp, bottomEnd = 25.dp
+                        topEnd = 50.dp, bottomEnd = 50.dp
                     )
 
                     Row(

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Queue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Queue.kt
@@ -234,8 +234,8 @@ fun Queue(
                             .size(buttonSize)
                             .clip(
                                 RoundedCornerShape(
-                                    topStart = 25.dp,
-                                    bottomStart = 25.dp,
+                                    topStart = 50.dp,
+                                    bottomStart = 50.dp,
                                     topEnd = 5.dp,
                                     bottomEnd = 5.dp
                                 )
@@ -244,8 +244,8 @@ fun Queue(
                                 1.dp,
                                 borderColor,
                                 RoundedCornerShape(
-                                    topStart = 25.dp,
-                                    bottomStart = 25.dp,
+                                    topStart = 50.dp,
+                                    bottomStart = 50.dp,
                                     topEnd = 5.dp,
                                     bottomEnd = 5.dp
                                 )
@@ -327,8 +327,8 @@ fun Queue(
                                 RoundedCornerShape(
                                     topStart = 5.dp,
                                     bottomStart = 5.dp,
-                                    topEnd = 25.dp,
-                                    bottomEnd = 25.dp
+                                    topEnd = 50.dp,
+                                    bottomEnd = 50.dp
                                 )
                             )
                             .border(
@@ -337,8 +337,8 @@ fun Queue(
                                 RoundedCornerShape(
                                     topStart = 5.dp,
                                     bottomStart = 5.dp,
-                                    topEnd = 25.dp,
-                                    bottomEnd = 25.dp
+                                    topEnd = 50.dp,
+                                    bottomEnd = 50.dp
                                 )
                             )
                             .clickable {


### PR DESCRIPTION
Improve button group layout to match Material Design 3 guidelines

- Reduce spacing between buttons from 12dp to 6dp for tighter grouping
- Adjust corner radius to only reduce inner radius (5dp) while preserving outer radius (50dp) for better visual cohesion
- Applied to both like button group (share/heart) and lyrics mode button group (queue/sleep timer/lyrics/repeat)