### PR TITLE
UI: Keep screen on during lyrics view & clarify animation style setting

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Lyrics.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Lyrics.kt
@@ -6,9 +6,11 @@
 package com.metrolist.music.ui.component
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.content.Intent
 import android.content.res.Configuration
 import android.os.Build
+import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.annotation.RequiresApi
@@ -477,6 +479,17 @@ fun Lyrics(
     }
 
     val lifecycleOwner = LocalLifecycleOwner.current
+
+    // Keep screen on while lyrics are visible
+    DisposableEffect(showLyrics) {
+        val activity = context as? Activity
+        if (showLyrics) {
+            activity?.window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+        onDispose {
+            activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+    }
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -314,7 +314,7 @@
     <string name="cache_size_warning_confirm">Continue</string>
 
     <!-- Lyrics Animation Styles -->
-    <string name="lyrics_animation_style">Lyrics animation style</string>
+    <string name="lyrics_animation_style">Word-by-word animation style</string>
     <string name="none">None</string>
     <string name="fade">Fade</string>
     <string name="glow">Glow</string>


### PR DESCRIPTION
- Added FLAG_KEEP_SCREEN_ON to prevent screen sleep while lyrics are visible
- Renamed 'Lyrics animation style' to 'Word-by-word animation style' for clarity