### PR TITLE
fix(innertube): resolve playlist pagination capping at 100 songs

### DIFF
--- a/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
@@ -469,7 +469,9 @@ object YouTube {
                     PlaylistPage.fromMusicResponsiveListItemRenderer(it)
                 } ?: emptyList(),
             songsContinuation = response.contents?.twoColumnBrowseResultsRenderer?.secondaryContents?.sectionListRenderer
-                ?.contents?.firstOrNull()?.musicPlaylistShelfRenderer?.contents?.getContinuation(),
+                ?.contents?.firstOrNull()?.musicPlaylistShelfRenderer?.contents?.getContinuation()
+                ?: response.contents?.twoColumnBrowseResultsRenderer?.secondaryContents?.sectionListRenderer
+                    ?.contents?.firstOrNull()?.musicPlaylistShelfRenderer?.continuations?.getContinuation(),
             continuation = response.contents?.twoColumnBrowseResultsRenderer?.secondaryContents?.sectionListRenderer
                 ?.continuations?.getContinuation()
         )
@@ -479,7 +481,6 @@ object YouTube {
         val response = innerTube.browse(
             client = WEB_REMIX,
             continuation = continuation,
-            browseId = "",
             setLogin = true
         ).body<BrowseResponse>()
 
@@ -488,13 +489,16 @@ object YouTube {
             ?.flatten()
             ?: emptyList()
 
+        val shelfContents: List<MusicShelfRenderer.Content> =
+            response.continuationContents?.musicPlaylistShelfContinuation?.contents ?: emptyList()
+
         val appendedContents: List<MusicShelfRenderer.Content> = response.onResponseReceivedActions
             ?.firstOrNull()
             ?.appendContinuationItemsAction
             ?.continuationItems
             .orEmpty()
 
-        val allContents = mainContents + appendedContents
+        val allContents = mainContents + shelfContents + appendedContents
 
         val songs = allContents
             .mapNotNull { content: MusicShelfRenderer.Content -> content.musicResponsiveListItemRenderer }


### PR DESCRIPTION
## Summary
Fixes playlists being capped at 100 songs when syncing from YouTube Music by addressing three pagination bugs in the innertube playlist fetching logic.
## Problem
Synced playlists only display the first ~100 songs, even when the YouTube Music playlist contains more. The root cause is that the pagination loop responsible for fetching subsequent pages of songs either never starts or terminates prematurely due to missing data extraction paths.
## Changes
All changes are in `innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt`.
### 1. Missing continuation token source in `playlist()`
The initial playlist fetch only looked for the continuation token as an inline `ContinuationItemRenderer` inside `musicPlaylistShelfRenderer.contents`. YouTube's API can also return it in `musicPlaylistShelfRenderer.continuations` (the `List<Continuation>` format). When it did, `songsContinuation` was `null` and the pagination loop in `completed()` never executed.
Added a `?:` fallback to check `musicPlaylistShelfRenderer.continuations`.
### 2. Missing song source in `playlistContinuation()`
Continuation responses were only checked for songs in `sectionListContinuation` and `onResponseReceivedActions`, but not in `musicPlaylistShelfContinuation.contents` — even though the next continuation *token* was already being extracted from that same object. When the API returned songs there, the result was an empty list, which terminated the loop.
Added `musicPlaylistShelfContinuation.contents` as an additional song source.
### 3. Invalid `browseId` in continuation requests
`playlistContinuation()` passed `browseId = ""` instead of omitting it. Since the serializer only omits `null` (not empty strings), this sent `"browseId": ""` in the request body — unlike every other continuation function in the codebase, which correctly defaults to `null`. This could cause the API to return an unexpected response format.
Removed the explicit `browseId = ""` parameter so it defaults to `null` and is omitted from the JSON payload.