### PR TITLE
feat(playback): increase crossfade duration limit to 15 seconds

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
@@ -300,8 +300,8 @@ fun PlayerSettings(
                                 Slider(
                                     value = crossfadeDuration,
                                     onValueChange = onCrossfadeDurationChange,
-                                    valueRange = 1f..12f,
-                                    steps = 11
+                                    valueRange = 1f..15f,
+                                    steps = 14
                                 )
                             }
                         }


### PR DESCRIPTION
**Problem**
User request to extend crossfade duration beyond current 12 second limit.

**Cause**
PlayerSettings.kt line 303 enforces valueRange = 1f..12f with 11 steps.

**Solution**
Changed valueRange to 1f..15f with 14 steps.

**Testing**
Syntax validated. No compilation errors.

Closes #2839