### PR TITLE
fix(playback): fix sleep timer resetting on song change during crossfade

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -2862,7 +2862,7 @@ class MusicService :
         
         crossfadeTriggerJob = scope.launch {
             delay(delayMs)
-            if (isActive && player.isPlaying && player.currentMediaItem?.mediaId == targetMediaId) {
+            if (isActive && player.isPlaying && player.currentMediaItem?.mediaId == targetMediaId && !sleepTimer.pauseWhenSongEnd) {
                 startCrossfade()
             }
         }
@@ -2957,6 +2957,7 @@ class MusicService :
         secondaryPlayer = null
         
         fadingPlayer?.removeListener(this)
+        fadingPlayer?.removeListener(sleepTimer)
         
         // Add listener to sync play/pause state
         player.addListener(object : Player.Listener {
@@ -2975,6 +2976,7 @@ class MusicService :
 
         nextPlayer.removeListener(secondaryPlayerListener)
         nextPlayer.addListener(this)
+        nextPlayer.addListener(sleepTimer)
         // Add PlaybackStatsListener to the new player for history tracking
         nextPlayer.addAnalyticsListener(PlaybackStatsListener(false, this@MusicService))
         
@@ -3025,6 +3027,7 @@ class MusicService :
         fadingPlayer?.release()
         fadingPlayer = null
         isCrossfading = false
+        sleepTimer.notifySongTransition()
     }
 
     companion object {

--- a/app/src/main/kotlin/com/metrolist/music/playback/SleepTimer.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/SleepTimer.kt
@@ -34,7 +34,9 @@ class SleepTimer(
         sleepTimerJob = null
         if (minute == -1) {
             pauseWhenSongEnd = true
+            triggerTime = -1L
         } else {
+            pauseWhenSongEnd = false
             triggerTime = System.currentTimeMillis() + minute.minutes.inWholeMilliseconds
             sleepTimerJob =
                 scope.launch {
@@ -42,6 +44,18 @@ class SleepTimer(
                     player.pause()
                     triggerTime = -1L
                 }
+        }
+    }
+
+    /**
+     * Notify the sleep timer that a song transition has occurred outside of normal
+     * player callbacks (e.g. during crossfade player swap). If "end of song" mode
+     * is active, this will pause the player and deactivate the timer.
+     */
+    fun notifySongTransition() {
+        if (pauseWhenSongEnd) {
+            pauseWhenSongEnd = false
+            player.pause()
         }
     }
 


### PR DESCRIPTION
## Summary
Fixed an issue where the Sleep Timer would reset or fail to trigger when Crossfade was enabled.
## Changes
- **Re-registered SleepTimer listener:** The `SleepTimer` is now correctly removed from the old player and added to the new player during the crossfade player swap. This ensures it continues to receive playback events on the active player.
- **Handled Crossfade Completion:** Added a notification to `SleepTimer` when a crossfade finishes. This ensures "End of Song" mode correctly pauses playback when the transition completes.
- **prevented Crossfade in End-of-Song Mode:** Modified `MusicService` to skip starting a crossfade if the "End of Song" timer is active. This ensures the song plays to its natural conclusion and stops there, avoiding overlap and transition issues.
- **State Management:** Updated `SleepTimer.start()` to mutually exclude timed mode and end-of-song mode, preventing stale state where both might appear active.
## Testing
- Verified that "End of Song" mode now correctly pauses playback at the end of the track, even with crossfade enabled in settings (crossfade is skipped for this specific action).
- Verified that timed sleep timer continues to work across track changes.
## Issues
Closes #2749