### PR TITLE
Fix compilation errors from PR #2686

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -277,7 +277,8 @@ class MusicService :
     @DownloadCache
     lateinit var downloadCache: SimpleCache
 
-    private lateinit var player: ExoPlayer
+    lateinit var player: ExoPlayer
+        private set
     private lateinit var mediaSession: MediaLibrarySession
     
     // Tracks if player has been properly initilized

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
@@ -564,10 +564,6 @@ fun BottomSheetPlayer(
         mutableStateOf(false)
     }
 
-    LaunchedEffect(mediaMetadata?.id) {
-        showInlineLyrics = false
-    }
-
     var isFullScreen by rememberSaveable {
         mutableStateOf(false)
     }


### PR DESCRIPTION
## Summary

This PR fixes all the compilation errors from PR #2686.

## Changes Made

### MusicService.kt
- Made `player` publicly readable with private setter to fix the access issue

### PlayerConnection.kt
- Added missing imports: `android.util.Log`, `kotlinx.coroutines.launch`, `ExoPlayer`
- Restructured `init` block to avoid `val` reassignment issues
- Removed duplicate `startRadioSeamlessly()` function
- Fixed `playNext` and `addToQueue` functions that were calling service methods twice
- Changed `player` return type from `Player` to `ExoPlayer` for `setShuffleOrder` and `audioSessionId`

### Player.kt
- Removed `LaunchedEffect(mediaMetadata?.id)` as requested

## Errors Fixed

All 14 compilation errors are now fixed.