### PR TITLE
Fix playback loop after call or audio focus changes

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -993,7 +993,6 @@ class MusicService :
     }
 
     private fun setupLoudnessEnhancer() {
-    private fun setupLoudnessEnhancer() {
     val audioSessionId = player.audioSessionId
 
     if (audioSessionId == C.AUDIO_SESSION_ID_UNSET || audioSessionId <= 0) {


### PR DESCRIPTION
Adjusted AudioFocus handling to prevent play/pause loops after ending Bluetooth calls by adding reentrancy control and a short delay when regaining focus.