### PR TITLE
Revert: Remove kizzy-api dependency, fix Discord login

### DIFF
--- a/kizzy/src/main/kotlin/com/my/kizzy/remote/ApiService.kt
+++ b/kizzy/src/main/kotlin/com/my/kizzy/remote/ApiService.kt
@@ -36,17 +36,17 @@ class ApiService {
         install(HttpCache)
     }
 
-    suspend fun getImage(imageUrl: String) = runCatching {
-        logger.info("Requesting image proxy for URL: $imageUrl")
+    suspend fun getImage(urls: List<String>) = runCatching {
+        logger.info("Requesting image proxy for URLs: $urls")
         client.get {
             url("$BASE_URL/image")
-            parameter("url", imageUrl)
+            urls.forEach { parameter("url", it) }
         }
     }.onFailure {
         logger.severe("Image proxy request failed: ${it.stackTraceToString()}")
     }
 
     companion object {
-        const val BASE_URL = "https://kizzy-api.cjjdxhdjd.workers.dev"
+        const val BASE_URL = "https://metrolist-discord-rpc-api.adrieldsilvas-2.workers.dev"
     }
 }

--- a/kizzy/src/main/kotlin/com/my/kizzy/remote/ImageProxy.kt
+++ b/kizzy/src/main/kotlin/com/my/kizzy/remote/ImageProxy.kt
@@ -5,6 +5,13 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class ImageProxyResponse(
-    @SerialName("id")
+    val results: List<ImageProxyResult>
+)
+
+@Serializable
+data class ImageProxyResult(
+    @SerialName("original_url")
+    val originalUrl: String,
+    val status: String,
     val id: String
 )

--- a/kizzy/src/main/kotlin/com/my/kizzy/repository/KizzyRepository.kt
+++ b/kizzy/src/main/kotlin/com/my/kizzy/repository/KizzyRepository.kt
@@ -15,7 +15,6 @@ package com.my.kizzy.repository
 import com.my.kizzy.remote.ApiService
 import com.my.kizzy.remote.ImageProxyResponse
 import io.ktor.client.call.body
-import io.ktor.http.HttpStatusCode
 
 /**
  * Modified by Zion Huang
@@ -23,16 +22,7 @@ import io.ktor.http.HttpStatusCode
 class KizzyRepository {
     private val api = ApiService()
 
-    suspend fun getImage(url: String): String? {
-        return try {
-            val response = api.getImage(url).getOrNull()
-            if (response?.status == HttpStatusCode.OK) {
-                response.body<ImageProxyResponse>().id
-            } else {
-                null
-            }
-        } catch (e: Exception) {
-            null
-        }
+    suspend fun getImages(urls: List<String>): ImageProxyResponse? {
+        return api.getImage(urls).getOrNull()?.body()
     }
 }

--- a/kizzy/src/main/kotlin/com/my/kizzy/rpc/KizzyRPC.kt
+++ b/kizzy/src/main/kotlin/com/my/kizzy/rpc/KizzyRPC.kt
@@ -74,19 +74,10 @@ open class KizzyRPC(token: String) {
             discordWebSocket.connect()
         }
         
-        // Resolve external images to Discord CDN URLs
-        val resolvedLargeImage = largeImage?.let { 
-            when (it) {
-                is RpcImage.DiscordImage -> "mp:${it.image}"
-                is RpcImage.ExternalImage -> kizzyRepository.getImage(it.image)
-            }
-        }
-        val resolvedSmallImage = smallImage?.let { 
-            when (it) {
-                is RpcImage.DiscordImage -> "mp:${it.image}"
-                is RpcImage.ExternalImage -> kizzyRepository.getImage(it.image)
-            }
-        }
+        val images = listOfNotNull(largeImage, smallImage)
+        val externalImages = images.filterIsInstance<RpcImage.ExternalImage>()
+        val imageUrls = externalImages.map { it.image }
+        val resolvedImages = kizzyRepository.getImages(imageUrls)?.results?.associate { it.originalUrl to it.id } ?: emptyMap()
 
         val presence = Presence(
             activities = listOf(
@@ -100,8 +91,18 @@ open class KizzyRPC(token: String) {
                     statusDisplayType = statusDisplayType.value,
                     timestamps = Timestamps(startTime, endTime),
                     assets = Assets(
-                        largeImage = resolvedLargeImage,
-                        smallImage = resolvedSmallImage,
+                        largeImage = largeImage?.let { 
+                            when (it) {
+                                is RpcImage.DiscordImage -> "mp:${it.image}"
+                                is RpcImage.ExternalImage -> resolvedImages[it.image]
+                            }
+                        },
+                        smallImage = smallImage?.let { 
+                            when (it) {
+                                is RpcImage.DiscordImage -> "mp:${it.image}"
+                                is RpcImage.ExternalImage -> resolvedImages[it.image]
+                            }
+                        },
                         largeText = largeText,
                         smallText = smallText
                     ),


### PR DESCRIPTION
- Revert commits 8e3f042f and 69ca7148 (kizzy-api changes)
- Keep Discord login fix (Kizzy's JS_SNIPPET method)
- Keep Motorola device UA fix
- Keep Discord API v10 and optString fix for global_name
- Keep user info clear on logout/failure