### PR TITLE
fix: Observe localization settings changes to update API client local…

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/App.kt
+++ b/app/src/main/kotlin/com/metrolist/music/App.kt
@@ -192,6 +192,30 @@ class App : Application(), SingletonImageLoader.Factory {
                     }
                 }
         }
+
+        applicationScope.launch(Dispatchers.IO) {
+            dataStore.data
+                .map { Triple(it[ContentCountryKey], it[ContentLanguageKey], it[AppLanguageKey]) }
+                .distinctUntilChanged()
+                .collect { (contentCountry, contentLanguage, appLanguage) ->
+                    val systemLocale = Locale.getDefault()
+                    val effectiveAppLocale = appLanguage
+                        ?.takeUnless { it == SYSTEM_DEFAULT }
+                        ?.let { Locale.forLanguageTag(it) }
+                        ?: systemLocale
+
+                    YouTube.locale = YouTubeLocale(
+                        gl = contentCountry?.takeIf { it != SYSTEM_DEFAULT }
+                            ?: effectiveAppLocale.country.takeIf { it in CountryCodeToName }
+                            ?: systemLocale.country.takeIf { it in CountryCodeToName }
+                            ?: "US",
+                        hl = contentLanguage?.takeIf { it != SYSTEM_DEFAULT }
+                            ?: effectiveAppLocale.toLanguageTag().takeIf { it in LanguageCodeToName }
+                            ?: effectiveAppLocale.language.takeIf { it in LanguageCodeToName }
+                            ?: "en"
+                    )
+                }
+        }
     }
 
     override fun newImageLoader(context: PlatformContext): ImageLoader {


### PR DESCRIPTION
fix(app): dynamically update API locale on settings change
## Summary
This PR fixes an issue where the app would ignore localization settings for API content (resulting in incorrect song titles, e.g., "con" instead of "feat.") and sometimes fail to respect the app language on startup.
## Changes
- Added a `dataStore` observer in `App.kt` to monitor changes in `ContentCountryKey`, `ContentLanguageKey`, and `AppLanguageKey`.
- Implemented logic to dynamically update the global `YouTube.locale` configuration whenever these settings change.
Priority order for locale resolution:
1. Content Settings (if set)
2. App Language (if set)
3. System Default
4. Fallback to "US" / "en"
## Related Issue
Fixes #2613