### PR TITLE
fix: Crash on shuffle empty queue

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -1107,6 +1107,9 @@ class MusicService :
     override fun onShuffleModeEnabledChanged(shuffleModeEnabled: Boolean) {
         updateNotification()
         if (shuffleModeEnabled) {
+            // If queue is empty, don't shuffle
+            if (player.mediaItemCount == 0) return
+
             // Always put current playing item at first
             val shuffledIndices = IntArray(player.mediaItemCount) { it }
             shuffledIndices.shuffle()


### PR DESCRIPTION
Steps to reproduce:
1. Remove all songs from queue
2. Click shuffle in bottom left
3. Crash
`java.lang.ArrayIndexOutOfBoundsException: length=0; index=0`

