### PR TITLE
Already-latin lyrics containing cyrillic e don't get romanized anymore

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsUtils.kt
@@ -528,7 +528,10 @@ object LyricsUtils {
     suspend fun romanizeCyrillic(text: String): String? = withContext(Dispatchers.Default) {
         if (text.isEmpty()) return@withContext null
 
-        if (!text.any { it in '\u0400'..'\u04FF' }) {
+        val cyrillicChars = text.filter { it in '\u0400'..'\u04FF' }
+
+        if (cyrillicChars.isEmpty() ||
+            (cyrillicChars.length == 1 && (cyrillicChars[0] == 'е' || cyrillicChars[0] == 'Е'))) {
             return@withContext null
         }
 


### PR DESCRIPTION
I have added a check to see if the only character is the cyrillic e, incase it is it just doesn't romanize it. This serves as a fix for #1772 