### PR TITLE
fix: handle music.youtube.com/watch links with playlist only

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -335,7 +335,7 @@ class MainActivity : ComponentActivity() {
                                     val intent = Intent(Intent.ACTION_VIEW, Uri.parse(downloadUrl))
 
                                     val flags = PendingIntent.FLAG_UPDATE_CURRENT or
-                                            (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0)
+                                        (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0)
                                     val pending = PendingIntent.getActivity(this@MainActivity, 1001, intent, flags)
 
                                     val notif = NotificationCompat.Builder(this@MainActivity, "updates")
@@ -418,11 +418,11 @@ class MainActivity : ComponentActivity() {
             ) {
                 BoxWithConstraints(
                     modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .background(
-                                if (pureBlack) Color.Black else MaterialTheme.colorScheme.surface
-                            )
+                    Modifier
+                        .fillMaxSize()
+                        .background(
+                            if (pureBlack) Color.Black else MaterialTheme.colorScheme.surface
+                        )
                 ) {
                     val focusManager = LocalFocusManager.current
                     val density = LocalDensity.current
@@ -486,10 +486,10 @@ class MainActivity : ComponentActivity() {
                     }
 
                     val shouldShowNavigationBar = remember(navBackStackEntry) {
-                        val currentRoute = navBackStackEntry?.destination?.route
+                    val currentRoute = navBackStackEntry?.destination?.route
                         currentRoute == null ||
-                                navigationItems.fastAny { it.route == currentRoute } ||
-                                currentRoute.startsWith("search/")
+                            navigationItems.fastAny { it.route == currentRoute } ||
+                            currentRoute.startsWith("search/")
                     }
 
                     val isLandscape = remember(configuration) {
@@ -517,9 +517,9 @@ class MainActivity : ComponentActivity() {
                         rememberBottomSheetState(
                             dismissedBound = 0.dp,
                             collapsedBound = bottomInset +
-                                    (if (!showRail && shouldShowNavigationBar) getNavPadding() else 0.dp) +
-                                    (if (useNewMiniPlayerDesign) MiniPlayerBottomSpacing else 0.dp) +
-                                    MiniPlayerHeight,
+                                (if (!showRail && shouldShowNavigationBar) getNavPadding() else 0.dp) +
+                                (if (useNewMiniPlayerDesign) MiniPlayerBottomSpacing else 0.dp) +
+                                MiniPlayerHeight,
                             expandedBound = maxHeight,
                         )
 


### PR DESCRIPTION
This PR fixes an issue where YouTube Music links in the format .../watch?list=OLAK... were ignored because they lack a v (video) parameter.

Changes:

Added logic to check for list parameter inside the watch path block when videoId is null.

Correctly routes OLAK IDs to the album view and others to the playlist view.