### PR TITLE
Fix: SimpMusic lyrics provider returning wrong lyrics

### DIFF
--- a/simpmusic/src/main/kotlin/com/metrolist/simpmusic/SimpMusicLyrics.kt
+++ b/simpmusic/src/main/kotlin/com/metrolist/simpmusic/SimpMusicLyrics.kt
@@ -73,12 +73,25 @@ object SimpMusicLyrics {
             throw IllegalStateException("Lyrics unavailable")
         }
 
-        val bestMatch = if (duration > 0 && tracks.size > 1) {
-            tracks.minByOrNull { track ->
+        // Filter tracks that match duration within tolerance (10 seconds)
+        val validTracks = if (duration > 0) {
+            tracks.filter { track ->
+                abs((track.duration ?: 0) - duration) <= 10
+            }
+        } else {
+            tracks
+        }
+
+        if (validTracks.isEmpty()) {
+            throw IllegalStateException("Lyrics unavailable")
+        }
+
+        val bestMatch = if (duration > 0 && validTracks.size > 1) {
+            validTracks.minByOrNull { track ->
                 abs((track.duration ?: 0) - duration)
             }
         } else {
-            tracks.firstOrNull()
+            validTracks.firstOrNull()
         }
 
         // Prioritize richSyncLyrics for word-by-word sync, then syncedLyrics, then plainLyrics


### PR DESCRIPTION
When automatic lyrics search or refetch was triggered, the SimpMusic provider would return lyrics from a different song if the actual song had no lyrics. This happened because getLyrics() picked the closest duration match without validating if it was actually reasonable.

Fixed by adding duration validation (±10 seconds tolerance) to match the behavior already present in getAllLyrics(). Now when no lyrics match the song's duration, the provider correctly throws an exception allowing the next provider to try.