### PR TITLE
Fix lyrics location (if provider is shown)

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Lyrics.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Lyrics.kt
@@ -452,6 +452,8 @@ fun Lyrics(
     val selectedIndices = remember { mutableStateListOf<Int>() }
     var showMaxSelectionToast by remember { mutableStateOf(false) } // State for showing max selection toast
 
+    val isLyricsProviderShown = lyricsEntity?.provider != null && lyricsEntity?.provider != "Unknown" && !isSelectionModeActive
+
     val lazyListState = rememberLazyListState()
     
     // Professional animation states for smooth Metrolist-style transitions
@@ -546,7 +548,8 @@ fun Lyrics(
         if (isAnimating) return // Prevent multiple animations
         isAnimating = true
         try {
-            val itemInfo = lazyListState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == targetIndex }
+            val lookUpIndex = if (isLyricsProviderShown) targetIndex + 1 else targetIndex
+            val itemInfo = lazyListState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == lookUpIndex }
             if (itemInfo != null) {
                 // Item is visible, animate directly to center without sudden jumps
                 val viewportHeight = lazyListState.layoutInfo.viewportEndOffset - lazyListState.layoutInfo.viewportStartOffset
@@ -666,7 +669,7 @@ fun Lyrics(
             }
 
             // Show lyrics provider at the top, scrolling with content
-            if (lyricsEntity?.provider != null && lyricsEntity?.provider != "Unknown" && !isSelectionModeActive) {
+            if (isLyricsProviderShown) {
                 item {
                     Text(
                         text = "Lyrics from ${lyricsEntity?.provider}",


### PR DESCRIPTION
As was discovered by @GoldenWarriorM, mentioned in #2171, the lyrics location was not centered for some songs. In particular, songs that had a lyrics provider text item (e.g. "Lyrics from SimpMusic") at the top of the lyrics screen. The bug was that if this text item was present, `lazyListState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == targetIndex }` in `performSmoothPageScroll(...)` would index the lyrics provider text item as well and therefore the indices of the actual lyrics items would be offset by +1.

fixes #2152

