### PR TITLE
feat(settings): add high refresh rate toggle

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -129,6 +129,7 @@ import com.metrolist.music.constants.DarkModeKey
 import com.metrolist.music.constants.DefaultOpenTabKey
 import com.metrolist.music.constants.DisableScreenshotKey
 import com.metrolist.music.constants.DynamicThemeKey
+import com.metrolist.music.constants.EnableHighRefreshRateKey
 import com.metrolist.music.constants.ListenTogetherUsernameKey
 import com.metrolist.music.constants.MiniPlayerBottomSpacing
 import com.metrolist.music.constants.MiniPlayerHeight
@@ -402,6 +403,35 @@ class MainActivity : ComponentActivity() {
         }
 
         val enableDynamicTheme by rememberPreference(DynamicThemeKey, defaultValue = true)
+        val enableHighRefreshRate by rememberPreference(EnableHighRefreshRateKey, defaultValue = true)
+
+        LaunchedEffect(enableHighRefreshRate) {
+            val window = this@MainActivity.window
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                val layoutParams = window.attributes
+                if (enableHighRefreshRate) {
+                    layoutParams.preferredDisplayModeId = 0
+                } else {
+                    val modes = window.windowManager.defaultDisplay.supportedModes
+                    val mode60 = modes.firstOrNull { kotlin.math.abs(it.refreshRate - 60f) < 1f }
+                        ?: modes.minByOrNull { kotlin.math.abs(it.refreshRate - 60f) }
+
+                    if (mode60 != null) {
+                        layoutParams.preferredDisplayModeId = mode60.modeId
+                    }
+                }
+                window.attributes = layoutParams
+            } else {
+                val params = window.attributes
+                if (enableHighRefreshRate) {
+                    params.preferredRefreshRate = 0f
+                } else {
+                    params.preferredRefreshRate = 60f
+                }
+                window.attributes = params
+            }
+        }
+
         val darkTheme by rememberEnumPreference(DarkModeKey, defaultValue = DarkMode.AUTO)
         val isSystemInDarkTheme = isSystemInDarkTheme()
         val useDarkTheme = remember(darkTheme, isSystemInDarkTheme) {

--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -14,6 +14,7 @@ import java.time.LocalDateTime
 import java.time.ZoneOffset
 
 val EnableDynamicIconKey = booleanPreferencesKey("enableDynamicIcon")
+val EnableHighRefreshRateKey = booleanPreferencesKey("enableHighRefreshRate")
 val DynamicThemeKey = booleanPreferencesKey("dynamicTheme")
 val SelectedThemeColorKey = intPreferencesKey("selectedThemeColor")
 val DarkModeKey = stringPreferencesKey("darkMode")

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AppearanceSettings.kt
@@ -60,6 +60,7 @@ import com.metrolist.music.constants.CropAlbumArtKey
 import com.metrolist.music.constants.DefaultOpenTabKey
 import com.metrolist.music.constants.DynamicThemeKey
 import com.metrolist.music.constants.EnableDynamicIconKey
+import com.metrolist.music.constants.EnableHighRefreshRateKey
 import com.metrolist.music.constants.GridItemSize
 import com.metrolist.music.constants.GridItemsSizeKey
 import com.metrolist.music.constants.HidePlayerThumbnailKey
@@ -124,6 +125,10 @@ fun AppearanceSettings(
     )
     val (enableDynamicIcon, onEnableDynamicIconChange) = rememberPreference(
         EnableDynamicIconKey,
+        defaultValue = true
+    )
+    val (enableHighRefreshRate, onEnableHighRefreshRateChange) = rememberPreference(
+        EnableHighRefreshRateKey,
         defaultValue = true
     )
     val (selectedThemeColorInt) = rememberPreference(
@@ -797,6 +802,29 @@ fun AppearanceSettings(
                             )
                         },
                         onClick = { handleIconChange(!enableDynamicIcon) }
+                    )
+                )
+                add(
+                    Material3SettingsItem(
+                        icon = painterResource(R.drawable.speed),
+                        title = { Text(stringResource(R.string.enable_high_refresh_rate)) },
+                        description = { Text(stringResource(R.string.enable_high_refresh_rate_desc)) },
+                        trailingContent = {
+                            Switch(
+                                checked = enableHighRefreshRate,
+                                onCheckedChange = onEnableHighRefreshRateChange,
+                                thumbContent = {
+                                    Icon(
+                                        painter = painterResource(
+                                            id = if (enableHighRefreshRate) R.drawable.check else R.drawable.close
+                                        ),
+                                        contentDescription = null,
+                                        modifier = Modifier.size(SwitchDefaults.IconSize)
+                                    )
+                                }
+                            )
+                        },
+                        onClick = { onEnableHighRefreshRateChange(!enableHighRefreshRate) }
                     )
                 )
                 // Only show dynamic theme option when using the default/dynamic color

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -629,4 +629,6 @@
     <string name="cd_system_mode">System mode</string>
     <string name="cd_palette_item">%1$s palette</string>
     <string name="play_all">Play all</string>
+    <string name="enable_high_refresh_rate">Enable high refresh rate</string>
+    <string name="enable_high_refresh_rate_desc">Force the display to run at the highest supported refresh rate (e.g. 120Hz)</string>
 </resources>


### PR DESCRIPTION
## Summary
This PR adds a new toggle in **Settings > Appearance** to control high refresh rates.
### Motivation
Currently, the app forces the highest available refresh rate (e.g., 120Hz) by default. While this provides a smoother experience, it may not be desirable for all users because:
- It consumes more battery.
- It might cause issues on specific devices where high refresh rates are unstable or unsupported in certain contexts.
### Changes
- Added a "Enable high refresh rate" toggle in the Appearance settings (default: enabled).
- When disabled, the app attempts to lock the window to 60Hz.
- When enabled, it uses the system default (usually the highest available rate).
- Implemented logic in `MainActivity` to apply these preferences using `preferredDisplayModeId` (Android 11+) and `preferredRefreshRate` (Legacy).
<p float="left">
  <img src="https://github.com/user-attachments/assets/b1775b62-c582-4686-9c49-7d145f5bdaa9" width="300" />
  <img src="https://github.com/user-attachments/assets/919a7d23-d133-4c6f-a4a9-9f6cdf852916" width="300" /> 
</p>