### PR TITLE
fix(VolumeSlider): hide circle if the volume is more than 90%

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/VolumeSlider.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/VolumeSlider.kt
@@ -128,13 +128,13 @@ fun VolumeSlider(
                 enabled = enabled,
                 thumbTrackGapSize = VolumeSliderDefaults.ThumbTrackGapSize,
                 trackCornerSize = VolumeSliderDefaults.TrackCornerRadius,
-                drawStopIndicator = { offset ->
+                drawStopIndicator = if (value < 0.90f) { offset ->
                     drawCircle(
                         color = stopIndicatorColor,
                         radius = VolumeSliderDefaults.StopIndicatorRadius.toPx(),
                         center = offset
                     )
-                }
+                } else null
             )
         }
     )


### PR DESCRIPTION
this hides the circle (at the end of the slider) when the volume is more than 90% so it would look something like this
![IMG_20260121_201538](https://github.com/user-attachments/assets/b743796c-c368-4fb1-8599-3ef946250314)
instead of this
![IMG_20260121_144721](https://github.com/user-attachments/assets/91beef37-1849-4a01-953e-9382f905d70f)
