### PR TITLE
Fix 'Play next' item in Selection Song Menu completely replacing the queue instead of adding to the queue

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/SelectionSongsMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/SelectionSongsMenu.kt
@@ -267,22 +267,17 @@ fun SelectionSongMenu(
             Material3MenuGroup(
                 items = listOf(
                     Material3MenuItemData(
-                        title = { Text(text = stringResource(R.string.play)) },
+                        title = { Text(text = stringResource(R.string.play_next)) },
                         description = { Text(text = stringResource(R.string.play_next_desc)) },
                         icon = {
                             Icon(
-                                painter = painterResource(R.drawable.play),
+                                painter = painterResource(R.drawable.playlist_play),
                                 contentDescription = null,
                             )
                         },
                         onClick = {
                             onDismiss()
-                            playerConnection.playQueue(
-                                ListQueue(
-                                    title = "Selection",
-                                    items = songSelection.map { it.toMediaItem() },
-                                ),
-                            )
+                            playerConnection.playNext(songSelection.map { it.toMediaItem() })
                             clearAction()
                         }
                     ),


### PR DESCRIPTION
fixes #2180 