### PR TITLE
Replace MetrolistExtractor with MetroExtractor and MetrolistShared

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -172,6 +172,8 @@ android {
             excludes += "META-INF/NOTICE.md"
             excludes += "META-INF/CONTRIBUTORS.md"
             excludes += "META-INF/LICENSE.md"
+            excludes += "META-INF/INDEX.LIST"
+            excludes += "META-INF/io.netty.versions.properties"
         }
     }
 }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -60,7 +60,28 @@
 -dontwarn org.openjsse.net.ssl.OpenJSSE
 -dontwarn org.slf4j.impl.StaticLoggerBinder
 
-## Rules for NewPipeExtractor
+## Rules for PipePipeExtractor
+-keep class project.pipepipe.extractor.** { *; }
+-keep class project.pipepipe.shared.** { *; }
+
+## Netty rules (used by PipePipeExtractor dependencies)
+-dontwarn io.netty.**
+-dontwarn org.apache.log4j.**
+-dontwarn org.apache.logging.log4j.**
+-dontwarn reactor.blockhound.**
+-dontwarn io.micrometer.context.**
+-dontwarn javax.enterprise.inject.**
+
+## Lettuce (Redis client used by PipePipeExtractor)
+-dontwarn io.lettuce.core.**
+
+## Reactor
+-dontwarn reactor.util.context.**
+
+## Keep Wire protobuf classes
+-keep class com.squareup.wire.** { *; }
+
+## Legacy NewPipeExtractor rules (kept for compatibility)
 -keep class org.schabi.newpipe.extractor.services.youtube.protos.** { *; }
 -keep class org.schabi.newpipe.extractor.timeago.patterns.** { *; }
 -keep class org.mozilla.javascript.** { *; }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,8 @@ junit = "4.13.2"
 timber = "5.0.1"
 materialKolor = "4.0.5"
 kuromojiIpadic = "0.9.0"
-extractor = "d7c67daf"
+extractor = "9a242ad3af"
+metrolistshared = "8c2dda1732"
 tinypinyin = "2.0.3"
 
 [libraries]
@@ -116,7 +117,8 @@ multidex = { module = "androidx.multidex:multidex", version.ref = "multidex" }
 
 #newpipe-extractor = { module = "com.github.libre-tube:NewPipeExtractor", version = "70abbdb" }
 #newpipe-extractor = { module = "com.github.TeamNewPipe:NewPipeExtractor", version = "dev-SNAPSHOT" }
-extractor = { module = "com.github.mostafaalagamy:MetrolistExtractor", version.ref = "extractor" }
+extractor = { module = "com.github.mostafaalagamy:MetroExtractor", version.ref = "extractor" }
+metrolistshared = { module = "com.github.mostafaalagamy.MetrolistShared:shared-jvm", version.ref = "metrolistshared" }
 
 kuromoji-ipadic = { module = "com.atilika.kuromoji:kuromoji-ipadic", version.ref = "kuromojiIpadic" }
 tinypinyin = { module = "com.github.promeG:tinypinyin", version.ref = "tinypinyin" }

--- a/innertube/build.gradle.kts
+++ b/innertube/build.gradle.kts
@@ -15,5 +15,6 @@ dependencies {
     implementation(libs.ktor.client.encoding)
     implementation(libs.brotli)
     implementation(libs.extractor)
+    implementation(libs.metrolistshared)
     testImplementation(libs.junit)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,18 +25,18 @@ include(":kizzy")
 include(":lastfm")
 include(":betterlyrics")
 
-// Use a local copy of NewPipe Extractor by uncommenting the lines below.
-// We assume, that Metrolist and NewPipe Extractor have the same parent directory.
+// Use a local copy of MetroExtractor by uncommenting the lines below.
+// We assume, that Metrolist and MetroExtractor have the same parent directory.
 // If this is not the case, please change the path in includeBuild().
 //
 // For this to work you also need to change the implementation in innertube/build.gradle.kts
 // to one which does not specify a version.
 // From:
-//      implementation(libs.newpipe.extractor)
+//      implementation(libs.extractor)
 // To:
-//      implementation("com.github.teamnewpipe:NewPipeExtractor")
-//includeBuild("../NewPipeExtractor") {
+//      implementation("com.github.mostafaalagamy:MetroExtractor")
+//includeBuild("../MetroExtractor") {
 //    dependencySubstitution {
-//        substitute(module("com.github.teamnewpipe:NewPipeExtractor")).using(project(":extractor"))
+//        substitute(module("com.github.mostafaalagamy:MetroExtractor")).using(project(":extractor"))
 //    }
 //}


### PR DESCRIPTION
- Updated extractor dependency from MetrolistExtractor to MetroExtractor (fork with JitPack support)
- Added MetrolistShared (shared-jvm) as a new dependency
- Rewrote NewPipe.kt to use PipePipeExtractor API (YouTubeDecryptionHelper)
- Updated version references to latest commits
- Updated settings.gradle.kts comments to reflect new library name
- Added META-INF exclusions for netty library conflicts
- Added ProGuard rules for PipePipeExtractor, netty, lettuce, and reactor