### PR TITLE
Improve player controls physics

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
@@ -1178,17 +1178,36 @@ fun BottomSheetPlayer(
                             val backInteractionSource = remember { MutableInteractionSource() }
                             val nextInteractionSource = remember { MutableInteractionSource() }
                             val playPauseInteractionSource = remember { MutableInteractionSource() }
+
                             val isPlayPausePressed by playPauseInteractionSource.collectIsPressedAsState()
+                            val isBackPressed by backInteractionSource.collectIsPressedAsState()
+                            val isNextPressed by nextInteractionSource.collectIsPressedAsState()
 
                             val playPauseWeight by animateFloatAsState(
-                                targetValue = if (isPlayPausePressed) 1.9f else 1.3f,
-                                animationSpec = spring(),
+                                targetValue = if (isPlayPausePressed) 1.9f else if (isBackPressed || isNextPressed) 1.1f else 1.3f,
+                                animationSpec = spring(
+                                    dampingRatio = 0.6f,
+                                    stiffness = 500f
+                                ),
                                 label = "playPauseWeight"
                             )
-                            val sideButtonWeight by animateFloatAsState(
-                                targetValue = if (isPlayPausePressed) 0.35f else 0.45f,
-                                animationSpec = spring(),
-                                label = "sideButtonWeight"
+
+                            val backButtonWeight by animateFloatAsState(
+                                targetValue = if (isBackPressed) 0.65f else if (isPlayPausePressed) 0.35f else 0.45f,
+                                animationSpec = spring(
+                                    dampingRatio = 0.6f,
+                                    stiffness = 500f
+                                ),
+                                label = "backButtonWeight"
+                            )
+
+                            val nextButtonWeight by animateFloatAsState(
+                                targetValue = if (isNextPressed) 0.65f else if (isPlayPausePressed) 0.35f else 0.45f,
+                                animationSpec = spring(
+                                    dampingRatio = 0.6f,
+                                    stiffness = 500f
+                                ),
+                                label = "nextButtonWeight"
                             )
 
                             FilledIconButton(
@@ -1202,8 +1221,7 @@ fun BottomSheetPlayer(
                                 ),
                                 modifier = Modifier
                                     .height(68.dp)
-                                    .weight(sideButtonWeight)
-                                    .bouncy(backInteractionSource)
+                                    .weight(backButtonWeight)
                             ) {
                                 Icon(
                                     painter = painterResource(R.drawable.skip_previous),
@@ -1271,8 +1289,7 @@ fun BottomSheetPlayer(
                                 ),
                                 modifier = Modifier
                                     .height(68.dp)
-                                    .weight(sideButtonWeight)
-                                    .bouncy(nextInteractionSource)
+                                    .weight(nextButtonWeight)
                             ) {
                                 Icon(
                                     painter = painterResource(R.drawable.skip_next),
@@ -1591,19 +1608,6 @@ fun InlineLyricsView(mediaMetadata: MediaMetadata?, showLyrics: Boolean) {
     }
 }
 
-private fun Modifier.bouncy(interactionSource: InteractionSource) = composed {
-    val isPressed by interactionSource.collectIsPressedAsState()
-    val scale by animateFloatAsState(
-        targetValue = if (isPressed) 0.9f else 1f,
-        animationSpec = spring(),
-        label = "scale"
-    )
-
-    graphicsLayer {
-        scaleX = scale
-        scaleY = scale
-    }
-}
 
 @Composable
 fun MoreActionsButton(


### PR DESCRIPTION
feat(player): improve new player button physics

Implements a new animation logic for the control buttons in the "New player UI design".

- The play/pause and skip buttons now symmetrically compress each other when pressed.
- A spring animation is used to create a "jelly-like" bouncy effect.
- The skip buttons no longer shrink on their own press, but they expand, while still compressing in response to the play/pause button press.