### PR TITLE
fix: mute state not resetting after exiting Listen Together

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -276,11 +276,17 @@ class MusicService :
     val isMuted = MutableStateFlow(false)
 
     fun toggleMute() {
-        isMuted.value = !isMuted.value
+        val newMutedState = !isMuted.value
+        isMuted.value = newMutedState
+        // Immediately update player volume to ensure it takes effect
+        player.volume = if (newMutedState) 0f else playerVolume.value
     }
 
     fun setMuted(muted: Boolean) {
         isMuted.value = muted
+        // Immediately update player volume to ensure it takes effect
+        // This handles cases where the player reference may have changed
+        player.volume = if (muted) 0f else playerVolume.value
     }
 
 


### PR DESCRIPTION
When a guest mutes the music while in Listen Together mode and then exits the room, the mute state was persisting and affecting normal playback outside the session.

Root cause: The isMuted StateFlow was being set to false but the actual player.volume was not being updated because the combine flow might be operating on a stale player reference.

Changes:
- Save the current mute state when joining a room as guest
- Automatically unmute the player when leaving Listen Together
- Fix toggleMute() and setMuted() to immediately update player.volume in addition to updating the isMuted StateFlow, ensuring the volume change takes effect even if the player reference has changed