### PR TITLE
chore: Add GPL-3.0 license headers to all Kotlin source files

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/App.kt
+++ b/app/src/main/kotlin/com/metrolist/music/App.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music
 
 import android.app.Application

--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music
 
 import android.Manifest

--- a/app/src/main/kotlin/com/metrolist/music/constants/Dimensions.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/Dimensions.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.constants
 
 import androidx.compose.animation.core.Spring

--- a/app/src/main/kotlin/com/metrolist/music/constants/HistorySource.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/HistorySource.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.constants
 
 enum class HistorySource {

--- a/app/src/main/kotlin/com/metrolist/music/constants/LibraryFilter.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/LibraryFilter.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.constants
 
 enum class LibraryFilter {

--- a/app/src/main/kotlin/com/metrolist/music/constants/MediaSessionConstants.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/MediaSessionConstants.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.constants
 
 import android.os.Bundle

--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.constants
 
 import androidx.datastore.preferences.core.booleanPreferencesKey

--- a/app/src/main/kotlin/com/metrolist/music/constants/StatPeriod.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/StatPeriod.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.constants
 
 import com.metrolist.music.ui.screens.OptionStats

--- a/app/src/main/kotlin/com/metrolist/music/db/Converters.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/Converters.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db
 
 import androidx.room.TypeConverter

--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db
 
 import androidx.room.Dao

--- a/app/src/main/kotlin/com/metrolist/music/db/MusicDatabase.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/MusicDatabase.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db
 
 import android.annotation.SuppressLint

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/Album.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/Album.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.compose.runtime.Immutable

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/AlbumArtistMap.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/AlbumArtistMap.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.room.ColumnInfo

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/AlbumEntity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/AlbumEntity.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.compose.runtime.Immutable

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/AlbumWithSongs.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/AlbumWithSongs.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.compose.runtime.Immutable

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/Artist.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/Artist.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.compose.runtime.Immutable

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/ArtistEntity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/ArtistEntity.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.compose.runtime.Immutable

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/Event.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/Event.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.compose.runtime.Immutable

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/EventWithSong.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/EventWithSong.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.compose.runtime.Immutable

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/FormatEntity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/FormatEntity.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.room.Entity

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/LocalItem.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/LocalItem.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 sealed class LocalItem {

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/LyricsEntity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/LyricsEntity.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.room.Entity

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/PlayCountEntity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/PlayCountEntity.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.compose.runtime.Immutable

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/Playlist.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/Playlist.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.compose.runtime.Immutable

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/PlaylistEntity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/PlaylistEntity.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.compose.runtime.Immutable

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/PlaylistSong.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/PlaylistSong.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.room.Embedded

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/PlaylistSongMap.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/PlaylistSongMap.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.room.ColumnInfo

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/PlaylistSongMapPreview.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/PlaylistSongMapPreview.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.room.ColumnInfo

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/RelatedSongMap.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/RelatedSongMap.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.room.ColumnInfo

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/SearchHistory.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/SearchHistory.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.room.Entity

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/SetVideoIdEntity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/SetVideoIdEntity.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.room.Entity

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/Song.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/Song.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.compose.runtime.Immutable

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/SongAlbumMap.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/SongAlbumMap.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.room.ColumnInfo

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/SongArtistMap.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/SongArtistMap.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.room.ColumnInfo

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/SongEntity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/SongEntity.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.compose.runtime.Immutable

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/SongWithStats.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/SongWithStats.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.compose.runtime.Immutable

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/SortedSongAlbumMap.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/SortedSongAlbumMap.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.room.ColumnInfo

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/SortedSongArtistMap.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/SortedSongArtistMap.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.db.entities
 
 import androidx.room.ColumnInfo

--- a/app/src/main/kotlin/com/metrolist/music/di/AppModule.kt
+++ b/app/src/main/kotlin/com/metrolist/music/di/AppModule.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.di
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/di/LyricsHelperEntryPoint.kt
+++ b/app/src/main/kotlin/com/metrolist/music/di/LyricsHelperEntryPoint.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.di
 
 import com.metrolist.music.lyrics.LyricsHelper

--- a/app/src/main/kotlin/com/metrolist/music/di/NetworkModule.kt
+++ b/app/src/main/kotlin/com/metrolist/music/di/NetworkModule.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.di
 
 import com.metrolist.music.utils.NetworkConnectivityObserver

--- a/app/src/main/kotlin/com/metrolist/music/di/Qualifiers.kt
+++ b/app/src/main/kotlin/com/metrolist/music/di/Qualifiers.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.di
 
 import javax.inject.Qualifier

--- a/app/src/main/kotlin/com/metrolist/music/extensions/ContextExt.kt
+++ b/app/src/main/kotlin/com/metrolist/music/extensions/ContextExt.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.extensions
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/extensions/CoroutineExt.kt
+++ b/app/src/main/kotlin/com/metrolist/music/extensions/CoroutineExt.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.extensions
 
 import kotlinx.coroutines.CoroutineExceptionHandler

--- a/app/src/main/kotlin/com/metrolist/music/extensions/FileExt.kt
+++ b/app/src/main/kotlin/com/metrolist/music/extensions/FileExt.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.extensions
 
 import java.io.File

--- a/app/src/main/kotlin/com/metrolist/music/extensions/ListExt.kt
+++ b/app/src/main/kotlin/com/metrolist/music/extensions/ListExt.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.extensions
 
 import com.metrolist.music.db.entities.Song

--- a/app/src/main/kotlin/com/metrolist/music/extensions/MediaItemExt.kt
+++ b/app/src/main/kotlin/com/metrolist/music/extensions/MediaItemExt.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.extensions
 
 import androidx.core.net.toUri

--- a/app/src/main/kotlin/com/metrolist/music/extensions/PlayerExt.kt
+++ b/app/src/main/kotlin/com/metrolist/music/extensions/PlayerExt.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.extensions
 
 import androidx.media3.common.C

--- a/app/src/main/kotlin/com/metrolist/music/extensions/QueueExt.kt
+++ b/app/src/main/kotlin/com/metrolist/music/extensions/QueueExt.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.extensions
 
 import com.metrolist.music.models.PersistQueue

--- a/app/src/main/kotlin/com/metrolist/music/extensions/StringExt.kt
+++ b/app/src/main/kotlin/com/metrolist/music/extensions/StringExt.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.extensions
 
 import androidx.sqlite.db.SimpleSQLiteQuery

--- a/app/src/main/kotlin/com/metrolist/music/extensions/UtilExt.kt
+++ b/app/src/main/kotlin/com/metrolist/music/extensions/UtilExt.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.extensions
 
 fun <T> tryOrNull(block: () -> T): T? =

--- a/app/src/main/kotlin/com/metrolist/music/lyrics/BetterLyricsProvider.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/BetterLyricsProvider.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.lyrics
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/lyrics/KuGouLyricsProvider.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/KuGouLyricsProvider.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.lyrics
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/lyrics/LrcLibLyricsProvider.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/LrcLibLyricsProvider.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.lyrics
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsEntry.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsEntry.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.lyrics
 
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsHelper.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsHelper.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.lyrics
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsProvider.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsProvider.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.lyrics
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsUtils.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.lyrics
 
 import android.text.format.DateUtils

--- a/app/src/main/kotlin/com/metrolist/music/lyrics/YouTubeLyricsProvider.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/YouTubeLyricsProvider.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.lyrics
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/lyrics/YouTubeSubtitleLyricsProvider.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/YouTubeSubtitleLyricsProvider.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.lyrics
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/models/ItemsPage.kt
+++ b/app/src/main/kotlin/com/metrolist/music/models/ItemsPage.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.models
 
 import com.metrolist.innertube.models.YTItem

--- a/app/src/main/kotlin/com/metrolist/music/models/MediaMetadata.kt
+++ b/app/src/main/kotlin/com/metrolist/music/models/MediaMetadata.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.models
 
 import androidx.compose.runtime.Immutable

--- a/app/src/main/kotlin/com/metrolist/music/models/PersistPlayerState.kt
+++ b/app/src/main/kotlin/com/metrolist/music/models/PersistPlayerState.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.models
 
 import java.io.Serializable

--- a/app/src/main/kotlin/com/metrolist/music/models/PersistQueue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/models/PersistQueue.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.models
 
 import java.io.Serializable

--- a/app/src/main/kotlin/com/metrolist/music/models/SimilarRecommendation.kt
+++ b/app/src/main/kotlin/com/metrolist/music/models/SimilarRecommendation.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.models
 
 import com.metrolist.innertube.models.YTItem

--- a/app/src/main/kotlin/com/metrolist/music/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/DownloadUtil.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.playback
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/playback/ExoDownloadService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/ExoDownloadService.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.playback
 
 import android.app.Notification

--- a/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.playback
 
 import android.content.ContentResolver

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 @file:Suppress("DEPRECATION")
 
 package com.metrolist.music.playback

--- a/app/src/main/kotlin/com/metrolist/music/playback/PlayerConnection.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/PlayerConnection.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.playback
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/playback/SleepTimer.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/SleepTimer.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.playback
 
 import androidx.compose.runtime.getValue

--- a/app/src/main/kotlin/com/metrolist/music/playback/queues/EmptyQueue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/queues/EmptyQueue.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.playback.queues
 
 import androidx.media3.common.MediaItem

--- a/app/src/main/kotlin/com/metrolist/music/playback/queues/ListQueue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/queues/ListQueue.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.playback.queues
 
 import androidx.media3.common.MediaItem

--- a/app/src/main/kotlin/com/metrolist/music/playback/queues/LocalAlbumRadio.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/queues/LocalAlbumRadio.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.playback.queues
 
 import androidx.media3.common.MediaItem

--- a/app/src/main/kotlin/com/metrolist/music/playback/queues/Queue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/queues/Queue.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.playback.queues
 
 import androidx.media3.common.MediaItem

--- a/app/src/main/kotlin/com/metrolist/music/playback/queues/YouTubeAlbumRadio.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/queues/YouTubeAlbumRadio.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.playback.queues
 
 import androidx.media3.common.MediaItem

--- a/app/src/main/kotlin/com/metrolist/music/playback/queues/YouTubeQueue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/queues/YouTubeQueue.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.playback.queues
 
 import androidx.media3.common.MediaItem

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/AutoResizeText.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/AutoResizeText.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.compose.material3.LocalTextStyle

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/BigSeekBar.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/BigSeekBar.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.compose.foundation.Canvas

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/BottomSheet.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/BottomSheet.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.activity.compose.BackHandler

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/BottomSheetMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/BottomSheetMenu.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.compose.foundation.background

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/BottomSheetPage.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/BottomSheetPage.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.activity.compose.BackHandler

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/ChipsRow.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/ChipsRow.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import android.annotation.SuppressLint

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/CreatePlaylistDialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/CreatePlaylistDialog.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import android.widget.Toast

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Dialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Dialog.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.compose.foundation.background

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/DraggableScrollBarOverlay.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/DraggableScrollBarOverlay.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.compose.animation.core.Animatable

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/EmptyPlaceholder.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/EmptyPlaceholder.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.annotation.DrawableRes

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/EnumDialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/EnumDialog.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.compose.foundation.clickable

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/GridMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/GridMenu.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.annotation.DrawableRes

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/HideOnScrollFAB.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/HideOnScrollFAB.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.annotation.DrawableRes

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/IconButton.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/IconButton.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.annotation.DrawableRes

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/IntegrationCard.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/IntegrationCard.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.compose.animation.animateContentSize

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import android.annotation.SuppressLint

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Library.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Library.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.compose.foundation.ExperimentalFoundationApi

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Lyrics.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Lyrics.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import android.annotation.SuppressLint

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/LyricsImageCard.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/LyricsImageCard.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import android.annotation.SuppressLint

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Material3SettingsGroup.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Material3SettingsGroup.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.compose.animation.animateContentSize

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Menu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Menu.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.compose.animation.animateContentSize

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/NavigationTile.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/NavigationTile.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.annotation.DrawableRes

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/NavigationTitle.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/NavigationTitle.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.compose.foundation.clickable

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/NewMenuComponents.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/NewMenuComponents.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.compose.animation.animateColorAsState

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/PlayerSlider.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/PlayerSlider.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.compose.foundation.Canvas

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/PlayingIndicator.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/PlayingIndicator.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.compose.animation.AnimatedVisibility

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Preference.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Preference.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.compose.foundation.clickable

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/ReleaseNotesCard.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/ReleaseNotesCard.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.compose.foundation.layout.Column

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/SearchBar.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/SearchBar.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.activity.compose.BackHandler

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/SortHeader.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/SortHeader.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component
 
 import androidx.compose.foundation.clickable

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/shimmer/ButtonPlaceholder.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/shimmer/ButtonPlaceholder.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component.shimmer
 
 import androidx.compose.foundation.background

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/shimmer/GridItemPlaceholder.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/shimmer/GridItemPlaceholder.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component.shimmer
 
 import androidx.compose.foundation.background

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/shimmer/ListItemPlaceholder.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/shimmer/ListItemPlaceholder.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component.shimmer
 
 import androidx.compose.foundation.background

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/shimmer/ShimmerHost.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/shimmer/ShimmerHost.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component.shimmer
 
 import androidx.compose.animation.core.LinearEasing

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/shimmer/TextPlaceholder.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/shimmer/TextPlaceholder.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.component.shimmer
 
 import androidx.compose.foundation.background

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.menu
 
 import androidx.compose.foundation.Image

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialogOnline.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialogOnline.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.menu
 
 import androidx.compose.foundation.Image

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.menu
 
 import android.annotation.SuppressLint

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/ArtistMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/ArtistMenu.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.menu
 
 import android.content.Intent

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/CustomThumbnailMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/CustomThumbnailMenu.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.menu
 
 import androidx.compose.foundation.clickable

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/ImportPlaylistDialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/ImportPlaylistDialog.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.menu
 
 import androidx.compose.material3.Icon

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/LoadingScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/LoadingScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.menu
 
 import androidx.compose.foundation.layout.Arrangement

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/LyricsMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/LyricsMenu.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.menu
 
 import android.app.SearchManager

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.menu
 
 import android.content.Intent

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/PlaylistMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/PlaylistMenu.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.menu
 
 import android.content.Intent

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/PlaylistScreenMenus.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/PlaylistScreenMenus.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.menu
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/SelectionSongsMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/SelectionSongsMenu.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.menu
 
 import android.annotation.SuppressLint

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.menu
 
 import android.content.Intent

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.menu
 
 import android.annotation.SuppressLint

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeArtistMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeArtistMenu.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.menu
 
 import android.content.Intent

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubePlaylistMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubePlaylistMenu.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.menu
 
 import android.annotation.SuppressLint

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSelectionSongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSelectionSongMenu.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.menu
 
 import androidx.compose.foundation.layout.PaddingValues

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSongMenu.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.menu
 
 import android.annotation.SuppressLint

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.player
 
 import android.content.res.Configuration

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/PlaybackError.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/PlaybackError.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.player
 
 import androidx.compose.foundation.gestures.detectTapGestures

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.player
 
 import android.content.ClipData

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Queue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Queue.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.player
 
 import androidx.activity.compose.BackHandler

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Thumbnail.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Thumbnail.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.player
 
 import androidx.compose.animation.AnimatedVisibility

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/AccountScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/AccountScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens
 
 import androidx.compose.foundation.ExperimentalFoundationApi

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/AlbumScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens
 
 import androidx.activity.compose.BackHandler
@@ -575,4 +583,3 @@ fun AlbumScreen(
         }
     )
 }
-

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/BrowseScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/BrowseScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens
  
  import androidx.compose.foundation.ExperimentalFoundationApi

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/ChartsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/ChartsScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens
 
 import androidx.compose.foundation.ExperimentalFoundationApi

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/ExploreScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/ExploreScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens
 
 import androidx.compose.foundation.ExperimentalFoundationApi

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/HistoryScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/HistoryScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens
 
 import androidx.activity.compose.BackHandler

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens
 
 import androidx.activity.compose.BackHandler

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/LoginScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/LoginScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens
 
 import android.annotation.SuppressLint

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/MoodAndGenresScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/MoodAndGenresScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens
 
 import android.content.res.Configuration.ORIENTATION_LANDSCAPE

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/NavigationBuilder.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens
 
 import androidx.compose.animation.core.tween

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/NewReleaseScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/NewReleaseScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens
 
 import androidx.compose.foundation.ExperimentalFoundationApi

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/Screens.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/Screens.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens
 
 import androidx.annotation.DrawableRes

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/StatsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/StatsScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens
 
 import androidx.compose.foundation.ExperimentalFoundationApi

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/YouTubeBrowseScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/YouTubeBrowseScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 @file:Suppress("UNUSED_EXPRESSION")
 
 package com.metrolist.music.ui.screens

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistAlbumsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistAlbumsScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.artist
 
 import androidx.activity.compose.BackHandler

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistItemsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistItemsScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.artist
 
 import androidx.compose.foundation.ExperimentalFoundationApi

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.artist
 
 import android.content.ClipData

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistSongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistSongsScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.artist
 
 import androidx.compose.foundation.ExperimentalFoundationApi

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryAlbumsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryAlbumsScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.library
 
 import androidx.compose.foundation.ExperimentalFoundationApi

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryArtistsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryArtistsScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.library
 
 import androidx.compose.foundation.ExperimentalFoundationApi

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryMixScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryMixScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.library
 
 import androidx.compose.foundation.ExperimentalFoundationApi

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPlaylistsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPlaylistsScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.library
 
 import androidx.compose.foundation.ExperimentalFoundationApi

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.library
 
 import androidx.compose.foundation.layout.Box

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.library
 
 import androidx.compose.foundation.ExperimentalFoundationApi

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.playlist
 
 import androidx.activity.compose.BackHandler

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/CachePlaylistScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.playlist
 
 import androidx.activity.compose.BackHandler

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.playlist
 
 import android.annotation.SuppressLint

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.playlist
 
 import androidx.activity.compose.BackHandler
@@ -506,4 +514,3 @@ private fun OnlinePlaylistHeader(
         }
     }
 }
