### PR TITLE
feat(player): add resume on bluetooth connect

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -34,6 +34,7 @@ val HidePlayerThumbnailKey = booleanPreferencesKey("hidePlayerThumbnail")
 val CropAlbumArtKey = booleanPreferencesKey("cropAlbumArt")
 val SeekExtraSeconds = booleanPreferencesKey("seekExtraSeconds")
 val PauseOnMute = booleanPreferencesKey("pauseOnMute")
+val ResumeOnBluetoothConnectKey = booleanPreferencesKey("resumeOnBluetoothConnect")
 val KeepScreenOn = booleanPreferencesKey("keepScreenOn")
 val DeveloperModeKey = booleanPreferencesKey("developerMode")
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
@@ -57,6 +57,7 @@ import com.metrolist.music.constants.PersistentQueueKey
 import com.metrolist.music.constants.PersistentShuffleAcrossQueuesKey
 import com.metrolist.music.constants.PreventDuplicateTracksInQueueKey
 import com.metrolist.music.constants.RememberShuffleAndRepeatKey
+import com.metrolist.music.constants.ResumeOnBluetoothConnectKey
 import com.metrolist.music.constants.SeekExtraSeconds
 import com.metrolist.music.constants.ShufflePlaylistFirstKey
 import com.metrolist.music.constants.SimilarContent
@@ -169,6 +170,10 @@ fun PlayerSettings(
     )
     val (pauseOnMute, onPauseOnMuteChange) = rememberPreference(
         PauseOnMute,
+        defaultValue = false
+    )
+    val (resumeOnBluetoothConnect, onResumeOnBluetoothConnectChange) = rememberPreference(
+        ResumeOnBluetoothConnectKey,
         defaultValue = false
     )
     val (keepScreenOn, onKeepScreenOnChange) = rememberPreference(
@@ -747,6 +752,26 @@ fun PlayerSettings(
                         )
                     },
                     onClick = { onPauseOnMuteChange(!pauseOnMute) }
+                ),
+                Material3SettingsItem(
+                    icon = painterResource(R.drawable.bluetooth),
+                    title = { Text(stringResource(R.string.resume_on_bluetooth_connect)) },
+                    trailingContent = {
+                        Switch(
+                            checked = resumeOnBluetoothConnect,
+                            onCheckedChange = onResumeOnBluetoothConnectChange,
+                            thumbContent = {
+                                Icon(
+                                    painter = painterResource(
+                                        id = if (resumeOnBluetoothConnect) R.drawable.check else R.drawable.close
+                                    ),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(SwitchDefaults.IconSize)
+                                )
+                            }
+                        )
+                    },
+                    onClick = { onResumeOnBluetoothConnectChange(!resumeOnBluetoothConnect) }
                 ),
                 Material3SettingsItem(
                     icon = painterResource(R.drawable.screenshot),

--- a/app/src/main/res/drawable/bluetooth.xml
+++ b/app/src/main/res/drawable/bluetooth.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L11,14.41V22h1l5.71-5.71L13.41,12L17.71,7.71z M13,5.83l1.88,1.88L13,9.59V5.83z M13,18.17v-3.76l1.88,1.88L13,18.17z"/>
+</vector>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -254,6 +254,7 @@
     <string name="disable_load_more_when_repeat_all">Disable load more when repeat all</string>
     <string name="disable_load_more_when_repeat_all_desc">Don\'t auto load more songs and similar content when repeat all mode is enabled</string>
     <string name="pause_music_when_media_is_muted">Pause music when media is muted</string>
+    <string name="resume_on_bluetooth_connect">Resume on Bluetooth connect</string>
     <string name="keep_screen_on_when_player_is_expanded">Keep screen on when player is expanded</string>
 
     <string name="crossfade">Crossfade</string>


### PR DESCRIPTION
feat(player): add resume on bluetooth connect
## Summary
This PR introduces a new feature that allows playback to automatically resume when a Bluetooth audio device is connected. This setting is disabled by default and can be toggled in the Player & Audio settings under the "Misc" section.
## Changes
- **Settings:** Added "Resume on Bluetooth connect" toggle in `PlayerSettings.kt`.
- **Logic:** Implemented `AudioDeviceCallback` in `MusicService.kt` to detect Bluetooth A2DP/SCO connections and resume playback if the player is ready.
- **Resources:** Added `bluetooth.xml` vector icon and new string resource `resume_on_bluetooth_connect`.
- **Preferences:** Added `ResumeOnBluetoothConnectKey` to `PreferenceKeys.kt`.
## How to Test
1. Go to Settings -> Player & Audio.
2. Scroll down to the "Misc" section.
3. Enable "Resume on Bluetooth connect".
4. Play a song and pause it.
5. Connect a Bluetooth audio device (headphones, speaker, etc.).
6. Verify that playback resumes automatically.
7. Disable the setting and verify that playback does *not* resume upon connection.