### PR TITLE
Fix: Decode search query to prevent URL-encoded text in search history

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/OnlineSearchViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/OnlineSearchViewModel.kt
@@ -22,6 +22,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import java.net.URLDecoder
 import javax.inject.Inject
 
 @HiltViewModel
@@ -31,7 +32,7 @@ constructor(
     @ApplicationContext val context: Context,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
-    val query = savedStateHandle.get<String>("query")!!
+    val query = URLDecoder.decode(savedStateHandle.get<String>("query")!!, "UTF-8")
     val filter = MutableStateFlow<YouTube.SearchFilter?>(null)
     var summaryPage by mutableStateOf<SearchSummaryPage?>(null)
     val viewStateMap = mutableStateMapOf<String, ItemsPage?>()


### PR DESCRIPTION
Fixed a bug where search queries synced from YouTube and YouTube Music were displayed in the app's search history with URL encoding (e.g., This+is+a+query+example instead of This is a query example).

The root cause was that the search query, passed as a navigation argument, was not being decoded before being used by the OnlineSearchViewModel.

The fix is a one-line change in OnlineSearchViewModel.kt to decode the query using java.net.URLDecoder upon initialization. This ensures that the UI and any subsequent logic handle the clean, human-readable version of the search term.