-

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/TopPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/TopPlaylistScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.playlist
 
 import androidx.activity.compose.BackHandler

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/search/LocalSearchScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/search/LocalSearchScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.search
 
 import androidx.compose.foundation.ExperimentalFoundationApi

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchResult.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchResult.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.search
 
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -443,5 +451,3 @@ fun OnlineSearchResult(
     //     focusRequester.requestFocus()
     // }
 }
-
-

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.search
 
 import androidx.compose.foundation.ExperimentalFoundationApi

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/search/SearchScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.search
 
 import androidx.compose.foundation.layout.Box

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AboutScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AboutScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.settings
 
 import androidx.compose.foundation.Image
@@ -245,4 +253,3 @@ fun AboutScreen(
         }
     )
 }
-

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AccountSettings.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.settings
 
 import android.content.ActivityNotFoundException

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AppearanceSettings.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.settings
 
 import android.os.Build

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/BackupAndRestore.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/BackupAndRestore.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.settings
 
 import androidx.activity.compose.rememberLauncherForActivityResult

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/ContentSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/ContentSettings.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.settings
 
 import android.annotation.TargetApi

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/DiscordLoginScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/DiscordLoginScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.settings
 
 import android.annotation.SuppressLint

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.settings
 
 import androidx.compose.foundation.layout.Column

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PrivacySettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PrivacySettings.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.settings
 
 import androidx.compose.foundation.layout.Column

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/RomanizationSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/RomanizationSettings.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.settings
 
 import android.annotation.TargetApi

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/SettingsScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.settings
 
 import android.content.ActivityNotFoundException

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/StorageSettings.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.settings
 
 import androidx.compose.animation.core.animateFloatAsState

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/UpdaterSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/UpdaterSettings.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.settings
 
 import androidx.compose.foundation.background

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/DiscordSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/DiscordSettings.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.settings.integrations
 
 import android.content.Intent

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/IntegrationScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/IntegrationScreen.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.settings.integrations
 
 import androidx.compose.foundation.layout.Column

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/LastFMSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/LastFMSettings.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.screens.settings.integrations
 
 import androidx.compose.foundation.layout.Arrangement

