### PR TITLE
feat: Apply grid size settings to all screens

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
@@ -104,12 +104,16 @@ import com.metrolist.music.LocalDatabase
 import com.metrolist.music.LocalDownloadUtil
 import com.metrolist.music.LocalPlayerConnection
 import com.metrolist.music.R
+import com.metrolist.music.constants.GridItemSize
+import com.metrolist.music.constants.GridItemsSizeKey
 import com.metrolist.music.constants.HideExplicitKey
 import com.metrolist.music.constants.ListItemHeight
 import com.metrolist.music.constants.GridThumbnailHeight
+import com.metrolist.music.constants.SmallGridThumbnailHeight
 import com.metrolist.music.constants.ListThumbnailSize
 import com.metrolist.music.constants.ThumbnailCornerRadius
 import com.metrolist.music.constants.SwipeToSongKey
+import com.metrolist.music.utils.rememberEnumPreference
 import com.metrolist.music.db.entities.Song
 import com.metrolist.music.db.entities.Album
 import com.metrolist.music.db.entities.AlbumEntity
@@ -134,6 +138,12 @@ import java.util.logging.Logger
 import kotlin.math.roundToInt
 
 const val ActiveBoxAlpha = 0.6f
+
+@Composable
+fun currentGridThumbnailHeight(): Dp {
+    val gridItemSize by rememberEnumPreference(GridItemsSizeKey, GridItemSize.BIG)
+    return if (gridItemSize == GridItemSize.BIG) GridThumbnailHeight else SmallGridThumbnailHeight
+}
 
 // Basic list item - optimized with inline to reduce recomposition
 @Composable
