### PR TITLE
Play after first play command on widget

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
@@ -143,11 +143,7 @@ fun MiniPlayer(
         Box(modifier = modifier.fillMaxWidth()) {
             LegacyMiniPlayer(
                 progressState = progressState,
-                modifier = if (isTabletLandscape) {
-                    Modifier.align(Alignment.CenterEnd)
-                } else {
-                    Modifier.align(Alignment.Center)
-                }
+                modifier = Modifier.align(Alignment.Center)
             )
         }
     }
@@ -282,7 +278,7 @@ private fun NewMiniPlayer(
     ) {
         Box(
             modifier = Modifier
-                .then(if (isTabletLandscape) Modifier.width(500.dp).align(Alignment.CenterEnd) else Modifier.fillMaxWidth())
+                .then(if (isTabletLandscape) Modifier.width(500.dp).align(Alignment.Center) else Modifier.fillMaxWidth())
                 .height(64.dp)
                 .offset { IntOffset(offsetXAnimatable.value.roundToInt(), 0) }
                 .clip(RoundedCornerShape(32.dp))


### PR DESCRIPTION
After app stopped, play song after first play command on widget, if a song is already in queue, even if "No song playing" is displayed. Before this change, it loaded the song but an additional tap on play would be necessary

fix mostafaalagamy/Metrolist#2300