### PR TITLE
Style: Add empty line after copyright header in Wrapped screens

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/WrappedAudioService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/WrappedAudioService.kt
@@ -2,6 +2,7 @@
  * Metrolist Project (C) 2026
  * Licensed under GPL-3.0 | See git history for contributors
  */
+
 package com.metrolist.music.ui.screens.wrapped
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/WrappedConstants.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/WrappedConstants.kt
@@ -2,6 +2,7 @@
  * Metrolist Project (C) 2026
  * Licensed under GPL-3.0 | See git history for contributors
  */
+
 package com.metrolist.music.ui.screens.wrapped
 
 object WrappedConstants {

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/WrappedData.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/WrappedData.kt
@@ -2,6 +2,7 @@
  * Metrolist Project (C) 2026
  * Licensed under GPL-3.0 | See git history for contributors
  */
+
 package com.metrolist.music.ui.screens.wrapped
 
 data class MessagePair(val range: LongRange, val tease: String, val reveal: String)

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/WrappedEntryPoint.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/WrappedEntryPoint.kt
@@ -2,6 +2,7 @@
  * Metrolist Project (C) 2026
  * Licensed under GPL-3.0 | See git history for contributors
  */
+
 package com.metrolist.music.ui.screens.wrapped
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/WrappedManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/WrappedManager.kt
@@ -2,6 +2,7 @@
  * Metrolist Project (C) 2026
  * Licensed under GPL-3.0 | See git history for contributors
  */
+
 package com.metrolist.music.ui.screens.wrapped
 
 import android.content.Context

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/WrappedScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/WrappedScreen.kt
@@ -2,6 +2,7 @@
  * Metrolist Project (C) 2026
  * Licensed under GPL-3.0 | See git history for contributors
  */
+
 package com.metrolist.music.ui.screens.wrapped
 
 import android.net.ConnectivityManager

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/WrappedState.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/WrappedState.kt
@@ -2,6 +2,7 @@
  * Metrolist Project (C) 2026
  * Licensed under GPL-3.0 | See git history for contributors
  */
+
 package com.metrolist.music.ui.screens.wrapped
 
 import com.metrolist.innertube.models.AccountInfo

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/WrappedViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/WrappedViewModel.kt
@@ -2,6 +2,7 @@
  * Metrolist Project (C) 2026
  * Licensed under GPL-3.0 | See git history for contributors
  */
+
 package com.metrolist.music.ui.screens.wrapped
 
 import androidx.lifecycle.ViewModel

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/components/AnimatedDecorativeElement.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/components/AnimatedDecorativeElement.kt
@@ -2,6 +2,7 @@
  * Metrolist Project (C) 2026
  * Licensed under GPL-3.0 | See git history for contributors
  */
+
 package com.metrolist.music.ui.screens.wrapped.components
 
 import androidx.compose.animation.core.Animatable

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/components/AutoResizingText.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/components/AutoResizingText.kt
@@ -2,6 +2,7 @@
  * Metrolist Project (C) 2026
  * Licensed under GPL-3.0 | See git history for contributors
  */
+
 package com.metrolist.music.ui.screens.wrapped.components
 
 import androidx.compose.material3.Text

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/AlbumPages.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/AlbumPages.kt
@@ -2,6 +2,7 @@
  * Metrolist Project (C) 2026
  * Licensed under GPL-3.0 | See git history for contributors
  */
+
 package com.metrolist.music.ui.screens.wrapped.pages
 
 import androidx.compose.animation.AnimatedVisibility

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/WrappedIntro.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/WrappedIntro.kt
@@ -2,6 +2,7 @@
  * Metrolist Project (C) 2026
  * Licensed under GPL-3.0 | See git history for contributors
  */
+
 package com.metrolist.music.ui.screens.wrapped.pages
 
 import androidx.compose.animation.AnimatedVisibility

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/WrappedMinutesScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/WrappedMinutesScreen.kt
@@ -2,6 +2,7 @@
  * Metrolist Project (C) 2026
  * Licensed under GPL-3.0 | See git history for contributors
  */
+
 package com.metrolist.music.ui.screens.wrapped.pages
 
 import androidx.compose.animation.core.Animatable

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/WrappedMinutesTease.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/WrappedMinutesTease.kt
@@ -2,6 +2,7 @@
  * Metrolist Project (C) 2026
  * Licensed under GPL-3.0 | See git history for contributors
  */
+
 package com.metrolist.music.ui.screens.wrapped.pages
 
 import androidx.compose.animation.AnimatedVisibility

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/WrappedTop5ArtistsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/WrappedTop5ArtistsScreen.kt
@@ -2,6 +2,7 @@
  * Metrolist Project (C) 2026
  * Licensed under GPL-3.0 | See git history for contributors
  */
+
 package com.metrolist.music.ui.screens.wrapped.pages
 
 import androidx.compose.animation.core.LinearEasing

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/WrappedTop5SongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/WrappedTop5SongsScreen.kt
@@ -2,6 +2,7 @@
  * Metrolist Project (C) 2026
  * Licensed under GPL-3.0 | See git history for contributors
  */
+
 package com.metrolist.music.ui.screens.wrapped.pages
 
 import androidx.compose.animation.core.LinearEasing

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/WrappedTopArtistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/WrappedTopArtistScreen.kt
@@ -2,6 +2,7 @@
  * Metrolist Project (C) 2026
  * Licensed under GPL-3.0 | See git history for contributors
  */
+
 package com.metrolist.music.ui.screens.wrapped.pages
 
 import androidx.compose.animation.AnimatedVisibility

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/WrappedTopSongScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/WrappedTopSongScreen.kt
@@ -2,6 +2,7 @@
  * Metrolist Project (C) 2026
  * Licensed under GPL-3.0 | See git history for contributors
  */
+
 package com.metrolist.music.ui.screens.wrapped.pages
 
 import androidx.compose.animation.AnimatedVisibility

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/WrappedTotalArtistsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/WrappedTotalArtistsScreen.kt
@@ -2,6 +2,7 @@
  * Metrolist Project (C) 2026
  * Licensed under GPL-3.0 | See git history for contributors
  */
+
 package com.metrolist.music.ui.screens.wrapped.pages
 
 import androidx.compose.animation.core.Animatable

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/WrappedTotalSongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/WrappedTotalSongsScreen.kt
@@ -2,6 +2,7 @@
  * Metrolist Project (C) 2026
  * Licensed under GPL-3.0 | See git history for contributors
  */
+
 package com.metrolist.music.ui.screens.wrapped.pages
 
 import androidx.compose.animation.core.*


### PR DESCRIPTION
Fixes formatting to match project style guidelines