### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Problem
+<!-- Describe the issue or limitation this PR addresses -->
+
+## Cause
+<!-- Explain the root cause of the problem -->
+
+## Solution
+<!-- List the changes made to fix the issue -->
+- 
+
+## Testing
+<!-- Describe how the changes were tested -->
+
+Closes #


### PR DESCRIPTION
Problem
Contributors submit PRs with varying formats and often missing important information like test results, issue references, or clear explanations of changes.

Cause
The repository lacks a standardized PR template to guide contributors on what information to include in their pull requests.

Solution
- Added pull_request_template.md in .github directory
- Template includes sections for Problem, Cause, Solution, Testing, and issue references
- Follows the concise format already being used in recent PRs

Testing
Template file created successfully. Future PRs will automatically populate with this template when opened on GitHub.

Closes no specific issue (workflow improvement)