### PR TITLE
add support for small screen phones with density scaler

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -135,6 +135,12 @@
                 android:resource="@xml/provider_paths" />
         </provider>
 
+        <provider
+            android:name="com.dpi.DensityScaler"
+            android:authorities="${applicationId}.com.dpi.DensityScaler"
+            android:enabled="true"
+            android:exported="false" />
+
         <activity
             android:name="com.yalantis.ucrop.UCropActivity"
             android:screenOrientation="fullSensor"

--- a/app/src/main/kotlin/com/dpi/ActivityLifecycleManager.kt
+++ b/app/src/main/kotlin/com/dpi/ActivityLifecycleManager.kt
@@ -1,0 +1,114 @@
+package com.dpi
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Manages activity lifecycle events and associated logic.
+ * Provides hooks for monitoring and responding to activity lifecycle changes.
+ */
+abstract class ActivityLifecycleManager : BaseLifecycleContentProvider() {
+
+    private val activeActivities: MutableSet<Activity> =
+        Collections.newSetFromMap(ConcurrentHashMap())
+
+    private val handler = Handler(Looper.getMainLooper())
+
+    private val activityTimerRunnable: Runnable = object : Runnable {
+        override fun run() {
+            try {
+                activeActivities.forEach { activity ->
+                    try {
+                        onActivityTimer(activity)
+                    } catch (e: Exception) {
+                        Log.w(TAG, "Error in activity timer", e)
+                    }
+                }
+                handler.postDelayed(this, activityTimerDelayMillis.toLong())
+            } catch (e: Exception) {
+                Log.w(TAG, "Error in activity timer runnable", e)
+            }
+        }
+    }
+
+    protected open val activityTimerDelayMillis: Int
+        get() = 3000
+
+    protected open fun onActivityTimer(activity: Activity) {}
+
+    override fun onCreate(): Boolean {
+        val application = getApplication() ?: return true
+
+        if (!onInit(application)) {
+            return true
+        }
+
+        application.registerActivityLifecycleCallbacks(object : Application.ActivityLifecycleCallbacks {
+            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+                this@ActivityLifecycleManager.onActivityCreated(activity)
+            }
+
+            override fun onActivityStarted(activity: Activity) {
+                this@ActivityLifecycleManager.onActivityStarted(activity)
+            }
+
+            override fun onActivityResumed(activity: Activity) {
+                activeActivities.add(activity)
+                handler.removeCallbacksAndMessages(null)
+                handler.post(activityTimerRunnable)
+                this@ActivityLifecycleManager.onActivityResumed(activity)
+            }
+
+            override fun onActivityPaused(activity: Activity) {
+                activeActivities.remove(activity)
+                this@ActivityLifecycleManager.onActivityPaused(activity)
+            }
+
+            override fun onActivityStopped(activity: Activity) {
+                this@ActivityLifecycleManager.onActivityStopped(activity)
+            }
+
+            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+
+            override fun onActivityDestroyed(activity: Activity) {
+                this@ActivityLifecycleManager.onActivityDestroyed(activity)
+            }
+        })
+
+        return true
+    }
+
+    protected open fun onInit(application: Application): Boolean = true
+
+    protected open fun onActivityCreated(activity: Activity) {}
+    protected open fun onActivityStarted(activity: Activity) {}
+    protected open fun onActivityResumed(activity: Activity) {}
+    protected open fun onActivityPaused(activity: Activity) {}
+    protected open fun onActivityStopped(activity: Activity) {}
+    protected open fun onActivityDestroyed(activity: Activity) {}
+
+    companion object {
+        private val TAG = ActivityLifecycleManager::class.java.simpleName
+
+        private fun getApplication(): Application? {
+            return try {
+                val activityThreadClass = Class.forName("android.app.ActivityThread")
+                val activityThread = activityThreadClass
+                    .getMethod("currentActivityThread")
+                    .invoke(null)
+                activityThreadClass
+                    .getMethod("getApplication")
+                    .invoke(activityThread) as? Application
+            } catch (e: Exception) {
+                Log.w("AppUtils", "Failed to get Application instance", e)
+                null
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/dpi/BaseLifecycleContentProvider.kt
+++ b/app/src/main/kotlin/com/dpi/BaseLifecycleContentProvider.kt
@@ -1,0 +1,36 @@
+package com.dpi
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+
+/**
+ * Base class for lifecycle management ContentProvider with default implementations.
+ * This class exists solely to leverage ContentProvider's early initialization lifecycle.
+ */
+abstract class BaseLifecycleContentProvider : ContentProvider() {
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<String>?): Int = 0
+
+    override fun getType(uri: Uri): String? = null
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+    override fun onCreate(): Boolean = true
+
+    override fun query(
+        uri: Uri,
+        projection: Array<String>?,
+        selection: String?,
+        selectionArgs: Array<String>?,
+        sortOrder: String?
+    ): Cursor? = null
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<String>?
+    ): Int = 0
+}

--- a/app/src/main/kotlin/com/dpi/DensityConfiguration.kt
+++ b/app/src/main/kotlin/com/dpi/DensityConfiguration.kt
@@ -1,0 +1,84 @@
+package com.dpi
+
+import android.app.Activity
+import android.content.Context
+import android.content.res.Configuration
+import android.content.res.Resources
+import android.util.Log
+import kotlin.math.roundToInt
+
+/**
+ * Configuration class for adjusting screen density dynamically.
+ * Applies density scaling to the entire application and maintains it across activity lifecycle events.
+ */
+internal class DensityConfiguration(
+    private val densityScale: Float
+) : ActivityLifecycleManager() {
+
+    private var originalDensityDpi: Int = 0
+
+    /**
+     * Applies the density scaling to the application context.
+     * This method should be called once during initialization.
+     */
+    fun applyDensityScaling(context: Context) {
+        if (densityScale == 1.0f) return
+
+        try {
+            onCreate()
+            val resources = context.resources
+            val config = Configuration(resources.configuration)
+            originalDensityDpi = config.densityDpi
+            updateDensityDpi(config, resources)
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to apply configuration", e)
+        }
+    }
+
+    /**
+     * Updates the density DPI in the configuration and applies it to resources.
+     */
+    private fun updateDensityDpi(config: Configuration, resources: Resources) {
+        val newDensityDpi = (originalDensityDpi * densityScale).roundToInt()
+        config.densityDpi = newDensityDpi
+        Log.i(TAG, "Updated densityDpi to: $newDensityDpi")
+        @Suppress("DEPRECATION")
+        resources.updateConfiguration(config, resources.displayMetrics)
+    }
+
+    /**
+     * Reapply density scaling when an activity is created.
+     */
+    override fun onActivityCreated(activity: Activity) {
+        applyDensityToActivity(activity)
+    }
+
+    /**
+     * Reapply density scaling when an activity is resumed.
+     */
+    override fun onActivityResumed(activity: Activity) {
+        applyDensityToActivity(activity)
+    }
+
+    /**
+     * Reapply density scaling when an activity is started.
+     */
+    override fun onActivityStarted(activity: Activity) {
+        applyDensityToActivity(activity)
+    }
+
+    /**
+     * Applies the density configuration to a specific activity's resources.
+     */
+    private fun applyDensityToActivity(activity: Activity) {
+        try {
+            updateDensityDpi(activity.resources.configuration, activity.resources)
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to update density for activity", e)
+        }
+    }
+
+    companion object {
+        private val TAG = DensityConfiguration::class.java.simpleName
+    }
+}

--- a/app/src/main/kotlin/com/dpi/DensityScaler.kt
+++ b/app/src/main/kotlin/com/dpi/DensityScaler.kt
@@ -1,0 +1,45 @@
+package com.dpi
+
+import android.content.Context
+
+/**
+ * DensityScaler - Main entry point for screen density scaling.
+ *
+ * Modified for Metrolist to use manual SharedPreferences control instead of automatic scaling.
+ * Reads scale factor from user preferences with default of 1.0f (100% native).
+ *
+ * Supported scale factors:
+ * - 1.0f (100%) - Native density (default)
+ * - 0.75f (75%) - Compact
+ * - 0.65f (65%) - Very Compact
+ * - 0.55f (55%) - Ultra Compact
+ */
+class DensityScaler : BaseLifecycleContentProvider() {
+
+    override fun onCreate(): Boolean {
+        val context = context ?: return false
+        val scaleFactor = getScaleFactorFromPreferences(context)
+        DensityConfiguration(scaleFactor).applyDensityScaling(context)
+        return true
+    }
+
+    companion object {
+        private const val PREFS_NAME = "metrolist_settings"
+        private const val KEY_DENSITY_SCALE = "density_scale_factor"
+        private const val DEFAULT_SCALE_FACTOR = 1.0f
+
+        /**
+         * Reads the density scale factor from SharedPreferences.
+         * Uses SharedPreferences instead of DataStore for synchronous access during ContentProvider initialization.
+         */
+        private fun getScaleFactorFromPreferences(context: Context): Float {
+            return try {
+                val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                prefs.getFloat(KEY_DENSITY_SCALE, DEFAULT_SCALE_FACTOR)
+            } catch (e: Exception) {
+                android.util.Log.w("DensityScaler", "Failed to read scale factor from preferences", e)
+                DEFAULT_SCALE_FACTOR
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -11,6 +11,8 @@ import java.time.ZoneOffset
 val DynamicThemeKey = booleanPreferencesKey("dynamicTheme")
 val DarkModeKey = stringPreferencesKey("darkMode")
 val PureBlackKey = booleanPreferencesKey("pureBlack")
+val DensityScaleKey = floatPreferencesKey("density_scale_factor")
+val CustomDensityScaleKey = floatPreferencesKey("custom_density_scale_value")
 val DefaultOpenTabKey = stringPreferencesKey("defaultOpenTab")
 val SlimNavBarKey = booleanPreferencesKey("slimNavBar")
 val GridItemsSizeKey = stringPreferencesKey("gridItemSize")
@@ -21,6 +23,19 @@ val UseNewPlayerDesignKey= booleanPreferencesKey("useNewPlayerDesign")
 val UseNewMiniPlayerDesignKey = booleanPreferencesKey("useNewMiniPlayerDesign")
 val HidePlayerThumbnailKey = booleanPreferencesKey("hidePlayerThumbnail")
 val SeekExtraSeconds = booleanPreferencesKey("seekExtraSeconds")
+
+enum class DensityScale(val value: Float, val label: String) {
+    NATIVE(1.0f, "Native (100%)"),
+    COMPACT(0.75f, "Compact (75%)"),
+    VERY_COMPACT(0.65f, "Very Compact (65%)"),
+    ULTRA_COMPACT(0.55f, "Ultra Compact (55%)"),
+    CUSTOM(-1f, "Custom"),
+    ;
+
+    companion object {
+        fun fromValue(value: Float): DensityScale = entries.find { it.value == value } ?: CUSTOM
+    }
+}
 
 enum class SliderStyle {
     DEFAULT,


### PR DESCRIPTION
This PR adds a display density scaler feature to Settings > Appearance, allowing users with small screen phones to adjust the UI density.

**Features:**
- Display density setting with presets: Native (100%), Compact (75%), Very Compact (65%), Ultra Compact (55%), and Custom
- Custom density input dialog for values between 50% and 120%
- Restart prompt after changing density
- Persistent setting using SharedPreferences
- Early initialization via ContentProvider for app-wide scaling

**Implementation:**
- New `com.dpi` package with density scaling infrastructure
- `DensityScaler` ContentProvider for early initialization
- Added preferences to `PreferenceKeys.kt`
- Added UI to Settings > Appearance (between Pure Black and Player section)
- Uses deprecated `updateConfiguration` API (no modern alternative for system-wide density changes)

**Testing:**
- Tested on multiple screen sizes
- Density changes apply after app restart
- Custom values validated (50-120% range)

This feature is particularly useful for users with small phones who want to see more content on screen.

<img width="1440" height="2071" alt="Screenshot_20251107-090319_com metrolist music" src="https://github.com/user-attachments/assets/b2cb7083-e595-4959-89f6-243bdc6972f4" />
