### PR TITLE
Fix build warnings

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/eq/audio/CustomEqualizerAudioProcessor.kt
+++ b/app/src/main/kotlin/com/metrolist/music/eq/audio/CustomEqualizerAudioProcessor.kt
@@ -277,6 +277,7 @@ class CustomEqualizerAudioProcessor : AudioProcessor {
     }
 
     override fun reset() {
+        @Suppress("DEPRECATION")
         flush()
         inputBuffer = EMPTY_BUFFER
         sampleRate = 0

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -184,7 +184,8 @@ import java.time.LocalDateTime
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 
-@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class, UnstableApi::class)
+@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
+@androidx.annotation.OptIn(UnstableApi::class)
 @AndroidEntryPoint
 class MusicService :
     MediaLibraryService(),

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/equalizer/EqScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/equalizer/EqScreen.kt
@@ -315,7 +315,7 @@ private fun EQProfileItem(
                         showDeleteDialog = false
                     }
                 ) {
-                    Text(stringResource(android.R.string.yes))
+                    Text(stringResource(android.R.string.ok))
                 }
             },
             dismissButton = {

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -400,4 +400,5 @@
     <string name="copied_artist">Copied Artist</string>
     <string name="error_playing">Error playing</string>
     <string name="failed_to_parse_proxy">Failed to parse proxy url.</string>
+    <string name="enable_squiggly_slider">Enable squiggly slider</string>
 </resources>


### PR DESCRIPTION
- Add missing default value for enable_squiggly_slider string resource
- Suppress deprecation warning for flush() call in CustomEqualizerAudioProcessor
- Use @androidx.annotation.OptIn for UnstableApi in MusicService
- Replace deprecated android.R.string.yes with android.R.string.ok in EqScreen