### PR TITLE
Fix artist sync, improve MediaSession metadata, remove material-icons

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -263,7 +263,4 @@ dependencies {
     coreLibraryDesugaring(libs.desugaring)
 
     implementation(libs.timber)
-
-    // Icons
-    implementation(libs.androidx.material.icons.extended)
 }

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/ArtistEntity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/ArtistEntity.kt
@@ -40,10 +40,10 @@ data class ArtistEntity(
 
     fun toggleLike() = localToggleLike().also {
         CoroutineScope(Dispatchers.IO).launch {
-            if (channelId == null)
-                YouTube.subscribeChannel(YouTube.getChannelId(id), bookmarkedAt == null)
-            else
-                YouTube.subscribeChannel(channelId, bookmarkedAt == null)
+            val targetChannelId = channelId ?: YouTube.getChannelId(id)
+            if (targetChannelId.isNotEmpty()) {
+                YouTube.subscribeChannel(targetChannelId, bookmarkedAt == null)
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/extensions/MediaItemExt.kt
+++ b/app/src/main/kotlin/com/metrolist/music/extensions/MediaItemExt.kt
@@ -5,6 +5,7 @@
 
 package com.metrolist.music.extensions
 
+import android.os.Bundle
 import androidx.core.net.toUri
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata.MEDIA_TYPE_MUSIC
@@ -29,7 +30,14 @@ fun Song.toMediaItem() = MediaItem.Builder()
             .setArtist((if (song.explicit) "🅴 " else "") + artists.joinToString { it.name })
             .setArtworkUri(song.thumbnailUrl?.toUri())
             .setAlbumTitle(song.albumName)
+            .setAlbumArtist(artists.firstOrNull()?.name)
+            .setDisplayTitle(song.title)
             .setMediaType(MEDIA_TYPE_MUSIC)
+            .setIsBrowsable(false)
+            .setIsPlayable(true)
+            .setExtras(Bundle().apply {
+                putString("artwork_uri", song.thumbnailUrl)
+            })
             .build()
     )
     .build()
@@ -46,7 +54,14 @@ fun SongItem.toMediaItem() = MediaItem.Builder()
             .setArtist((if (explicit) "🅴 " else "") + artists.joinToString { it.name })
             .setArtworkUri(thumbnail.resize(544, 544).toUri())
             .setAlbumTitle(album?.name)
+            .setAlbumArtist(artists.firstOrNull()?.name)
+            .setDisplayTitle(title)
             .setMediaType(MEDIA_TYPE_MUSIC)
+            .setIsBrowsable(false)
+            .setIsPlayable(true)
+            .setExtras(Bundle().apply {
+                putString("artwork_uri", thumbnail.resize(544, 544))
+            })
             .build()
     )
     .build()
@@ -63,7 +78,14 @@ fun MediaMetadata.toMediaItem() = MediaItem.Builder()
             .setArtist((if (explicit) "🅴 " else "") + artists.joinToString { it.name })
             .setArtworkUri(thumbnailUrl?.toUri())
             .setAlbumTitle(album?.title)
+            .setAlbumArtist(artists.firstOrNull()?.name)
+            .setDisplayTitle(title)
             .setMediaType(MEDIA_TYPE_MUSIC)
+            .setIsBrowsable(false)
+            .setIsPlayable(true)
+            .setExtras(Bundle().apply {
+                thumbnailUrl?.let { putString("artwork_uri", it) }
+            })
             .build()
     )
     .build()

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/VolumeSlider.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/VolumeSlider.kt
@@ -15,11 +15,6 @@ package com.metrolist.music.ui.component
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.height
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.VolumeUp
-import androidx.compose.material.icons.automirrored.filled.VolumeOff
-import androidx.compose.material.icons.automirrored.filled.VolumeMute
-import androidx.compose.material.icons.automirrored.filled.VolumeDown
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
@@ -29,16 +24,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.translate
-import androidx.compose.ui.graphics.vector.VectorPainter
-import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import com.metrolist.music.R
 
 /**
  * Material 3 Expressive Volume Slider dimensions (Size M)
@@ -66,10 +61,10 @@ fun VolumeSlider(
 ) {
     val interactionSource = remember { MutableInteractionSource() }
 
-    val volumeOffIcon = rememberVectorPainter(Icons.AutoMirrored.Filled.VolumeOff)
-    val volumeMuteIcon = rememberVectorPainter(Icons.AutoMirrored.Filled.VolumeMute)
-    val volumeDownIcon = rememberVectorPainter(Icons.AutoMirrored.Filled.VolumeDown)
-    val volumeUpIcon = rememberVectorPainter(Icons.AutoMirrored.Filled.VolumeUp)
+    val volumeOffIcon = painterResource(R.drawable.volume_off)
+    val volumeMuteIcon = painterResource(R.drawable.volume_mute)
+    val volumeDownIcon = painterResource(R.drawable.volume_down)
+    val volumeUpIcon = painterResource(R.drawable.volume_up)
 
     val currentIcon = when {
         value <= 0f -> volumeOffIcon
@@ -146,7 +141,7 @@ fun VolumeSlider(
 }
 
 private fun DrawScope.drawVolumeIcon(
-    icon: VectorPainter,
+    icon: Painter,
     iconSize: DpSize,
     iconPadding: Dp,
     yOffset: Float,
@@ -155,7 +150,7 @@ private fun DrawScope.drawVolumeIcon(
     inactiveTrackWidth: Float,
     activeIconColor: Color,
     inactiveIconColor: Color,
-    volumeOffIcon: VectorPainter
+    volumeOffIcon: Painter
 ) {
     val iconSizePx = iconSize.toSize()
     val iconPaddingPx = iconPadding.toPx()

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/equalizer/EqScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/equalizer/EqScreen.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -190,7 +188,7 @@ private fun EqScreenContent(
                 Row {
                     IconButton(onClick = onImportCustomEQ) {
                         Icon(
-                            imageVector = Icons.Default.Add,
+                            painter = painterResource(R.drawable.add),
                             contentDescription = stringResource(R.string.import_profile)
                         )
                     }
@@ -243,7 +241,7 @@ private fun EqScreenContent(
                                 horizontalAlignment = Alignment.CenterHorizontally
                             ) {
                                 Icon(
-                                    imageVector = Icons.Default.Equalizer,
+                                    painter = painterResource(R.drawable.equalizer),
                                     contentDescription = null,
                                     modifier = Modifier.size(48.dp),
                                     tint = MaterialTheme.colorScheme.onSurfaceVariant
@@ -331,7 +329,7 @@ private fun EQProfileItem(
         trailingContent = {
             IconButton(onClick = { showDeleteDialog = true }) {
                 Icon(
-                    imageVector = Icons.Default.Delete,
+                    painter = painterResource(R.drawable.delete),
                     contentDescription = stringResource(R.string.delete_profile_desc),
                     tint = MaterialTheme.colorScheme.error
                 )

--- a/app/src/main/res/drawable/volume_down.xml
+++ b/app/src/main/res/drawable/volume_down.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M200,600v-240h160l200,-200v640L360,600L200,600ZM560,640v-322q47,22 73.5,66t26.5,96q0,51 -26.5,94.5T560,640ZM480,354l-86,86L280,440v80h114l86,86v-252ZM380,480Z" />
+</vector>

--- a/app/src/main/res/drawable/volume_mute.xml
+++ b/app/src/main/res/drawable/volume_mute.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M280,600v-240h160l200,-200v640L440,600L280,600ZM560,354l-86,86L360,440v80h114l86,86v-252ZM460,480Z" />
+</vector>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,11 @@
 [versions]
 androidGradlePlugin = "8.13.2"
-annotation = "1.9.1"
 json = "20250517"
 kotlin = "2.3.0"
 compose = "1.10.1"
 lifecycle = "2.10.0"
 material3 = "1.5.0-alpha09"
 appcompat = "1.7.1"
-materialIconsExtended = "1.7.8"
 media3 = "1.9.0"
 mediarouter = "1.8.1"
 castFramework = "22.2.0"
@@ -16,7 +14,6 @@ hilt = "2.57.2"
 ktor = "3.3.3"
 ksp = "2.3.4"
 jsoup = "1.22.1"
-multidex = "2.0.1"
 coil = "3.3.0"
 ucrop = "2.2.11"
 guava = "33.5.0-jre"
@@ -42,8 +39,6 @@ squigglyslider = "1.0.0"
 glance = "1.1.1"
 
 [libraries]
-androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
-annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 coroutines-guava = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-guava", version.ref = "coroutinesGuava" }
 concurrent-futures = { module = "androidx.concurrent:concurrent-futures-ktx", version.ref = "concurrentFutures" }
@@ -113,8 +108,6 @@ desugaring = { module = "com.android.tools:desugar_jdk_libs", version.ref = "des
 junit = { module = "junit:junit", version.ref = "junit" }
 
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
-
-multidex = { module = "androidx.multidex:multidex", version.ref = "multidex" }
 
 #newpipe-extractor = { module = "com.github.libre-tube:NewPipeExtractor", version = "70abbdb" }
 #newpipe-extractor = { module = "com.github.TeamNewPipe:NewPipeExtractor", version = "dev-SNAPSHOT" }


### PR DESCRIPTION
- Fix artist unsubscribe sync issue when artist has no thumbnail
  - Check if channelId is empty before calling subscribeChannel
  - Update sync to fetch and store channelId if missing

- Improve MediaSession metadata exposure for third-party apps
  - Add albumArtist, displayTitle fields
  - Add isBrowsable, isPlayable flags
  - Include artwork_uri in extras bundle

- Remove androidx.compose.material.icons dependency
  - Replace Icons.Default.Add with R.drawable.add
  - Replace Icons.Default.Delete with R.drawable.delete
  - Replace Icons.Default.Equalizer with R.drawable.equalizer
  - Replace volume icons with vector XML drawables
  - Add volume_mute.xml and volume_down.xml

- Remove unused libraries from libs.versions.toml
  - Remove annotation library
  - Remove materialIconsExtended
  - Remove multidex library