### PR TITLE
fix(lyrics): exporting lyrics as image now respects their position

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Lyrics.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Lyrics.kt
@@ -9,6 +9,7 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Intent
 import android.content.res.Configuration
+import android.text.Layout
 import android.os.Build
 import android.view.WindowManager
 import android.widget.Toast
@@ -1478,10 +1479,16 @@ fun Lyrics(
         val headerFooterEstimate = (48.dp + 14.dp + 16.dp + 20.dp + 8.dp + 28.dp * 2)
         val previewAvailableHeight = previewBoxHeight - headerFooterEstimate
 
+        val lyricsTextAlign = when (lyricsTextPosition) {
+            LyricsPosition.LEFT -> TextAlign.Left
+            LyricsPosition.CENTER -> TextAlign.Center
+            LyricsPosition.RIGHT -> TextAlign.Right
+        }
+
         val textStyleForMeasurement = TextStyle(
             color = previewTextColor,
             fontWeight = FontWeight.Bold,
-            textAlign = TextAlign.Center
+            textAlign = lyricsTextAlign
         )
         val textMeasurer = rememberTextMeasurer()
 
@@ -1554,7 +1561,8 @@ fun Lyrics(
                             mediaMetadata = mediaMetadata ?: return@Box,
                             backgroundColor = previewBackgroundColor,
                             textColor = previewTextColor,
-                            secondaryTextColor = previewSecondaryTextColor
+                                secondaryTextColor = previewSecondaryTextColor,
+                                textAlign = lyricsTextAlign
                         )
                     }
 
@@ -1633,6 +1641,11 @@ fun Lyrics(
                                         backgroundColor = previewBackgroundColor.toArgb(),
                                         textColor = previewTextColor.toArgb(),
                                         secondaryTextColor = previewSecondaryTextColor.toArgb(),
+                                        lyricsAlignment = when (lyricsTextPosition) {
+                                            LyricsPosition.LEFT -> Layout.Alignment.ALIGN_NORMAL
+                                            LyricsPosition.CENTER -> Layout.Alignment.ALIGN_CENTER
+                                            LyricsPosition.RIGHT -> Layout.Alignment.ALIGN_OPPOSITE
+                                        }
                                     )
                                     val timestamp = System.currentTimeMillis()
                                     val filename = "lyrics_$timestamp"

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/LyricsImageCard.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/LyricsImageCard.kt
@@ -124,7 +124,8 @@ fun LyricsImageCard(
     darkBackground: Boolean = true,
     backgroundColor: Color? = null,
     textColor: Color? = null,
-    secondaryTextColor: Color? = null
+    secondaryTextColor: Color? = null,
+    textAlign: TextAlign = TextAlign.Center
 ) {
     val context = LocalContext.current
     val density = LocalDensity.current
@@ -214,14 +215,18 @@ fun LyricsImageCard(
                         .weight(1f)
                         .fillMaxWidth()
                         .padding(vertical = 6.dp),
-                    contentAlignment = Alignment.Center
+                    contentAlignment = when (textAlign) {
+                        TextAlign.Left, TextAlign.Start -> Alignment.CenterStart
+                        TextAlign.Right, TextAlign.End -> Alignment.CenterEnd
+                        else -> Alignment.Center
+                    }
                 ) {
                     val availableWidth = maxWidth
                     val availableHeight = maxHeight
                     val textStyle = TextStyle(
                         color = mainTextColor,
                         fontWeight = FontWeight.Bold,
-                        textAlign = TextAlign.Center,
+                        textAlign = textAlign,
                         letterSpacing = 0.005.em,
                     )
 
@@ -252,7 +257,7 @@ fun LyricsImageCard(
                             lineHeight = dynamicFontSize.value.sp * 1.2f
                         ),
                         overflow = TextOverflow.Ellipsis,
-                        textAlign = TextAlign.Center,
+                        textAlign = textAlign,
                         modifier = Modifier.fillMaxWidth()
                     )
                 }

--- a/app/src/main/kotlin/com/metrolist/music/utils/ComposeToImage.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/ComposeToImage.kt
@@ -44,7 +44,8 @@ object ComposeToImage {
         height: Int,
         backgroundColor: Int? = null,
         textColor: Int? = null,
-        secondaryTextColor: Int? = null
+        secondaryTextColor: Int? = null,
+        lyricsAlignment: Layout.Alignment = Layout.Alignment.ALIGN_CENTER
     ): Bitmap = withContext(Dispatchers.Default) {
         val cardSize = minOf(width, height) - 32
         val bitmap = createBitmap(cardSize, cardSize)
@@ -149,7 +150,7 @@ object ComposeToImage {
             lyricsLayout = StaticLayout.Builder.obtain(
                 lyrics, 0, lyrics.length, lyricsPaint, lyricsMaxWidth
             )
-                .setAlignment(Layout.Alignment.ALIGN_CENTER)
+                .setAlignment(lyricsAlignment)
                 .setIncludePad(false)
                 .setLineSpacing(10f, 1.3f)
                 .setMaxLines(10)


### PR DESCRIPTION
fixes #2120

makes the lyrics export to image respect the "Lyrics text position" setting

<img width="392" height="862" alt="image" src="https://github.com/user-attachments/assets/159d71e1-f22c-45e4-b4de-642316b9c06c" />
<img width="392" height="862" alt="image" src="https://github.com/user-attachments/assets/da1d7ae5-fe56-46dd-99de-783a18b9fab9" />
