### PR TITLE
feat: Implement a working playlist shuffle for Android Auto (#830)

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -2516,6 +2516,7 @@ class MusicService :
         const val PLAYLIST = "playlist"
         const val YOUTUBE_PLAYLIST = "youtube_playlist"
         const val SEARCH = "search"
+        const val SHUFFLE_ACTION = "__shuffle__"
 
         const val CHANNEL_ID = "music_channel_01"
         const val NOTIFICATION_ID = 888


### PR DESCRIPTION
Adds a button to shuffle after selecting a playlist in Android Auto that matches the functionality in the main app.
https://github.com/mostafaalagamy/Metrolist/issues/830