### PR TITLE
feat(miniPlayer): adjust layout for tablet landscape orientation

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
@@ -250,7 +250,7 @@ private fun NewMiniPlayer(
                 .then(
                     if (isTabletLandscape) {
                         Modifier
-                            .width(288.dp) // ~3 inches (288dp ≈ 3 inches at 96dpi)
+                            .width(500.dp)
                             .align(Alignment.CenterEnd) // Right align
                     } else {
                         Modifier.fillMaxWidth()


### PR DESCRIPTION
Adjusts the mini-player layout for tablets (>600dp) in landscape mode, moving it to the bottom-right and reducing its width. This provides a more polished UI on wider screens by preventing the player from awkwardly spanning the full screen.
Old screenshot, I made it a little bigger.
Since we have a separate tablet mode, we can even make it little thicker.
<img width="2000" height="1200" alt="Screenshot_20251001-223731_Metrolist Debug" src="https://github.com/user-attachments/assets/c60cc111-957e-4af7-86ba-e6f41a21ec2f" />
