### PR TITLE
fixes random ForegroundService crash

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -220,7 +220,8 @@
 
         <receiver
             android:name="androidx.media3.session.MediaButtonReceiver"
-            android:exported="true">
+            android:exported="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="android.intent.action.MEDIA_BUTTON" />
             </intent-filter>

--- a/app/src/main/kotlin/com/metrolist/music/widget/MusicWidgetReceiver.kt
+++ b/app/src/main/kotlin/com/metrolist/music/widget/MusicWidgetReceiver.kt
@@ -27,11 +27,7 @@ class MusicWidgetReceiver : AppWidgetProvider() {
                 action = ACTION_UPDATE_WIDGET
             }
             try {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    context.startForegroundService(intent)
-                } else {
-                    context.startService(intent)
-                }
+                context.startService(intent)
             } catch (e: Exception) {
                 // Service might be restricted in background
             }
@@ -52,11 +48,7 @@ class MusicWidgetReceiver : AppWidgetProvider() {
                 action = ACTION_UPDATE_WIDGET
             }
             try {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    context.startForegroundService(intent)
-                } else {
-                    context.startService(intent)
-                }
+                context.startService(intent)
             } catch (e: Exception) {
                 // Service might be restricted in background
             }

--- a/app/src/main/kotlin/com/metrolist/music/widget/TurntableWidgetReceiver.kt
+++ b/app/src/main/kotlin/com/metrolist/music/widget/TurntableWidgetReceiver.kt
@@ -26,11 +26,7 @@ class TurntableWidgetReceiver : AppWidgetProvider() {
                 action = ACTION_UPDATE_TURNTABLE_WIDGET
             }
             try {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    context.startForegroundService(intent)
-                } else {
-                    context.startService(intent)
-                }
+                context.startService(intent)
             } catch (e: Exception) {
                 // Service might be restricted in background
             }


### PR DESCRIPTION
Removes the conditional `startForegroundService` calls in widget receivers, simplifying them to just `startService`. This is safe because the service already calls `startForeground` itself when appropriate.