### PR TITLE
Fix Discord RPC not updating for subsequent songs during continuous playback

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -1495,6 +1495,17 @@ class MusicService :
             }
         }
 
+        // Update Discord RPC when media item transitions (for continuous playback)
+        if (events.containsAny(Player.EVENT_MEDIA_ITEM_TRANSITION) && player.isPlaying) {
+            scope.launch {
+                // Small delay to ensure currentSong is updated from the database
+                delay(100)
+                currentSong.value?.let { song ->
+                    discordRpc?.updateSong(song, player.currentPosition, player.playbackParameters.speed, dataStore.get(DiscordUseDetailsKey, false))
+                }
+            }
+        }
+
         // Scrobbling
         if (events.containsAny(Player.EVENT_IS_PLAYING_CHANGED)) {
             scrobbleManager?.onPlayerStateChanged(player.isPlaying, player.currentMetadata, duration = player.duration)


### PR DESCRIPTION
## Problem
When playing songs continuously, the Discord RPC was not updating for the second song onwards. If you stop and restart playback, it would be reflected correctly.

## Root Cause
The Discord RPC update was only triggered when `EVENT_IS_PLAYING_CHANGED` fires. However, during continuous playback (when one song ends and the next begins automatically), this event does not fire because the player is still in a playing state - only the media item changes.

## Solution
Added handling for `EVENT_MEDIA_ITEM_TRANSITION` in the `onEvents` method to update the Discord RPC when songs transition during continuous playback. A small delay (100ms) is added to ensure the `currentSong` value is updated from the database before sending the update to Discord.

## Changes
- Added a new condition in `MusicService.onEvents()` to handle `EVENT_MEDIA_ITEM_TRANSITION`
- When this event fires and the player is playing, the Discord RPC is updated with the new song information