### PR TITLE
Love/Unlove songs when they are Liked/Unliked in Metrolist

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -82,6 +82,8 @@ val LastFMUsernameKey = stringPreferencesKey("lastfmUsername")
 val EnableLastFMScrobblingKey = booleanPreferencesKey("lastfmScrobblingEnable")
 val LastFMUseNowPlaying = booleanPreferencesKey("lastfmUseNowPlaying")
 
+val LastFMUseSendLikes = booleanPreferencesKey("lastfmUseSendLikes")
+
 val ScrobbleDelayPercentKey = floatPreferencesKey("scrobbleDelayPercent")
 val ScrobbleMinSongDurationKey = intPreferencesKey("scrobbleMinSongDuration")
 val ScrobbleDelaySecondsKey = intPreferencesKey("scrobbleDelaySeconds")

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/LastFMSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/LastFMSettings.kt
@@ -50,6 +50,7 @@ import com.metrolist.lastfm.LastFM
 import com.metrolist.music.constants.EnableLastFMScrobblingKey
 import com.metrolist.music.constants.LastFMSessionKey
 import com.metrolist.music.constants.LastFMUseNowPlaying
+import com.metrolist.music.constants.LastFMUseSendLikes
 import com.metrolist.music.constants.LastFMUsernameKey
 import com.metrolist.music.constants.ScrobbleMinSongDurationKey
 import com.metrolist.music.constants.ScrobbleDelayPercentKey
@@ -78,6 +79,11 @@ fun LastFMSettings(
 
     val (useNowPlaying, onUseNowPlayingChange) = rememberPreference(
         key = LastFMUseNowPlaying,
+        defaultValue = false
+    )
+
+    val (useSendLikes, onUseSendLikes) = rememberPreference(
+        key = LastFMUseSendLikes,
         defaultValue = false
     )
 
@@ -220,6 +226,14 @@ fun LastFMSettings(
             checked = useNowPlaying,
             onCheckedChange = onUseNowPlayingChange,
             isEnabled = isLoggedIn && lastfmScrobbling,
+        )
+
+        SwitchPreference(
+            title = { Text(stringResource(R.string.last_fm_send_likes)) },
+            description = stringResource(R.string.last_fm_send_likes_description),
+            checked = useSendLikes,
+            onCheckedChange = onUseSendLikes,
+            isEnabled = isLoggedIn,
         )
 
         PreferenceGroupTitle(

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -258,6 +258,9 @@
     <string name="lastfm_integration">Last.fm Integration</string>
     <string name="enable_scrobbling">Enable scrobbling</string>
     <string name="lastfm_now_playing">Send Now Playing</string>
+    <string name="last_fm_send_likes">Send Likes/Unlikes</string>
+    <string name="last_fm_send_likes_description">Love/Unlove songs in Last.fm when they are Liked/Unliked in Metrolist</string>
+
     <string name="scrobbling_configuration">Scrobbling Configuration</string>
     <string name="scrobble_min_track_duration">Scrobble songs longer than</string>
     <string name="scrobble_delay_percent">Scrobble delay percent</string>

--- a/lastfm/src/main/kotlin/com/metrolist/lastfm/LastFM.kt
+++ b/lastfm/src/main/kotlin/com/metrolist/lastfm/LastFM.kt
@@ -110,6 +110,26 @@ object LastFM {
         }
     }
 
+
+    suspend fun setLoveStatus(
+        artist: String, track: String, love: Boolean
+    ) = runCatching {
+        val method = if (love) "track.love" else "track.unlove"
+        client.post {
+            lastfmParams(
+                method = method,
+                apiKey = API_KEY,
+                secret = SECRET,
+                sessionKey = sessionKey!!,
+                extra = buildMap {
+                    put("artist", artist)
+                    put("track", track)
+                }
+            )
+            parameter("format", "json")
+        }
+    }
+
     // API keys passed from the app module (loaded from BuildConfig/GitHub Secrets)
     private var API_KEY = ""
     private var SECRET = ""


### PR DESCRIPTION
When a song is Liked/Unliked in Metrolist set it as Loved/Unloved in Last.fm using the `track.love` API.

It also add an option in the Last.fm integration settings to enable/disable this feature.

<img height="300" alt="image" src="https://github.com/user-attachments/assets/cdec173d-38c5-4ee5-9644-785f980db2e7" />



Important: This is not a proper synchronization of liked songs between Last.fm and Metrolist. This can be done using Last.fm APIs but it will need more work