--- a/app/src/main/kotlin/com/metrolist/music/ui/theme/PlayerColorExtractor.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/theme/PlayerColorExtractor.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.theme
 
 import androidx.compose.ui.graphics.Color

--- a/app/src/main/kotlin/com/metrolist/music/ui/theme/PlayerSliderColors.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/theme/PlayerSliderColors.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.theme
 
 import androidx.compose.material3.MaterialTheme

--- a/app/src/main/kotlin/com/metrolist/music/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/theme/Theme.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.theme
 
 import android.graphics.Bitmap

--- a/app/src/main/kotlin/com/metrolist/music/ui/theme/Type.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/theme/Type.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.theme
 
 import androidx.compose.material3.Typography
@@ -120,4 +128,3 @@ val AppTypography = Typography(
         letterSpacing = 0.5.sp
     )
 )
-

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/AppBar.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/AppBar.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.utils
 
 import androidx.compose.animation.core.AnimationSpec

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/FadingEdge.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/FadingEdge.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.utils
 
 import androidx.compose.ui.Modifier

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/ItemWrapper.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/ItemWrapper.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.utils
 
 import androidx.compose.runtime.mutableStateOf

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/KeyUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/KeyUtils.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.utils
 
 import java.util.concurrent.atomic.AtomicLong

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/LazyGridSnapLayoutInfoProvider.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/LazyGridSnapLayoutInfoProvider.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.utils
 
 import androidx.compose.foundation.ExperimentalFoundationApi

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/NavControllerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/NavControllerUtils.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.utils
 
 import androidx.navigation.NavController

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/ScrollUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/ScrollUtils.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.utils
 
 import androidx.compose.foundation.ScrollState

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/ShapeUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/ShapeUtils.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.utils
 
 import androidx.compose.foundation.shape.CornerBasedShape

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.utils
 
 import android.text.format.Formatter

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/StringUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/StringUtils.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.utils
 
 import java.text.DecimalFormat

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/YouTubeUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/YouTubeUtils.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.ui.utils
 
 fun String.resize(

--- a/app/src/main/kotlin/com/metrolist/music/utils/CoilBitmapLoader.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/CoilBitmapLoader.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.utils
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/utils/ComposeDebugUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/ComposeDebugUtils.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.utils
 
 import androidx.compose.runtime.LaunchedEffect

--- a/app/src/main/kotlin/com/metrolist/music/utils/ComposeToImage.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/ComposeToImage.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.utils
 
 import android.content.ContentValues

--- a/app/src/main/kotlin/com/metrolist/music/utils/DataStore.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/DataStore.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.utils
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/utils/DiscordRPC.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/DiscordRPC.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.utils
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/utils/IconUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/IconUtils.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.utils
 
 import android.app.Activity

--- a/app/src/main/kotlin/com/metrolist/music/utils/NetworkConnectivityObserver.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/NetworkConnectivityObserver.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.utils
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/utils/NetworkUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/NetworkUtils.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.utils
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/utils/ScrobbleManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/ScrobbleManager.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.utils
 
 import com.metrolist.music.models.MediaMetadata

--- a/app/src/main/kotlin/com/metrolist/music/utils/StringUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/StringUtils.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.utils
 
 import java.math.BigInteger

--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.utils
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/utils/Updater.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/Updater.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.utils
 
 import com.metrolist.music.BuildConfig

--- a/app/src/main/kotlin/com/metrolist/music/utils/Utils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/Utils.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.utils
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.utils
 
 import android.net.ConnectivityManager

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/AccountSettingsViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/AccountSettingsViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/AccountViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/AccountViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import androidx.lifecycle.ViewModel

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/AlbumViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/AlbumViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import androidx.lifecycle.SavedStateHandle

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistAlbumsViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistAlbumsViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import androidx.lifecycle.SavedStateHandle

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistItemsViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistItemsViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import androidx.compose.runtime.getValue

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/AutoPlaylistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/AutoPlaylistViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/BackupRestoreViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/BackupRestoreViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/BrowseViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/BrowseViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
  
 import androidx.lifecycle.SavedStateHandle

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/CachePlaylistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/CachePlaylistViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/ChartsViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/ChartsViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import androidx.lifecycle.ViewModel

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/ExploreViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/ExploreViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/HistoryViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/HistoryViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import androidx.compose.runtime.mutableStateOf

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/HomeViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/LibraryViewModels.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/LibraryViewModels.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 @file:OptIn(ExperimentalCoroutinesApi::class)
 
 package com.metrolist.music.viewmodels

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/LocalPlaylistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/LocalPlaylistViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/LocalSearchViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/LocalSearchViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import androidx.lifecycle.ViewModel

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/LyricsMenuViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/LyricsMenuViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/MoodAndGenresViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/MoodAndGenresViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import androidx.lifecycle.ViewModel

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/NewReleaseViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/NewReleaseViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/OnlinePlaylistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/OnlinePlaylistViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/OnlineSearchSuggestionViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/OnlineSearchSuggestionViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/OnlineSearchViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/OnlineSearchViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/StatsViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/StatsViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import androidx.lifecycle.ViewModel

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/TopPlaylistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/TopPlaylistViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/YouTubeBrowseViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/YouTubeBrowseViewModel.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.viewmodels
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/widget/HelloWidget.kt
+++ b/app/src/main/kotlin/com/metrolist/music/widget/HelloWidget.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2026 Metrolist Project
+ *
+ * SPDX-License-Identifier: GPL-3.0
+ *
+ * For any other attributions, refer to the git commit history
+ */
+
 package com.metrolist.music.widget
 
 import android.app.PendingIntent


### PR DESCRIPTION
Added copyright and license headers to all 239 Kotlin files in the com.metrolist.music package as required by GPL-3.0 license terms.