### PR TITLE
Update strings.xml

### DIFF
--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -50,7 +50,9 @@
     <string name="details">Detaylar</string>
     <string name="edit">Düzenle</string>
     <string name="start_radio">Radyo başlat</string>
-    <string name="play">Çal</string>
+    <string name="play">Oynat</string>
+    <string name="pause">Duraklat</string>
+    <string name="play_pause">Oynat/Duraklat</string>
     <string name="play_next">Bir sonra çal</string>
     <string name="add_to_queue">Sıraya ekle</string>
     <string name="add_to_library">Kütüphaneye ekle</string>


### PR DESCRIPTION
Hello!
I tried to fix a forgotten string line in the media player UI.
It looks like Weblate did not include some strings properly.
Because of that, the Pause / Play button text is incorrect:
when the music is paused, it shows "Çal" instead of "Pause", and vice versa.
This PR fixes the missing / wrong string mapping so the correct text is shown depending on the playback state.
Thanks 🙌
![Screenshot_20260122_221549_Metrolist](https://github.com/user-attachments/assets/e65dca50-5200-4022-8605-8fcacf12f9f9)
![Screenshot_20260122_221545_Metrolist](https://github.com/user-attachments/assets/6d4e9bf0-c228-41e8-9d5d-a1a06d91ed3e)
