### PR TITLE
Show error dialog when applying EQ profile fails

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/eq/EqualizerService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/eq/EqualizerService.kt
@@ -55,14 +55,14 @@ class EqualizerService @Inject constructor() {
      * If audio processor is not set, stores as pending profile
      */
     @OptIn(UnstableApi::class)
-    fun applyProfile(profile: SavedEQProfile): Boolean {
+    fun applyProfile(profile: SavedEQProfile): Result<Unit> {
         val processor = audioProcessor
         if (processor == null) {
             Timber.tag(TAG)
                 .w("Audio processor not set yet. Storing profile as pending: ${profile.name}")
             pendingProfile = profile
             shouldDisable = false
-            return true
+            return Result.success(Unit)
         }
 
         try {
@@ -79,10 +79,10 @@ class EqualizerService @Inject constructor() {
             processor.applyProfile(parametricEQ)
             Timber.tag(TAG)
                 .d("Applied EQ profile: ${profile.name} with ${profile.bands.size} bands and ${profile.preamp} dB preamp")
-            return true
+            return Result.success(Unit)
         } catch (e: Exception) {
             Timber.tag(TAG).e("Failed to apply profile: ${e.message}")
-            return false
+            return Result.failure(e)
         }
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -417,8 +417,8 @@ class MusicService :
         scope.launch {
             eqProfileRepository.activeProfile.collect { profile ->
                 if (profile != null) {
-                    val applied = equalizerService.applyProfile(profile)
-                    if (applied && player.playbackState == Player.STATE_READY && player.isPlaying) {
+                    val result = equalizerService.applyProfile(profile)
+                    if (result.isSuccess && player.playbackState == Player.STATE_READY && player.isPlaying) {
                         // Instant update: flush buffers and seek slightly to re-process audio
                         customEqualizerAudioProcessor.flush()
                         // Small seek to force re-buffer through the new EQ settings

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/equalizer/EQState.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/equalizer/EQState.kt
@@ -8,5 +8,6 @@ import com.metrolist.music.eq.data.SavedEQProfile
 data class EQState(
     val profiles: List<SavedEQProfile> = emptyList(),
     val activeProfileId: String? = null,
-    val importStatus: String? = null
+    val importStatus: String? = null,
+    val error: String? = null
 )

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/equalizer/EQViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/equalizer/EQViewModel.kt
@@ -69,15 +69,22 @@ class EQViewModel @Inject constructor(
                 // Apply the selected profile
                 val profile = _state.value.profiles.find { it.id == profileId }
                 if (profile != null) {
-                    val success = equalizerService.applyProfile(profile)
-                    if (success) {
+                    val result = equalizerService.applyProfile(profile)
+                    result.onSuccess {
                         eqProfileRepository.setActiveProfile(profileId)
-                    } else {
-                        // TODO: Show error message
+                    }.onFailure { e ->
+                        _state.update { it.copy(error = e.message ?: "Unknown error") }
                     }
                 }
             }
         }
+    }
+
+    /**
+     * Clear error message
+     */
+    fun clearError() {
+        _state.update { it.copy(error = null) }
     }
 
     /**

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/equalizer/EqScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/equalizer/EqScreen.kt
@@ -81,6 +81,7 @@ fun EqScreen(
                         },
                         onError = { error ->
                             Timber.d("Error: Unable to import Custom EQ profile: $fileName")
+                            showError = context.getString(R.string.import_error_title) + ": " + error.message
                         })
                 } else {
                     showError = context.getString(R.string.error_file_read)
@@ -135,6 +136,24 @@ fun EqScreen(
             },
             confirmButton = {
                 TextButton(onClick = { showError = null }) {
+                    Text(stringResource(android.R.string.ok))
+                }
+            }
+        )
+    }
+
+    // Error dialog for apply failure
+    if (state.error != null) {
+        AlertDialog(
+            onDismissRequest = { viewModel.clearError() },
+            title = {
+                Text(stringResource(R.string.error_title))
+            },
+            text = {
+                Text(stringResource(R.string.error_eq_apply_failed, state.error ?: ""))
+            },
+            confirmButton = {
+                TextButton(onClick = { viewModel.clearError() }) {
                     Text(stringResource(android.R.string.ok))
                 }
             }

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -411,6 +411,8 @@
     <string name="error_file_read">Could not read file</string>
     <string name="error_file_open">Failed to open file: %1$s</string>
     <string name="import_error_title">Import Error</string>
+    <string name="error_title">Error</string>
+    <string name="error_eq_apply_failed">Failed to apply EQ profile: %1$s</string>
 
     <!-- Hardcoded strings -->
     <string name="casting_to">Casting to %s</string>


### PR DESCRIPTION
- Updated EqualizerService.applyProfile to return Result<Unit> instead of Boolean.
- Added error handling in EQViewModel.
- Added error field to EQState.
- Added AlertDialog in EqScreen to display error messages.
- Updated MusicService to handle Result type.
- Added string resources for error messages.
---
Previously, users received no feedback if an EQ profile failed to apply or if a custom import failed. This change ensures users are informed of issues, improving the overall user experience and debuggability.