### PR TITLE
fix(player): add WEB_CREATOR fallback for age-restricted content

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -26,6 +26,7 @@ import com.metrolist.innertube.models.YouTubeClient.Companion.WEB_CREATOR
 import com.metrolist.innertube.models.YouTubeClient.Companion.WEB_REMIX
 import com.metrolist.innertube.models.response.PlayerResponse
 import com.metrolist.music.constants.AudioQuality
+import com.metrolist.music.utils.cipher.CipherDeobfuscator
 import com.metrolist.music.utils.YTPlayerUtils.MAIN_CLIENT
 import com.metrolist.music.utils.YTPlayerUtils.STREAM_FALLBACK_CLIENTS
 import com.metrolist.music.utils.YTPlayerUtils.validateStatus
@@ -48,6 +49,7 @@ object YTPlayerUtils {
     private val MAIN_CLIENT: YouTubeClient = WEB_REMIX
 
     private val STREAM_FALLBACK_CLIENTS: Array<YouTubeClient> = arrayOf(
+        TVHTML5_SIMPLY_EMBEDDED_PLAYER,  // Try embedded player first for age-restricted content
         TVHTML5,
         ANDROID_VR_1_43_32,
         ANDROID_VR_1_61_48,
@@ -55,7 +57,6 @@ object YTPlayerUtils {
         IPADOS,
         ANDROID_VR_NO_AUTH,
         MOBILE,
-        TVHTML5_SIMPLY_EMBEDDED_PLAYER,
         IOS,
         WEB,
         WEB_CREATOR
@@ -80,45 +81,58 @@ object YTPlayerUtils {
         connectivityManager: ConnectivityManager,
     ): Result<PlaybackData> = runCatching {
         Timber.tag(logTag).d("Fetching player response for videoId: $videoId, playlistId: $playlistId")
-        /**
-         * This is required for some clients to get working streams however
-         * it should not be forced for the [MAIN_CLIENT] because the response of the [MAIN_CLIENT]
-         * is required even if the streams won't work from this client.
-         * This is why it is allowed to be null.
-         */
-        val signatureTimestamp = getSignatureTimestampOrNull(videoId)
-        Timber.tag(logTag).d("Signature timestamp: $signatureTimestamp")
 
         val isLoggedIn = YouTube.cookie != null
-        val sessionId =
-            if (isLoggedIn) {
-                // signed in sessions use dataSyncId as identifier
-                YouTube.dataSyncId
-            } else {
-                // signed out sessions use visitorData as identifier
-                YouTube.visitorData
-            }
         Timber.tag(logTag).d("Session authentication status: ${if (isLoggedIn) "Logged in" else "Not logged in"}")
 
-        // Generate PoToken for WEB_REMIX client
+        // Get signature timestamp (same as before for normal content)
+        val signatureTimestamp = getSignatureTimestampOrNull(videoId)
+        Timber.tag(logTag).d("Signature timestamp: ${signatureTimestamp.timestamp}")
+
+        // Generate PoToken
         var poToken: PoTokenResult? = null
+        val sessionId = if (isLoggedIn) YouTube.dataSyncId else YouTube.visitorData
         if (MAIN_CLIENT.useWebPoTokens && sessionId != null) {
             Timber.tag(logTag).d("Generating PoToken for WEB_REMIX with sessionId")
             try {
                 poToken = poTokenGenerator.getWebClientPoToken(videoId, sessionId)
                 if (poToken != null) {
                     Timber.tag(logTag).d("PoToken generated successfully")
-                } else {
-                    Timber.tag(logTag).d("PoToken generation returned null, will try without")
                 }
             } catch (e: Exception) {
                 Timber.tag(logTag).e(e, "PoToken generation failed: ${e.message}")
             }
         }
 
+        // Try WEB_REMIX with signature timestamp and poToken (same as before)
         Timber.tag(logTag).d("Attempting to get player response using MAIN_CLIENT: ${MAIN_CLIENT.clientName}")
-        val mainPlayerResponse =
-            YouTube.player(videoId, playlistId, MAIN_CLIENT, signatureTimestamp, poToken?.playerRequestPoToken).getOrThrow()
+        var mainPlayerResponse = YouTube.player(videoId, playlistId, MAIN_CLIENT, signatureTimestamp.timestamp, poToken?.playerRequestPoToken).getOrThrow()
+
+        var usedAgeRestrictedClient: YouTubeClient? = null
+        val wasOriginallyAgeRestricted: Boolean
+
+        // Check if WEB_REMIX response indicates age-restricted
+        val mainStatus = mainPlayerResponse.playabilityStatus.status
+        val isAgeRestrictedFromResponse = mainStatus in listOf("AGE_CHECK_REQUIRED", "AGE_VERIFICATION_REQUIRED", "LOGIN_REQUIRED", "CONTENT_CHECK_REQUIRED")
+        wasOriginallyAgeRestricted = isAgeRestrictedFromResponse
+
+        if (isAgeRestrictedFromResponse && isLoggedIn) {
+            // Age-restricted: use WEB_CREATOR directly (no NewPipe needed from here)
+            Timber.tag(logTag).d("Age-restricted detected, using WEB_CREATOR")
+            Log.i(TAG, "Age-restricted: using WEB_CREATOR for videoId=$videoId")
+            val creatorResponse = YouTube.player(videoId, playlistId, WEB_CREATOR, null, null).getOrNull()
+            if (creatorResponse?.playabilityStatus?.status == "OK") {
+                Timber.tag(logTag).d("WEB_CREATOR works for age-restricted content")
+                mainPlayerResponse = creatorResponse
+                usedAgeRestrictedClient = WEB_CREATOR
+            }
+        }
+
+        // If we still don't have a valid response, throw
+        if (mainPlayerResponse == null) {
+            throw Exception("Failed to get player response")
+        }
+
         val audioConfig = mainPlayerResponse.playerConfig?.audioConfig
         val videoDetails = mainPlayerResponse.videoDetails
         val playbackTracking = mainPlayerResponse.playbackTracking
@@ -126,8 +140,21 @@ object YTPlayerUtils {
         var streamUrl: String? = null
         var streamExpiresInSeconds: Int? = null
         var streamPlayerResponse: PlayerResponse? = null
+        var retryMainPlayerResponse: PlayerResponse? = if (usedAgeRestrictedClient != null) mainPlayerResponse else null
 
-        for (clientIndex in (-1 until STREAM_FALLBACK_CLIENTS.size)) {
+        // Check current status
+        val currentStatus = mainPlayerResponse.playabilityStatus.status
+        var isAgeRestricted = currentStatus in listOf("AGE_CHECK_REQUIRED", "AGE_VERIFICATION_REQUIRED", "LOGIN_REQUIRED", "CONTENT_CHECK_REQUIRED")
+
+        if (isAgeRestricted) {
+            Timber.tag(logTag).d("Content is still age-restricted (status: $currentStatus), will try fallback clients")
+            Log.i(TAG, "Age-restricted content detected: videoId=$videoId, status=$currentStatus")
+        }
+
+        // If age-restricted, skip main client and go straight to fallbacks
+        val startIndex = if (isAgeRestricted) 0 else -1
+
+        for (clientIndex in (startIndex until STREAM_FALLBACK_CLIENTS.size)) {
             // reset for each client
             format = null
             streamUrl = null
@@ -136,9 +163,9 @@ object YTPlayerUtils {
             // decide which client to use for streams and load its player response
             val client: YouTubeClient
             if (clientIndex == -1) {
-                // try with streams from main client first
+                // try with streams from main client first (use retry response if available)
                 client = MAIN_CLIENT
-                streamPlayerResponse = mainPlayerResponse
+                streamPlayerResponse = retryMainPlayerResponse ?: mainPlayerResponse
                 Timber.tag(logTag).d("Trying stream from MAIN_CLIENT: ${client.clientName}")
             } else {
                 // after main client use fallback clients
@@ -154,17 +181,25 @@ object YTPlayerUtils {
                 Timber.tag(logTag).d("Fetching player response for fallback client: ${client.clientName}")
                 // Only pass poToken for clients that support it
                 val clientPoToken = if (client.useWebPoTokens) poToken?.playerRequestPoToken else null
+                // Skip signature timestamp for age-restricted (faster), use it for normal content
+                val clientSigTimestamp = if (wasOriginallyAgeRestricted) null else signatureTimestamp.timestamp
                 streamPlayerResponse =
-                    YouTube.player(videoId, playlistId, client, signatureTimestamp, clientPoToken).getOrNull()
+                    YouTube.player(videoId, playlistId, client, clientSigTimestamp, clientPoToken).getOrNull()
             }
 
             // process current client response
             if (streamPlayerResponse?.playabilityStatus?.status == "OK") {
                 Timber.tag(logTag).d("Player response status OK for client: ${if (clientIndex == -1) MAIN_CLIENT.clientName else STREAM_FALLBACK_CLIENTS[clientIndex].clientName}")
 
-                // Try to get streams using newPipePlayer method
-                val newPipeResponse = YouTube.newPipePlayer(videoId, streamPlayerResponse)
-                val responseToUse = newPipeResponse ?: streamPlayerResponse
+                // Skip NewPipe for age-restricted content (NewPipe doesn't use our auth)
+                val responseToUse = if (wasOriginallyAgeRestricted) {
+                    Timber.tag(logTag).d("Skipping NewPipe for age-restricted content")
+                    streamPlayerResponse
+                } else {
+                    // Try to get streams using newPipePlayer method
+                    val newPipeResponse = YouTube.newPipePlayer(videoId, streamPlayerResponse)
+                    newPipeResponse ?: streamPlayerResponse
+                }
 
                 format =
                     findFormat(
@@ -180,21 +215,27 @@ object YTPlayerUtils {
 
                 Timber.tag(logTag).d("Format found: ${format.mimeType}, bitrate: ${format.bitrate}")
 
-                streamUrl = findUrlOrNull(format, videoId, responseToUse)
+                streamUrl = findUrlOrNull(format, videoId, responseToUse, skipNewPipe = wasOriginallyAgeRestricted)
                 if (streamUrl == null) {
                     Timber.tag(logTag).d("Stream URL not found for format")
                     continue
                 }
 
-                // Apply n-transform for throttle parameter handling
-                val currentClient = if (clientIndex == -1) MAIN_CLIENT else STREAM_FALLBACK_CLIENTS[clientIndex]
-                if (currentClient.useWebPoTokens) {
+                // Apply n-transform for throttle parameter handling (for web clients)
+                val currentClient = if (clientIndex == -1) {
+                    usedAgeRestrictedClient ?: MAIN_CLIENT
+                } else {
+                    STREAM_FALLBACK_CLIENTS[clientIndex]
+                }
+                val needsNTransform = currentClient.useWebPoTokens ||
+                    currentClient.clientName in listOf("WEB", "WEB_REMIX", "WEB_CREATOR")
+                if (needsNTransform) {
                     try {
-                        Timber.tag(logTag).d("Applying n-transform to stream URL")
+                        Timber.tag(logTag).d("Applying n-transform to stream URL for ${currentClient.clientName}")
                         streamUrl = EjsNTransformSolver.transformNParamInUrl(streamUrl!!)
 
-                        // Append pot= parameter with streaming data poToken
-                        if (poToken?.streamingDataPoToken != null) {
+                        // Append pot= parameter with streaming data poToken (only for clients that use it)
+                        if (currentClient.useWebPoTokens && poToken?.streamingDataPoToken != null) {
                             Timber.tag(logTag).d("Appending pot= parameter to stream URL")
                             val separator = if ("?" in streamUrl!!) "&" else "?"
                             streamUrl = "${streamUrl}${separator}pot=${Uri.encode(poToken.streamingDataPoToken)}"
@@ -335,34 +376,70 @@ object YTPlayerUtils {
         }
         return false
     }
-    private fun getSignatureTimestampOrNull(videoId: String): Int? {
+    data class SignatureTimestampResult(
+        val timestamp: Int?,
+        val isAgeRestricted: Boolean
+    )
+
+    private fun getSignatureTimestampOrNull(videoId: String): SignatureTimestampResult {
         Timber.tag(logTag).d("Getting signature timestamp for videoId: $videoId")
-        return NewPipeExtractor.getSignatureTimestamp(videoId)
-            .onSuccess { Timber.tag(logTag).d("Signature timestamp obtained: $it") }
-            .onFailure {
-                Timber.tag(logTag).e(it, "Failed to get signature timestamp")
-                reportException(it)
+        val result = NewPipeExtractor.getSignatureTimestamp(videoId)
+        return result.fold(
+            onSuccess = { timestamp ->
+                Timber.tag(logTag).d("Signature timestamp obtained: $timestamp")
+                SignatureTimestampResult(timestamp, isAgeRestricted = false)
+            },
+            onFailure = { error ->
+                val isAgeRestricted = error.message?.contains("age-restricted", ignoreCase = true) == true ||
+                    error.cause?.message?.contains("age-restricted", ignoreCase = true) == true
+                if (isAgeRestricted) {
+                    Timber.tag(logTag).d("Age-restricted content detected from NewPipe")
+                    Log.i(TAG, "Age-restricted detected early via NewPipe: videoId=$videoId")
+                } else {
+                    Timber.tag(logTag).e(error, "Failed to get signature timestamp")
+                    reportException(error)
+                }
+                SignatureTimestampResult(null, isAgeRestricted)
             }
-            .getOrNull()
+        )
     }
 
-    private fun findUrlOrNull(
+    private suspend fun findUrlOrNull(
         format: PlayerResponse.StreamingData.Format,
         videoId: String,
-        playerResponse: PlayerResponse
+        playerResponse: PlayerResponse,
+        skipNewPipe: Boolean = false
     ): String? {
-        Timber.tag(logTag).d("Finding stream URL for format: ${format.mimeType}, videoId: $videoId")
+        Timber.tag(logTag).d("Finding stream URL for format: ${format.mimeType}, videoId: $videoId, skipNewPipe: $skipNewPipe")
 
-        // First check if format already has a URL from newPipePlayer
+        // First check if format already has a URL
         if (!format.url.isNullOrEmpty()) {
             Timber.tag(logTag).d("Using URL from format directly")
             return format.url
         }
 
+        // Try custom cipher deobfuscation for signatureCipher formats
+        val signatureCipher = format.signatureCipher ?: format.cipher
+        if (!signatureCipher.isNullOrEmpty()) {
+            Timber.tag(logTag).d("Format has signatureCipher, using custom deobfuscation")
+            val customDeobfuscatedUrl = CipherDeobfuscator.deobfuscateStreamUrl(signatureCipher, videoId)
+            if (customDeobfuscatedUrl != null) {
+                Timber.tag(logTag).d("Stream URL obtained via custom cipher deobfuscation")
+                return customDeobfuscatedUrl
+            }
+            Timber.tag(logTag).d("Custom cipher deobfuscation failed")
+        }
+
+        // Skip NewPipe for age-restricted content
+        if (skipNewPipe) {
+            Timber.tag(logTag).d("Skipping NewPipe methods for age-restricted content")
+            return null
+        }
+
         // Try to get URL using NewPipeExtractor signature deobfuscation
         val deobfuscatedUrl = NewPipeExtractor.getStreamUrl(format, videoId)
         if (deobfuscatedUrl != null) {
-            Timber.tag(logTag).d("Stream URL obtained via deobfuscation")
+            Timber.tag(logTag).d("Stream URL obtained via NewPipe deobfuscation")
             return deobfuscatedUrl
         }
 

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/Context.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/Context.kt
@@ -6,8 +6,8 @@ import kotlinx.serialization.Serializable
 data class Context(
     val client: Client,
     val thirdParty: ThirdParty? = null,
-    private val request: Request = Request(),
-    private val user: User = User()
+    val request: Request = Request(),
+    val user: User = User()
 ) {
     @Serializable
     data class Client(

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/YouTubeClient.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/YouTubeClient.kt
@@ -85,13 +85,17 @@ data class YouTubeClient(
             useSignatureTimestamp = true
         )
 
+        /**
+         * Embedded player that can bypass age-restriction.
+         * Does not require login for age-restricted content.
+         */
         val TVHTML5_SIMPLY_EMBEDDED_PLAYER = YouTubeClient(
             clientName = "TVHTML5_SIMPLY_EMBEDDED_PLAYER",
             clientVersion = "2.0",
             clientId = "85",
             userAgent = "Mozilla/5.0 (PlayStation; PlayStation 4/12.02) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Safari/605.1.15",
             loginSupported = true,
-            loginRequired = true,
+            loginRequired = false,
             useSignatureTimestamp = true,
             isEmbedded = true,
         )

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/NewPipe.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/NewPipe.kt
@@ -114,7 +114,7 @@ class NewPipeUtils(
                 url,
             )
         } catch (e: Exception) {
-            e.printStackTrace()
+            // Don't print stack trace - caller handles errors
             null
         }
 }
@@ -161,7 +161,7 @@ object NewPipeExtractor {
                 (it.itagItem?.id ?: return@mapNotNull null) to it.content
             }
         } catch (e: Exception) {
-            e.printStackTrace()
+            // Don't print stack trace - caller handles errors
             emptyList()
         }
     }


### PR DESCRIPTION
- Use WEB_CREATOR client for age-restricted videos (works with login)
- Skip NewPipe methods for age-restricted content (doesn't support auth)
- Add custom cipher deobfuscation fallback for stream URLs
- Remove noisy stack trace logging from NewPipe errors
- Keep normal content flow unchanged (signature timestamp + poToken)