### PR TITLE
fix: use Android-compatible NewPipeExtractor fork

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ junit = "4.13.2"
 timber = "5.0.1"
 materialKolor = "4.1.1"
 kuromojiIpadic = "0.9.0"
-newpipeextractor = "c1336db"
+newpipeextractor = "8885892764428a3f20eaec014dcc37a21cc209f5"
 tinypinyin = "2.0.3"
 mlkit = "17.0.6"
 protobuf = "4.33.5"
@@ -108,7 +108,7 @@ junit = { module = "junit:junit", version.ref = "junit" }
 
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 
-newpipeextractor = { module = "com.github.TeamNewPipe:NewPipeExtractor", version.ref = "newpipeextractor" }
+newpipeextractor = { module = "com.github.mostafaalagamy:NewPipeExtractor", version.ref = "newpipeextractor" }
 
 kuromoji-ipadic = { module = "com.atilika.kuromoji:kuromoji-ipadic", version.ref = "kuromojiIpadic" }
 tinypinyin = { module = "com.github.promeG:tinypinyin", version.ref = "tinypinyin" }


### PR DESCRIPTION
Switch to mostafaalagamy/NewPipeExtractor fork (commit 8885892) which uses the older URLDecoder.decode(String, String) and URLEncoder.encode(String, String) APIs that work on all Android versions, including Android 10, 11, 12.

The upstream NewPipeExtractor uses URLDecoder.decode(String, Charset) which is only available on Android 13+ (API 33), causing: java.lang.NoSuchMethodError: No static method decode(Ljava/lang/String; Ljava/nio/charset/Charset;)Ljava/lang/String; in class Ljava/net/URLDecoder

This fixes app crashes when downloading songs on devices running Android 10 (API 29), 11 (API 30), and 12 (API 31/32).