### PR TITLE
fix(crossfade): remove duplicate history recording during transition

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -2876,54 +2876,10 @@ class MusicService :
         return current.albumTitle != null && current.albumTitle == next.albumTitle
     }
     
-    /**
-     * Records the current song to history before crossfade completes.
-     * This ensures the song is tracked even though playback doesn't end naturally.
-     */
-    private fun recordCurrentSongToHistory() {
-        val mediaItem = player.currentMediaItem ?: return
-        val playTimeMs = player.currentPosition
-        val historyDurationMs = dataStore[HistoryDuration]?.times(1000f) ?: 30000f
-        
-        if (playTimeMs >= historyDurationMs && !dataStore.get(PauseListenHistoryKey, false)) {
-            database.query {
-                incrementTotalPlayTime(mediaItem.mediaId, playTimeMs)
-                try {
-                    insert(
-                        Event(
-                            songId = mediaItem.mediaId,
-                            timestamp = LocalDateTime.now(),
-                            playTime = playTimeMs,
-                        ),
-                    )
-                } catch (_: SQLException) {
-                }
-            }
-        }
-        
-        // Register playback with YouTube
-        if (playTimeMs >= historyDurationMs) {
-            CoroutineScope(Dispatchers.IO).launch {
-                val playbackUrl = database.format(mediaItem.mediaId).first()?.playbackUrl
-                    ?: YTPlayerUtils.playerResponseForMetadata(mediaItem.mediaId, null)
-                        .getOrNull()?.playbackTracking?.videostatsPlaybackUrl?.baseUrl
-                playbackUrl?.let {
-                    YouTube.registerPlayback(null, playbackUrl)
-                        .onFailure {
-                            reportException(it)
-                        }
-                }
-            }
-        }
-    }
-    
     private fun startCrossfade() {
         if (isCrossfading) return
         val nextIndex = player.nextMediaItemIndex
         if (nextIndex == C.INDEX_UNSET) return
-        
-        // Record current song to history before crossfade
-        recordCurrentSongToHistory()
         
         secondaryPlayer = createExoPlayer()
         val secPlayer = secondaryPlayer!!


### PR DESCRIPTION
Removed recordCurrentSongToHistory() which was manually recording playback history before crossfade started. The existing PlaybackStatsListener on the player already handles this when the player is released/transitioned, causing duplicate entries.

> I'll be gathering crossfade issues into a single one for now on, it's better than make many separate pull requests