### PR TITLE
Fixed crashing upon importing from Malopied's Innertune

### DIFF
--- a/app/schemas/com.metrolist.music.db.InternalDatabase/24.json
+++ b/app/schemas/com.metrolist.music.db.InternalDatabase/24.json
@@ -6,7 +6,7 @@
     "entities": [
       {
         "tableName": "song",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `duration` INTEGER NOT NULL, `thumbnailUrl` TEXT, `albumId` TEXT, `albumName` TEXT, `explicit` INTEGER NOT NULL DEFAULT 0, `year` INTEGER, `date` INTEGER, `dateModified` INTEGER, `liked` INTEGER NOT NULL, `likedDate` INTEGER, `totalPlayTime` INTEGER NOT NULL, `inLibrary` INTEGER, `dateDownload` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT false, `libraryAddToken` TEXT, `libraryRemoveToken` TEXT, `romanizeLyrics` INTEGER NOT NULL DEFAULT true, `isDownloaded` INTEGER NOT NULL DEFAULT 0, `isUploaded` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `duration` INTEGER NOT NULL, `thumbnailUrl` TEXT, `albumId` TEXT, `albumName` TEXT, `explicit` INTEGER NOT NULL DEFAULT 0, `year` INTEGER, `date` INTEGER, `dateModified` INTEGER, `liked` INTEGER NOT NULL, `likedDate` INTEGER, `totalPlayTime` INTEGER NOT NULL, `inLibrary` INTEGER, `dateDownload` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT false, `libraryAddToken` TEXT, `libraryRemoveToken` TEXT, `romanizeLyrics` INTEGER NOT NULL DEFAULT true, `isDownloaded` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",


### PR DESCRIPTION
This patch (somewhat) fixes the Migration issue for Innertune users. By somewhat means that there are a couple steps involved in being able to fully migrate. The steps to migrate are listed below:

1. Put all liked songs into a playlist using the functions inside Innertune. Some songs won't be liked by Metrolist and this is the most convenient fix for this.
2. Backup Innertune in the settings
3. Rename backup to old.zip (change extension)
4. Unzip the archive, you will get two files, song.db and settings.preferences_pb
5. Now you will need to modify song.db, which is a SQLite database that contains all your songs information. But it also has some information about the app it was made in, which makes it incompatible between versions. You will need any tool that can run queries on SQLite databases. I've found some site that can do this, so I will be using this one. Beware that this might pose privacy concerns, since you upload your songs database to this site, but if you use some local tool to modify the database (or you don't really care as I do) then you are fine
6. Go to https://sqlable.com/sqlite/# press "Open DB file" and upload your song.db
7. Run the following query:
`PRAGMA user_version = 14;
UPDATE room_master_table SET identity_hash = '7ae5d8f9982a0e0d04fb685750586978' WHERE id = 42`
8. Press "Save DB file" and select a place to download new database file
9. Rename the downloaded file back to song.db
10. Create an archive (using a tool like Zee Archiver, as zipping it normally won't work) with the new song.db and unchanged settings.preferences_pb, suppose it is named 'new.zip'
11. Rename new.zip to new.backup (change extension) and import it into Metrolist

I have tested my changes against the current Metrolist's exported playlist and it still works fine