### PR TITLE
style: remove NewActionButton elevation?

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/NewMenuComponents.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/NewMenuComponents.kt
@@ -83,7 +83,6 @@ fun NewActionButton(
         ),
         shape = RoundedCornerShape(16.dp),
         elevation = CardDefaults.cardElevation(
-            defaultElevation = 2.dp
         )
     ) {
         Column(


### PR DESCRIPTION
 I think current NewActionButton design with shadow looks out of place since other buttons don't have any shadow. Maybe some outline should be added for buttons to pop out a bit more (like with mini player)? To be honest on phone it looks a lot worse then in screenshots from vm (probably because no antialiasing in vm).
 
 WIth elevation (current):
 
<img width="411" height="862" alt="image" src="https://github.com/user-attachments/assets/82541482-4f1d-4b36-a4a9-66a0c15781d8" />

 No elevation:
<img width="435" height="872" alt="image" src="https://github.com/user-attachments/assets/c00b72b5-3205-4ed5-b272-e49529e215eb" />

