### PR TITLE
feat(ui): hide history button when listen history is paused and empty

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -136,6 +136,7 @@ import com.metrolist.music.constants.MiniPlayerBottomSpacing
 import com.metrolist.music.constants.MiniPlayerHeight
 import com.metrolist.music.constants.NavigationBarAnimationSpec
 import com.metrolist.music.constants.NavigationBarHeight
+import com.metrolist.music.constants.PauseListenHistoryKey
 import com.metrolist.music.constants.PauseSearchHistoryKey
 import com.metrolist.music.constants.PureBlackKey
 import com.metrolist.music.constants.SYSTEM_DEFAULT
@@ -759,6 +760,12 @@ class MainActivity : ComponentActivity() {
 
                 var showAccountDialog by remember { mutableStateOf(false) }
 
+                val pauseListenHistory by rememberPreference(PauseListenHistoryKey, defaultValue = false)
+                val eventCount by database.eventCount().collectAsState(initial = 0)
+                val showHistoryButton = remember(pauseListenHistory, eventCount) {
+                    !(pauseListenHistory && eventCount == 0)
+                }
+
                 val baseBg = if (pureBlack) Color.Black else MaterialTheme.colorScheme.surfaceContainer
 
                 CompositionLocalProvider(
@@ -789,11 +796,13 @@ class MainActivity : ComponentActivity() {
                                             )
                                         },
                                         actions = {
-                                            IconButton(onClick = { navController.navigate("history") }) {
-                                                Icon(
-                                                    painter = painterResource(R.drawable.history),
-                                                    contentDescription = stringResource(R.string.history)
-                                                )
+                                            if (showHistoryButton) {
+                                                IconButton(onClick = { navController.navigate("history") }) {
+                                                    Icon(
+                                                        painter = painterResource(R.drawable.history),
+                                                        contentDescription = stringResource(R.string.history)
+                                                    )
+                                                }
                                             }
                                             IconButton(onClick = { navController.navigate("stats") }) {
                                                 Icon(

--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -1145,6 +1145,9 @@ interface DatabaseDao {
     @Query("SELECT * FROM event ORDER BY rowId ASC LIMIT 1")
     fun firstEvent(): Flow<EventWithSong?>
 
+    @Query("SELECT COUNT(*) FROM event")
+    fun eventCount(): Flow<Int>
+
     @Transaction
     @Query("DELETE FROM event")
     fun clearListenHistory()


### PR DESCRIPTION
**Problem**
History button remains visible when listening history is paused and empty.

**Cause**
No conditional logic to hide the button based on listen history state.

**Solution**
Added eventCount() query in DatabaseDao to count listen history events.
In MainActivity, added conditional rendering that hides history button when PauseListenHistoryKey is true AND eventCount is 0.

**Testing**
Syntax validated. No compilation errors.

Closes #270