### PR TITLE
Fix active lyrics line not being centered

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Lyrics.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Lyrics.kt
@@ -581,7 +581,7 @@ fun Lyrics(
             deferredCurrentLineIndex = currentLineIndex
             if (isSeeking) {
                 // Fast scroll for seeking to center the target line (300ms)
-                val seekCenterIndex = kotlin.math.max(0, currentLineIndex - 1)
+                val seekCenterIndex = kotlin.math.max(0, currentLineIndex)
                 performSmoothPageScroll(seekCenterIndex, 500) // Fast seek duration
             } else if ((lastPreviewTime == 0L || currentLineIndex != previousLineIndex) && scrollLyrics) {
                 // Auto-scroll when lyrics settings allow it


### PR DESCRIPTION
Before
<img width="184" height="400" alt="afbeelding" src="https://github.com/user-attachments/assets/3ebcae8a-b97c-44d0-8812-3fe1b7f508bc" />
After:
<img width="184" height="400" alt="afbeelding" src="https://github.com/user-attachments/assets/83e3d071-a394-4416-8675-1d11e4642460" />

By accident the previous line got targeted to be in the center instead of the current line.

fixes #2152 