### PR TITLE
fix: artist display in search suggestions for music videos

### DIFF
--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/SearchSuggestionPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/SearchSuggestionPage.kt
@@ -7,6 +7,7 @@ import com.metrolist.innertube.models.ArtistItem
 import com.metrolist.innertube.models.MusicResponsiveListItemRenderer
 import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.models.YTItem
+import com.metrolist.innertube.models.clean
 import com.metrolist.innertube.models.oddElements
 import com.metrolist.innertube.models.splitBySeparator
 
@@ -14,6 +15,14 @@ object SearchSuggestionPage {
     fun fromMusicResponsiveListItemRenderer(renderer: MusicResponsiveListItemRenderer): YTItem? {
         return when {
             renderer.isSong -> {
+                val secondaryLine =
+                    renderer.flexColumns
+                        .getOrNull(1)
+                        ?.musicResponsiveListItemFlexColumnRenderer
+                        ?.text
+                        ?.runs
+                        ?.splitBySeparator()
+                        ?.clean()
                 SongItem(
                     id = renderer.playlistItemData?.videoId ?: return null,
                     title =
@@ -25,13 +34,8 @@ object SearchSuggestionPage {
                             ?.firstOrNull()
                             ?.text ?: return null,
                     artists =
-                        renderer.flexColumns
-                            .getOrNull(1)
-                            ?.musicResponsiveListItemFlexColumnRenderer
-                            ?.text
-                            ?.runs
-                            ?.splitBySeparator()
-                            ?.getOrNull(1)
+                        secondaryLine
+                            ?.firstOrNull()
                             ?.oddElements()
                             ?.map {
                                 Artist(


### PR DESCRIPTION
Previously, search suggestion results for some music videos showed view count instead of artist name. This was caused by hardcoded index access (getOrNull(1)) in the secondary line parser.

The fix uses the clean() function which intelligently determines whether to skip the first element based on whether it has a navigation endpoint or contains artist separators (comma/ampersand). This ensures artist information is correctly extracted regardless of the metadata structure.