@@ -265,6 +275,7 @@ fun GridItem(
     thumbnailRatio: Float = 1f,
     fillMaxWidth: Boolean = false,
 ) {
+    val gridHeight = currentGridThumbnailHeight()
     Column(
         modifier = if (fillMaxWidth) {
             modifier
@@ -273,7 +284,7 @@ fun GridItem(
         } else {
             modifier
                 .padding(12.dp)
-                .width(GridThumbnailHeight * thumbnailRatio)
+                .width(gridHeight * thumbnailRatio)
         }
     ) {
         BoxWithConstraints(
@@ -281,7 +292,7 @@ fun GridItem(
             modifier = if (fillMaxWidth) {
                 Modifier.fillMaxWidth()
             } else {
-                Modifier.height(GridThumbnailHeight)
+                Modifier.height(gridHeight)
             }
                 .aspectRatio(thumbnailRatio)
         ) {
@@ -455,12 +466,13 @@ fun SongGridItem(
     },
     badges = badges,
     thumbnailContent = {
+        val gridHeight = currentGridThumbnailHeight()
         ItemThumbnail(
             thumbnailUrl = song.song.thumbnailUrl,
             isActive = isActive,
             isPlaying = isPlaying,
             shape = RoundedCornerShape(ThumbnailCornerRadius),
-            modifier = Modifier.size(GridThumbnailHeight)
+            modifier = Modifier.size(gridHeight)
         )
         if (!isActive) {
             OverlayPlayButton(

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/shimmer/GridItemPlaceholder.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/shimmer/GridItemPlaceholder.kt
@@ -16,12 +16,17 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
+import com.metrolist.music.constants.GridItemSize
+import com.metrolist.music.constants.GridItemsSizeKey
 import com.metrolist.music.constants.GridThumbnailHeight
+import com.metrolist.music.constants.SmallGridThumbnailHeight
 import com.metrolist.music.constants.ThumbnailCornerRadius
+import com.metrolist.music.utils.rememberEnumPreference
 
 @Composable
 fun GridItemPlaceHolder(
@@ -29,6 +34,9 @@ fun GridItemPlaceHolder(
     thumbnailShape: Shape = RoundedCornerShape(ThumbnailCornerRadius),
     fillMaxWidth: Boolean = false,
 ) {
+    val gridItemSize by rememberEnumPreference(GridItemsSizeKey, GridItemSize.BIG)
+    val gridHeight = if (gridItemSize == GridItemSize.BIG) GridThumbnailHeight else SmallGridThumbnailHeight
+    
     Column(
         modifier =
         if (fillMaxWidth) {
@@ -38,7 +46,7 @@ fun GridItemPlaceHolder(
         } else {
             modifier
                 .padding(12.dp)
-                .width(GridThumbnailHeight)
+                .width(gridHeight)
         },
     ) {
         Spacer(
@@ -46,7 +54,7 @@ fun GridItemPlaceHolder(
             if (fillMaxWidth) {
                 Modifier.fillMaxWidth()
             } else {
-                Modifier.height(GridThumbnailHeight)
+                Modifier.height(gridHeight)
             }.aspectRatio(1f)
                 .clip(thumbnailShape)
                 .background(MaterialTheme.colorScheme.onSurface),

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/AccountScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/AccountScreen.kt
@@ -31,7 +31,10 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.metrolist.music.LocalPlayerAwareWindowInsets
 import com.metrolist.music.R
+import com.metrolist.music.constants.GridItemSize
+import com.metrolist.music.constants.GridItemsSizeKey
 import com.metrolist.music.constants.GridThumbnailHeight
+import com.metrolist.music.utils.rememberEnumPreference
 import com.metrolist.music.ui.component.ChipsRow
 import com.metrolist.music.ui.component.IconButton
 import com.metrolist.music.ui.component.LocalMenuState
@@ -61,9 +64,10 @@ fun AccountScreen(
     val albums by viewModel.albums.collectAsState()
     val artists by viewModel.artists.collectAsState()
     val selectedContentType by viewModel.selectedContentType.collectAsState()
+    val gridItemSize by rememberEnumPreference(GridItemsSizeKey, GridItemSize.BIG)
 
     LazyVerticalGrid(
-        columns = GridCells.Adaptive(minSize = GridThumbnailHeight + 24.dp),
+        columns = GridCells.Adaptive(minSize = GridThumbnailHeight + if (gridItemSize == GridItemSize.BIG) 24.dp else (-24).dp),
         contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
     ) {
         item(span = { GridItemSpan(maxLineSpan) }) {

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/BrowseScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/BrowseScreen.kt
@@ -29,7 +29,10 @@ package com.metrolist.music.ui.screens
  import com.metrolist.music.LocalPlayerAwareWindowInsets
  import com.metrolist.music.LocalPlayerConnection
  import com.metrolist.music.R
+ import com.metrolist.music.constants.GridItemSize
+ import com.metrolist.music.constants.GridItemsSizeKey
  import com.metrolist.music.constants.GridThumbnailHeight
+ import com.metrolist.music.utils.rememberEnumPreference
  import com.metrolist.music.ui.component.IconButton
  import com.metrolist.music.ui.component.LocalMenuState
  import com.metrolist.music.ui.component.YouTubeGridItem
@@ -61,9 +64,10 @@ package com.metrolist.music.ui.screens
      val items by viewModel.items.collectAsState()
  
      val coroutineScope = rememberCoroutineScope()
+     val gridItemSize by rememberEnumPreference(GridItemsSizeKey, GridItemSize.BIG)
  
      LazyVerticalGrid(
-         columns = GridCells.Adaptive(minSize = GridThumbnailHeight + 24.dp),
+         columns = GridCells.Adaptive(minSize = GridThumbnailHeight + if (gridItemSize == GridItemSize.BIG) 24.dp else (-24).dp),
          contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues()
      ) {
          items?.let { items ->

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
@@ -98,8 +98,12 @@ import com.metrolist.innertube.utils.parseCookieString
 import com.metrolist.music.LocalDatabase
 import com.metrolist.music.LocalPlayerAwareWindowInsets
 import com.metrolist.music.LocalPlayerConnection
+import com.metrolist.music.constants.GridItemSize
+import com.metrolist.music.constants.GridItemsSizeKey
 import com.metrolist.music.constants.GridThumbnailHeight
+import com.metrolist.music.constants.SmallGridThumbnailHeight
 import com.metrolist.music.constants.InnerTubeCookieKey
+import com.metrolist.music.utils.rememberEnumPreference
 import com.metrolist.music.constants.ListItemHeight
 import com.metrolist.music.constants.ListThumbnailSize
 import com.metrolist.music.constants.ThumbnailCornerRadius
@@ -198,6 +202,8 @@ fun HomeScreen(
 
     val scope = rememberCoroutineScope()
     val lazylistState = rememberLazyListState()
+    val gridItemSize by rememberEnumPreference(GridItemsSizeKey, GridItemSize.BIG)
+    val currentGridHeight = if (gridItemSize == GridItemSize.BIG) GridThumbnailHeight else SmallGridThumbnailHeight
     val backStackEntry by navController.currentBackStackEntryAsState()
     val scrollToTop =
         backStackEntry?.savedStateHandle?.getStateFlow("scrollToTop", false)?.collectAsState()
@@ -586,7 +592,7 @@ fun HomeScreen(
                                 .asPaddingValues(),
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .height((GridThumbnailHeight + with(LocalDensity.current) {
+                                .height((currentGridHeight + with(LocalDensity.current) {
                                     MaterialTheme.typography.bodyLarge.lineHeight.toDp() * 2 +
                                             MaterialTheme.typography.bodyMedium.lineHeight.toDp() * 2
                                 }) * rows)

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/NewReleaseScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/NewReleaseScreen.kt
@@ -31,7 +31,10 @@ import androidx.navigation.NavController
 import com.metrolist.music.LocalPlayerAwareWindowInsets
 import com.metrolist.music.LocalPlayerConnection
 import com.metrolist.music.R
+import com.metrolist.music.constants.GridItemSize
+import com.metrolist.music.constants.GridItemsSizeKey
 import com.metrolist.music.constants.GridThumbnailHeight
+import com.metrolist.music.utils.rememberEnumPreference
 import com.metrolist.music.ui.component.IconButton
 import com.metrolist.music.ui.component.LocalMenuState
 import com.metrolist.music.ui.component.YouTubeGridItem
@@ -57,9 +60,10 @@ fun NewReleaseScreen(
     val newReleaseAlbums by viewModel.newReleaseAlbums.collectAsState()
 
     val coroutineScope = rememberCoroutineScope()
+    val gridItemSize by rememberEnumPreference(GridItemsSizeKey, GridItemSize.BIG)
 
     LazyVerticalGrid(
-        columns = GridCells.Adaptive(minSize = GridThumbnailHeight + 24.dp),
+        columns = GridCells.Adaptive(minSize = GridThumbnailHeight + if (gridItemSize == GridItemSize.BIG) 24.dp else (-24).dp),
         contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
     ) {
         items(

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistAlbumsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistAlbumsScreen.kt
@@ -50,7 +50,10 @@ import com.metrolist.music.LocalPlayerConnection
 import com.metrolist.music.R
 import com.metrolist.music.constants.CONTENT_TYPE_ALBUM
 import com.metrolist.music.constants.CONTENT_TYPE_HEADER
+import com.metrolist.music.constants.GridItemSize
+import com.metrolist.music.constants.GridItemsSizeKey
 import com.metrolist.music.constants.GridThumbnailHeight
+import com.metrolist.music.utils.rememberEnumPreference
 import com.metrolist.music.ui.component.IconButton
 import com.metrolist.music.ui.component.LibraryAlbumGridItem
 import com.metrolist.music.ui.component.LocalMenuState
@@ -74,6 +77,7 @@ fun ArtistAlbumsScreen(
 
     val coroutineScope = rememberCoroutineScope()
     val lazyGridState = rememberLazyGridState()
+    val gridItemSize by rememberEnumPreference(GridItemsSizeKey, GridItemSize.BIG)
 
     var inSelectMode by rememberSaveable { mutableStateOf(false) }
     val selection = rememberSaveable(
@@ -97,7 +101,7 @@ fun ArtistAlbumsScreen(
     ) {
         LazyVerticalGrid(
             state = lazyGridState,
-            columns = GridCells.Adaptive(minSize = GridThumbnailHeight + 24.dp),
+            columns = GridCells.Adaptive(minSize = GridThumbnailHeight + if (gridItemSize == GridItemSize.BIG) 24.dp else (-24).dp),
             contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues()
         ) {
             item(

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistItemsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistItemsScreen.kt
@@ -44,8 +44,11 @@ import com.metrolist.innertube.models.WatchEndpoint
 import com.metrolist.music.LocalPlayerAwareWindowInsets
 import com.metrolist.music.LocalPlayerConnection
 import com.metrolist.music.R
+import com.metrolist.music.constants.GridItemSize
+import com.metrolist.music.constants.GridItemsSizeKey
 import com.metrolist.music.constants.GridThumbnailHeight
 import com.metrolist.music.models.toMediaMetadata
+import com.metrolist.music.utils.rememberEnumPreference
 import com.metrolist.music.playback.queues.YouTubeQueue
 import com.metrolist.music.ui.component.IconButton
 import com.metrolist.music.ui.component.LocalMenuState
@@ -77,6 +80,7 @@ fun ArtistItemsScreen(
     val lazyListState = rememberLazyListState()
     val lazyGridState = rememberLazyGridState()
     val coroutineScope = rememberCoroutineScope()
+    val gridItemSize by rememberEnumPreference(GridItemsSizeKey, GridItemSize.BIG)
 
     val title by viewModel.title.collectAsState()
     val itemsPage by viewModel.itemsPage.collectAsState()
@@ -206,7 +210,7 @@ fun ArtistItemsScreen(
     } else {
         LazyVerticalGrid(
             state = lazyGridState,
-            columns = GridCells.Adaptive(minSize = GridThumbnailHeight + 24.dp),
+            columns = GridCells.Adaptive(minSize = GridThumbnailHeight + if (gridItemSize == GridItemSize.BIG) 24.dp else (-24).dp),
             contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues()
         ) {
             items(


### PR DESCRIPTION
- Updated GridItem component to use currentGridThumbnailHeight() helper
- Updated HomeScreen keep_listening section to use grid size preference
- Updated ArtistItemsScreen, ArtistAlbumsScreen with grid size settings
- Updated AccountScreen, BrowseScreen, NewReleaseScreen with grid size settings
- Updated GridItemPlaceHolder shimmer to respect grid size preference
- All screens now follow the small/big grid size setting from preferences