### PR TITLE
feat(ui): enable pure black theme with auto light/dark mode

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/ThemeScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/ThemeScreen.kt
@@ -320,15 +320,14 @@ fun ThemeControls(
                     horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    // System mode (separated)
+                    // System mode (AUTO)
                     ModeCircle(
                         darkMode = darkMode,
                         pureBlack = pureBlack,
                         targetMode = DarkMode.AUTO,
-                        targetPureBlack = false,
+                        targetPureBlack = pureBlack,
                         onClick = {
                             onDarkModeChange(DarkMode.AUTO)
-                            onPureBlackChange(false)
                         },
                         showIcon = true
                     )


### PR DESCRIPTION
## Summary
Enable pure black theme to work with automatic light/dark mode.
Closes #2725
## Changes
Modified `ThemeScreen.kt` to allow pure black setting to persist when AUTO mode is selected. Pure black now correctly applies only when the system is in dark mode during AUTO.
## Behavior
- **AUTO mode**: Follows system theme - pure black when dark, normal when light
- **ON mode**: Always dark (with optional pure black)  
- **OFF mode**: Always light
## Testing
1. Select pure black color in Appearance Settings
2. Select AUTO mode in Theme settings
3. Toggle system light/dark mode - pure black should only apply in dark mode

Note: I had commited the change to the wrong branch sorry for the mess on the issue LOL