### PR TITLE
Fix: YouTube sync for like/subscribe buttons not completing

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/db/entities/AlbumEntity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/AlbumEntity.kt
@@ -12,7 +12,6 @@ import androidx.room.PrimaryKey
 import com.metrolist.innertube.YouTube
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
 
@@ -54,7 +53,6 @@ data class AlbumEntity(
         CoroutineScope(Dispatchers.IO).launch {
             if (playlistId != null)
                 YouTube.likePlaylist(playlistId, bookmarkedAt == null)
-            this.cancel()
         }
     }
 }

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/ArtistEntity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/ArtistEntity.kt
@@ -12,7 +12,6 @@ import androidx.room.PrimaryKey
 import com.metrolist.innertube.YouTube
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import org.apache.commons.lang3.RandomStringUtils
 import java.time.LocalDateTime
@@ -45,7 +44,6 @@ data class ArtistEntity(
                 YouTube.subscribeChannel(YouTube.getChannelId(id), bookmarkedAt == null)
             else
                 YouTube.subscribeChannel(channelId, bookmarkedAt == null)
-            this.cancel()
         }
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/PlaylistEntity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/PlaylistEntity.kt
@@ -12,7 +12,6 @@ import androidx.room.PrimaryKey
 import com.metrolist.innertube.YouTube
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import org.apache.commons.lang3.RandomStringUtils
 import java.time.LocalDateTime
@@ -58,7 +57,6 @@ data class PlaylistEntity(
         CoroutineScope(Dispatchers.IO).launch {
             if (browseId != null)
                 YouTube.likePlaylist(browseId, bookmarkedAt == null)
-            this.cancel()
         }
     }
 }

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/SongEntity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/SongEntity.kt
@@ -13,7 +13,6 @@ import androidx.room.PrimaryKey
 import com.metrolist.innertube.YouTube
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
 
@@ -66,7 +65,6 @@ data class SongEntity(
     ).also {
         CoroutineScope(Dispatchers.IO).launch {
             YouTube.likeVideo(id, !liked)
-            this.cancel()
         }
     }
 


### PR DESCRIPTION
The toggleLike() functions in SongEntity, ArtistEntity, AlbumEntity, and PlaylistEntity were calling this.cancel() immediately after launching the coroutine to sync with YouTube. This was canceling the API call before it could complete, causing likes and subscriptions to not sync properly.

Removed the this.cancel() calls to allow the YouTube API calls to complete.