### PR TITLE
Fix: Download correct APK variant during update

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/utils/Updater.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/Updater.kt
@@ -30,10 +30,20 @@ object Updater {
     fun getLatestDownloadUrl(): String {
         val baseUrl = "https://github.com/mostafaalagamy/Metrolist/releases/latest/download/"
         val architecture = BuildConfig.ARCHITECTURE
+        val isGmsVariant = BuildConfig.CAST_AVAILABLE
+        
         return if (architecture == "universal") {
-            baseUrl + "Metrolist.apk"
+            if (isGmsVariant) {
+                baseUrl + "Metrolist-with-Google-Cast.apk"
+            } else {
+                baseUrl + "Metrolist.apk"
+            }
         } else {
-            baseUrl + "app-${architecture}-release.apk"
+            if (isGmsVariant) {
+                baseUrl + "app-${architecture}-with-Google-Cast.apk"
+            } else {
+                baseUrl + "app-${architecture}-release.apk"
+            }
         }
     }
 }


### PR DESCRIPTION
When updating the app, the updater now correctly detects whether the user is running the GMS (Google Cast) or FOSS variant and downloads the matching APK.

Uses BuildConfig.CAST_AVAILABLE to determine the current variant:
- GMS variant: Downloads *-with-Google-Cast.apk
- FOSS variant: Downloads *-release.apk or Metrolist.apk