### PR TITLE
fix(lyrics): decode HTML entities in lyrics text

### DIFF
--- a/kugou/src/main/kotlin/com/metrolist/kugou/KuGou.kt
+++ b/kugou/src/main/kotlin/com/metrolist/kugou/KuGou.kt
@@ -166,7 +166,7 @@ object KuGou {
         Keyword(normalizeTitle(title), normalizeArtist(artist), album)
 
     private fun String.normalize(): String =
-        replace("&apos;", "'").lines().filter { line -> line.matches(ACCEPTED_REGEX) }
+        lines().filter { line -> line.matches(ACCEPTED_REGEX) }
             .let { lines ->
                 // Remove useless information such as singer, writer, composer, guitar, etc.
                 var headCutLine = 0


### PR DESCRIPTION
Lyrics from SimpMusic (and potentially other providers) contain raw HTML entities like &#x27; instead of apostrophes. Add a decodeHtmlEntities() step in the central parseLyrics() function to handle hex/decimal numeric entities and common named entities (&apos;, &amp;, &quot;, etc.).

Remove the now-redundant &apos; replacement in KuGou's normalize().

Fixes #2816