### PR TITLE
feat(player): improve playback experience with auto-load and state persistence

### DIFF
--- a/app/src/gms/kotlin/com/metrolist/music/playback/CastConnectionHandler.kt
+++ b/app/src/gms/kotlin/com/metrolist/music/playback/CastConnectionHandler.kt
@@ -258,6 +258,7 @@ class CastConnectionHandler(
     /**
      * Reload the Cast queue centered on the current item
      * This updates prev/next context after a skip
+     * Respects shuffle mode when determining prev/next items
      */
     private fun reloadQueueForCurrentItem(metadata: AppMediaMetadata) {
         if (!_isCasting.value || isReloadingQueue) return
@@ -267,15 +268,25 @@ class CastConnectionHandler(
             try {
                 val player = musicService.player
                 val currentIndex = player.currentMediaItemIndex
-                val mediaItemCount = player.mediaItemCount
+                val shuffleEnabled = player.shuffleModeEnabled
+                val timeline = player.currentTimeline
                 
                 // Build new queue items: up to 2 previous, current, and up to 2 next
                 val queueItems = mutableListOf<MediaQueueItem>()
                 
-                // Add up to 2 previous items if available
-                val prevCount = minOf(2, currentIndex)
-                for (i in prevCount downTo 1) {
-                    val prevItem = player.getMediaItemAt(currentIndex - i)
+                // Get previous items respecting shuffle order
+                val prevItems = mutableListOf<androidx.media3.common.MediaItem>()
+                if (!timeline.isEmpty) {
+                    var prevIdx = currentIndex
+                    for (i in 0 until 2) {
+                        prevIdx = timeline.getPreviousWindowIndex(prevIdx, Player.REPEAT_MODE_OFF, shuffleEnabled)
+                        if (prevIdx == androidx.media3.common.C.INDEX_UNSET) break
+                        prevItems.add(0, player.getMediaItemAt(prevIdx))
+                    }
+                }
+                
+                // Add previous items
+                for (prevItem in prevItems) {
                     prevItem.metadata?.let { prevMetadata ->
                         buildMediaInfo(prevMetadata)?.let { mediaInfo ->
                             queueItems.add(MediaQueueItem.Builder(mediaInfo).build())
@@ -290,19 +301,23 @@ class CastConnectionHandler(
                     queueItems.add(MediaQueueItem.Builder(currentMediaInfo).build())
                 }
                 
-                // Add up to 2 next items if available
-                val nextCount = minOf(2, mediaItemCount - currentIndex - 1)
-                for (i in 1..nextCount) {
-                    val nextItem = player.getMediaItemAt(currentIndex + i)
-                    nextItem.metadata?.let { nextMetadata ->
-                        buildMediaInfo(nextMetadata)?.let { mediaInfo ->
-                            queueItems.add(MediaQueueItem.Builder(mediaInfo).build())
+                // Get next items respecting shuffle order
+                if (!timeline.isEmpty) {
+                    var nextIdx = currentIndex
+                    for (i in 0 until 2) {
+                        nextIdx = timeline.getNextWindowIndex(nextIdx, Player.REPEAT_MODE_OFF, shuffleEnabled)
+                        if (nextIdx == androidx.media3.common.C.INDEX_UNSET) break
+                        val nextItem = player.getMediaItemAt(nextIdx)
+                        nextItem.metadata?.let { nextMetadata ->
+                            buildMediaInfo(nextMetadata)?.let { mediaInfo ->
+                                queueItems.add(MediaQueueItem.Builder(mediaInfo).build())
+                            }
                         }
                     }
                 }
                 
                 if (queueItems.isNotEmpty()) {
-                    Timber.d("Reloading Cast queue: ${queueItems.size} items, startIndex=$startIndex")
+                    Timber.d("Reloading Cast queue: ${queueItems.size} items, startIndex=$startIndex, shuffle=$shuffleEnabled")
                     
                     withContext(Dispatchers.Main) {
                         remoteMediaClient?.queueLoad(
@@ -490,6 +505,7 @@ class CastConnectionHandler(
     /**
      * Load media with queue context to enable skip prev/next buttons on Cast widget
      * Loads up to 5 items: 2 previous, current, and 2 next for smoother transitions
+     * Respects shuffle mode when determining prev/next items
      */
     private fun loadMediaWithQueue(metadata: AppMediaMetadata) {
         if (!_isCasting.value) return
@@ -504,22 +520,32 @@ class CastConnectionHandler(
                 val player = musicService.player
                 val currentIndex = player.currentMediaItemIndex
                 val mediaItemCount = player.mediaItemCount
+                val shuffleEnabled = player.shuffleModeEnabled
+                val timeline = player.currentTimeline
                 
                 // Build queue items: up to 2 previous, current, and up to 2 next songs
                 val queueItems = mutableListOf<MediaQueueItem>()
-                var startIndex = 0
                 
-                // Add up to 2 previous items if available
-                val prevCount = minOf(2, currentIndex)
-                for (i in prevCount downTo 1) {
-                    val prevItem = player.getMediaItemAt(currentIndex - i)
+                // Get previous items respecting shuffle order
+                val prevItems = mutableListOf<androidx.media3.common.MediaItem>()
+                if (!timeline.isEmpty) {
+                    var prevIdx = currentIndex
+                    for (i in 0 until 2) {
+                        prevIdx = timeline.getPreviousWindowIndex(prevIdx, Player.REPEAT_MODE_OFF, shuffleEnabled)
+                        if (prevIdx == androidx.media3.common.C.INDEX_UNSET) break
+                        prevItems.add(0, player.getMediaItemAt(prevIdx)) // Add at beginning to maintain order
+                    }
+                }
+                
+                // Add previous items
+                for (prevItem in prevItems) {
                     prevItem.metadata?.let { prevMetadata ->
                         buildMediaInfo(prevMetadata)?.let { mediaInfo ->
                             queueItems.add(MediaQueueItem.Builder(mediaInfo).build())
                         }
                     }
                 }
-                startIndex = queueItems.size // Current item index after previous items
+                val startIndex = queueItems.size // Current item index after previous items
                 
                 // Add current item
                 val currentMediaInfo = buildMediaInfo(metadata)
@@ -530,13 +556,17 @@ class CastConnectionHandler(
                 }
                 queueItems.add(MediaQueueItem.Builder(currentMediaInfo).build())
                 
-                // Add up to 2 next items if available
-                val nextCount = minOf(2, mediaItemCount - currentIndex - 1)
-                for (i in 1..nextCount) {
-                    val nextItem = player.getMediaItemAt(currentIndex + i)
-                    nextItem.metadata?.let { nextMetadata ->
-                        buildMediaInfo(nextMetadata)?.let { mediaInfo ->
-                            queueItems.add(MediaQueueItem.Builder(mediaInfo).build())
+                // Get next items respecting shuffle order
+                if (!timeline.isEmpty) {
+                    var nextIdx = currentIndex
+                    for (i in 0 until 2) {
+                        nextIdx = timeline.getNextWindowIndex(nextIdx, Player.REPEAT_MODE_OFF, shuffleEnabled)
+                        if (nextIdx == androidx.media3.common.C.INDEX_UNSET) break
+                        val nextItem = player.getMediaItemAt(nextIdx)
+                        nextItem.metadata?.let { nextMetadata ->
+                            buildMediaInfo(nextMetadata)?.let { mediaInfo ->
+                                queueItems.add(MediaQueueItem.Builder(mediaInfo).build())
+                            }
                         }
                     }
                 }
@@ -548,7 +578,7 @@ class CastConnectionHandler(
                     0L
                 }
                 
-                Timber.d("Loading Cast queue: ${queueItems.size} items, startIndex=$startIndex")
+                Timber.d("Loading Cast queue: ${queueItems.size} items, startIndex=$startIndex, shuffle=$shuffleEnabled")
                 
                 withContext(Dispatchers.Main) {
                     val client = remoteMediaClient ?: return@withContext

--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -68,6 +68,8 @@ enum class AudioQuality {
 val AudioOffload = booleanPreferencesKey("enableOffload")
 
 val PersistentQueueKey = booleanPreferencesKey("persistentQueue")
+val RememberShuffleAndRepeatKey = booleanPreferencesKey("rememberShuffleAndRepeat")
+val ShuffleModeKey = booleanPreferencesKey("shuffleMode")
 val SkipSilenceKey = booleanPreferencesKey("skipSilence")
 val AudioNormalizationKey = booleanPreferencesKey("audioNormalization")
 val AutoLoadMoreKey = booleanPreferencesKey("autoLoadMore")

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
@@ -45,6 +45,7 @@ import com.metrolist.music.constants.AutoLoadMoreKey
 import com.metrolist.music.constants.DisableLoadMoreWhenRepeatAllKey
 import com.metrolist.music.constants.AutoSkipNextOnErrorKey
 import com.metrolist.music.constants.EnableGoogleCastKey
+import com.metrolist.music.constants.RememberShuffleAndRepeatKey
 import com.metrolist.music.constants.ShufflePlaylistFirstKey
 import com.metrolist.music.constants.PersistentQueueKey
 import com.metrolist.music.constants.SimilarContent
@@ -119,6 +120,10 @@ fun PlayerSettings(
     val (autoSkipNextOnError, onAutoSkipNextOnErrorChange) = rememberPreference(
         AutoSkipNextOnErrorKey,
         defaultValue = false
+    )
+    val (rememberShuffleAndRepeat, onRememberShuffleAndRepeatChange) = rememberPreference(
+        RememberShuffleAndRepeatKey,
+        defaultValue = true
     )
     val (shufflePlaylistFirst, onShufflePlaylistFirstChange) = rememberPreference(
         ShufflePlaylistFirstKey,
@@ -428,6 +433,27 @@ fun PlayerSettings(
                         )
                     },
                     onClick = { similarContentEnabledChange(!similarContentEnabled) }
+                ),
+                Material3SettingsItem(
+                    icon = painterResource(R.drawable.shuffle),
+                    title = { Text(stringResource(R.string.remember_shuffle_and_repeat)) },
+                    description = { Text(stringResource(R.string.remember_shuffle_and_repeat_desc)) },
+                    trailingContent = {
+                        Switch(
+                            checked = rememberShuffleAndRepeat,
+                            onCheckedChange = onRememberShuffleAndRepeatChange,
+                            thumbContent = {
+                                Icon(
+                                    painter = painterResource(
+                                        id = if (rememberShuffleAndRepeat) R.drawable.check else R.drawable.close
+                                    ),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(SwitchDefaults.IconSize)
+                                )
+                            }
+                        )
+                    },
+                    onClick = { onRememberShuffleAndRepeatChange(!rememberShuffleAndRepeat) }
                 ),
                 Material3SettingsItem(
                     icon = painterResource(R.drawable.shuffle),

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -174,6 +174,8 @@
     <string name="audio_quality_max">Max (beta)</string>
     <string name="enable_similar_content">Enable similar content</string>
     <string name="similar_content_desc">Automatically add more similar songs when the end of the queue is reached</string>
+    <string name="remember_shuffle_and_repeat">Remember shuffle and repeat</string>
+    <string name="remember_shuffle_and_repeat_desc">Remember shuffle and repeat mode when restarting the app</string>
     <string name="min_playback_duration_title">Minimum playback duration</string>
     <string name="min_playback_duration_description">The minimum amount of a song that must be played before it is considered \"played\"</string>
     <string name="percentage_format">%d%%</string>


### PR DESCRIPTION
- Fix auto-load similar content to fetch radio content when automixItems is empty
- Fix shuffle mode not working correctly when casting to external devices
- Add option to remember shuffle and repeat states across app restarts
- Update Cast queue building to respect shuffle order using timeline navigation