### PR TITLE
Fix: Clear visitorData after backup restore to prevent 403 errors

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/BackupRestoreViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/BackupRestoreViewModel.kt
@@ -9,9 +9,11 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.widget.Toast
+import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.ViewModel
 import com.metrolist.music.MainActivity
 import com.metrolist.music.R
+import com.metrolist.music.constants.VisitorDataKey
 import com.metrolist.music.db.InternalDatabase
 import com.metrolist.music.db.MusicDatabase
 import com.metrolist.music.db.entities.ArtistEntity
@@ -23,6 +25,7 @@ import com.metrolist.music.extensions.zipInputStream
 import com.metrolist.music.extensions.zipOutputStream
 import com.metrolist.music.playback.MusicService
 import com.metrolist.music.playback.MusicService.Companion.PERSISTENT_QUEUE_FILE
+import com.metrolist.music.utils.dataStore
 import com.metrolist.music.utils.reportException
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -107,6 +110,15 @@ class BackupRestoreViewModel @Inject constructor(
                 }
             } ?: run {
                 Timber.tag("RESTORE").e("Could not open input stream for uri: $uri")
+            }
+
+            // Clear visitorData to force getting a fresh one on restart
+            // This fixes 403 errors caused by expired/invalid visitorData from old backups
+            Timber.tag("RESTORE").i("Clearing visitorData to force refresh on restart")
+            runBlocking(Dispatchers.IO) {
+                context.dataStore.edit { settings ->
+                    settings.remove(VisitorDataKey)
+                }
             }
 
             context.stopService(Intent(context, MusicService::class.java))


### PR DESCRIPTION
When restoring a backup from another device or an old backup, the visitorData stored in the settings may be expired or invalid for YouTube Music API. This causes 403 Forbidden errors when trying to play songs.

The fix clears the visitorData after restoring settings, forcing the app to fetch a fresh visitorData from YouTube on restart.

This resolves the issue where clean install works but restoring backup causes playback failures.