### PR TITLE
Navigate to playlist immediately after creation

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/CreatePlaylistDialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/CreatePlaylistDialog.kt
@@ -44,6 +44,7 @@ fun CreatePlaylistDialog(
     onDismiss: () -> Unit,
     initialTextFieldValue: String? = null,
     allowSyncing: Boolean = true,
+    onPlaylistCreated: ((String) -> Unit)? = null,
 ) {
     val database = LocalDatabase.current
     val coroutineScope = rememberCoroutineScope()
@@ -67,16 +68,18 @@ fun CreatePlaylistDialog(
                     return@launch
                 } else null
 
+                val playlistEntity = PlaylistEntity(
+                    name = playlistName,
+                    browseId = browseId,
+                    bookmarkedAt = LocalDateTime.now(),
+                    isEditable = true,
+                )
+                
                 database.query {
-                    insert(
-                        PlaylistEntity(
-                            name = playlistName,
-                            browseId = browseId,
-                            bookmarkedAt = LocalDateTime.now(),
-                            isEditable = true,
-                        )
-                    )
+                    insert(playlistEntity)
                 }
+
+                onPlaylistCreated?.invoke(playlistEntity.id)
             }
         },
         extraContent = {

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPlaylistsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPlaylistsScreen.kt
@@ -206,7 +206,11 @@ fun LibraryPlaylistsScreen(
         CreatePlaylistDialog(
             onDismiss = { showCreatePlaylistDialog = false },
             initialTextFieldValue = initialTextFieldValue,
-            allowSyncing = allowSyncing
+            allowSyncing = allowSyncing,
+            onPlaylistCreated = { playlistId ->
+                showCreatePlaylistDialog = false
+                navController.navigate("local_playlist/$playlistId")
+            }
         )
     }
 


### PR DESCRIPTION
**Problem**
After creating a new playlist, users must manually navigate to find it in the library, disrupting workflow continuity.

**Cause**
CreatePlaylistDialog does not provide navigation callback after playlist creation.

**Solution**
Added onPlaylistCreated callback parameter to CreatePlaylistDialog.
Modified LibraryPlaylistsScreen to navigate to the newly created playlist immediately using navController.navigate("local_playlist/$playlistId").
Playlist entity now created before database insertion to capture the ID for navigation.

**Testing**
Syntax validated. No compilation errors.
Workflow tested - playlist creation now immediately navigates to the new playlist.

Closes #2826