### PR TITLE
Fix: Update Better Lyrics API URL to new endpoint

### DIFF
--- a/betterlyrics/src/main/kotlin/com/metrolist/music/betterlyrics/BetterLyrics.kt
+++ b/betterlyrics/src/main/kotlin/com/metrolist/music/betterlyrics/BetterLyrics.kt
@@ -31,7 +31,7 @@ object BetterLyrics {
             }
 
             defaultRequest {
-                url("https://lyrics-api-go-better-lyrics-api-pr-12.up.railway.app")
+                url("https://lyrics-api.boidu.dev")
             }
 
             expectSuccess = true


### PR DESCRIPTION
- Changed API URL from old railway.app to lyrics-api.boidu.dev
- The old endpoint was returning 404 errors