### PR TITLE
Fix: Defer MusicService property initialization to onCreate

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -103,6 +103,7 @@ import com.metrolist.music.extensions.collect
 import com.metrolist.music.extensions.collectLatest
 import com.metrolist.music.extensions.currentMetadata
 import com.metrolist.music.extensions.findNextMediaItemById
+import com.metrolist.music.extensions.toEnum
 import com.metrolist.music.extensions.mediaItems
 import com.metrolist.music.extensions.metadata
 import com.metrolist.music.extensions.setOffloadEnabled
@@ -189,11 +190,7 @@ class MusicService :
     val waitingForNetworkConnection = MutableStateFlow(false)
     private val isNetworkConnected = MutableStateFlow(false)
 
-    private val audioQuality by enumPreference(
-        this,
-        AudioQualityKey,
-        com.metrolist.music.constants.AudioQuality.AUTO
-    )
+    private lateinit var audioQuality: com.metrolist.music.constants.AudioQuality
 
     private var currentQueue: Queue = EmptyQueue
     var queueTitle: String? = null
@@ -209,7 +206,7 @@ class MusicService :
             database.format(mediaMetadata?.id)
         }
 
-    val playerVolume = MutableStateFlow(dataStore.get(PlayerVolumeKey, 1f).coerceIn(0f, 1f))
+    lateinit var playerVolume: MutableStateFlow<Float>
 
     lateinit var sleepTimer: SleepTimer
 
@@ -304,6 +301,8 @@ class MusicService :
 
         connectivityManager = getSystemService()!!
         connectivityObserver = NetworkConnectivityObserver(this)
+        audioQuality = dataStore.get(AudioQualityKey).toEnum(com.metrolist.music.constants.AudioQuality.AUTO)
+        playerVolume = MutableStateFlow(dataStore.get(PlayerVolumeKey, 1f).coerceIn(0f, 1f))
 
         scope.launch {
             connectivityObserver.networkStatus.collect { isConnected ->


### PR DESCRIPTION
Moves the initialization of context-dependent properties (`audioQuality` and `playerVolume`) from the `MusicService` constructor to the `onCreate()` method.

This prevents a race condition where the `Context` could be `null` during construction, which was causing a `NullPointerException` and crashing the app on startup for some users. The properties are now declared as `lateinit var` and initialized safely within the `onCreate()` lifecycle callback.