### PR TITLE
fix: live performances and from your library sections in artist page

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistScreen.kt
@@ -675,6 +675,7 @@ fun ArtistScreen(
                                             },
                                             isPlaying = isPlaying,
                                             coroutineScope = coroutineScope,
+                                            thumbnailRatio = 1f, // Use square thumbnails for all items in horizontal scroll
                                             modifier = Modifier
                                                 .combinedClickable(
                                                     onClick = {

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistViewModel.kt
@@ -81,12 +81,10 @@ class ArtistViewModel @Inject constructor(
             YouTube.artist(artistId)
                 .onSuccess { page ->
                     val filteredSections = page.sections
-                        .filterNot { section ->
-                            section.moreEndpoint?.browseId?.startsWith("MPLAUC") == true
-                        }
                         .map { section ->
                             section.copy(items = section.items.filterExplicit(hideExplicit).filterVideoSongs(hideVideoSongs))
                         }
+                        .filter { section -> section.items.isNotEmpty() }
 
                     artistPage = page.copy(sections = filteredSections)
                 }.onFailure {

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistItemsPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistItemsPage.kt
@@ -19,27 +19,39 @@ data class ArtistItemsPage(
 ) {
     companion object {
         fun fromMusicResponsiveListItemRenderer(renderer: MusicResponsiveListItemRenderer): SongItem? {
+            // Extract artists from flexColumns - try multiple approaches
+            val artists = renderer.flexColumns.getOrNull(1)
+                ?.musicResponsiveListItemFlexColumnRenderer?.text?.runs
+                ?.oddElements()?.map {
+                    Artist(
+                        name = it.text,
+                        id = it.navigationEndpoint?.browseEndpoint?.browseId
+                    )
+                }
+            
+            // Extract album from last flexColumn (like SimpMusic does)
+            val album = renderer.flexColumns.lastOrNull()
+                ?.musicResponsiveListItemFlexColumnRenderer?.text?.runs
+                ?.firstOrNull()?.let {
+                    if (it.navigationEndpoint?.browseEndpoint?.browseId != null) {
+                        Album(
+                            name = it.text,
+                            id = it.navigationEndpoint.browseEndpoint.browseId
+                        )
+                    } else null
+                }
+            
             return SongItem(
                 id = renderer.playlistItemData?.videoId ?: return null,
                 title = renderer.flexColumns.firstOrNull()
                     ?.musicResponsiveListItemFlexColumnRenderer?.text
                     ?.runs?.firstOrNull()?.text ?: return null,
-                artists = renderer.flexColumns.getOrNull(1)?.musicResponsiveListItemFlexColumnRenderer?.text?.runs?.oddElements()?.map {
-                    Artist(
-                        name = it.text,
-                        id = it.navigationEndpoint?.browseEndpoint?.browseId
-                    )
-                } ?: return null,
-                album = renderer.flexColumns.getOrNull(3)?.musicResponsiveListItemFlexColumnRenderer?.text?.runs?.firstOrNull()?.let {
-                    Album(
-                        name = it.text,
-                        id = it.navigationEndpoint?.browseEndpoint?.browseId ?: return null
-                    )
-                },
+                artists = artists ?: return null,
+                album = album,
                 duration = renderer.fixedColumns?.firstOrNull()
                     ?.musicResponsiveListItemFlexColumnRenderer?.text
                     ?.runs?.firstOrNull()
-                    ?.text?.parseTime() ?: return null,
+                    ?.text?.parseTime(),
                 musicVideoType = renderer.musicVideoType,
                 thumbnail = renderer.thumbnail?.musicThumbnailRenderer?.getThumbnailUrl() ?: return null,
                 explicit = renderer.badges?.find {


### PR DESCRIPTION
- Remove MPLAUC filter to show Live performances and From your library sections
- Make duration optional in ArtistItemsPage.fromMusicResponsiveListItemRenderer
- Use lastOrNull() for album extraction in artist pages
- Add musicShelfRenderer handling in artistItems function
- Add musicShelfContinuation handling in artistItemsContinuation
- Fix null safety in continuation handling
- Simplify artists and album extraction in ArtistPage.kt
- Use square thumbnails (1:1) for songs in horizontal scroll sections