### PR TITLE
feat(appearance): Add display density scaling for comfortable viewing

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -186,6 +186,12 @@
                 android:resource="@xml/provider_paths" />
         </provider>
 
+        <provider
+            android:name="com.dpi.DensityScaler"
+            android:authorities="${applicationId}.com.dpi.DensityScaler"
+            android:enabled="true"
+            android:exported="false" />
+
         <activity
             android:name="com.yalantis.ucrop.UCropActivity"
             android:exported="false"

--- a/app/src/main/kotlin/com/dpi/BaseLifecycleContentProvider.kt
+++ b/app/src/main/kotlin/com/dpi/BaseLifecycleContentProvider.kt
@@ -1,0 +1,36 @@
+package com.dpi
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+
+/**
+ * Base class for lifecycle management ContentProvider with default implementations.
+ * This class exists solely to leverage ContentProvider's early initialization lifecycle.
+ */
+abstract class BaseLifecycleContentProvider : ContentProvider() {
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<String>?): Int = 0
+
+    override fun getType(uri: Uri): String? = null
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+    override fun onCreate(): Boolean = true
+
+    override fun query(
+        uri: Uri,
+        projection: Array<String>?,
+        selection: String?,
+        selectionArgs: Array<String>?,
+        sortOrder: String?
+    ): Cursor? = null
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<String>?
+    ): Int = 0
+}

--- a/app/src/main/kotlin/com/dpi/DensityConfiguration.kt
+++ b/app/src/main/kotlin/com/dpi/DensityConfiguration.kt
@@ -1,0 +1,87 @@
+package com.dpi
+
+import android.annotation.SuppressLint
+import android.app.Activity
+import android.content.Context
+import android.content.res.Configuration
+import android.content.res.Resources
+import android.util.Log
+import timber.log.Timber
+import kotlin.math.roundToInt
+
+/**
+ * Configuration class for adjusting screen density dynamically.
+ * Applies density scaling to the entire application and maintains it across activity lifecycle events.
+ */
+internal class DensityConfiguration(
+    private val densityScale: Float
+) : ActivityLifecycleManager() {
+
+    private var originalDensityDpi: Int = 0
+
+    /**
+     * Applies the density scaling to the application context.
+     * This method should be called once during initialization.
+     */
+    @SuppressLint("LogNotTimber")
+    fun applyDensityScaling(context: Context) {
+        if (densityScale == 1.0f) return
+
+        try {
+            onCreate()
+            val resources = context.resources
+            val config = Configuration(resources.configuration)
+            originalDensityDpi = config.densityDpi
+            updateDensityDpi(config, resources)
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to apply configuration", e)
+        }
+    }
+
+    /**
+     * Updates the density DPI in the configuration and applies it to resources.
+     */
+    private fun updateDensityDpi(config: Configuration, resources: Resources) {
+        val newDensityDpi = (originalDensityDpi * densityScale).roundToInt()
+        config.densityDpi = newDensityDpi
+        Timber.tag(TAG).i("Updated densityDpi to: $newDensityDpi")
+        @Suppress("DEPRECATION")
+        resources.updateConfiguration(config, resources.displayMetrics)
+    }
+
+    /**
+     * Reapply density scaling when an activity is created.
+     */
+    override fun onActivityCreated(activity: Activity) {
+        applyDensityToActivity(activity)
+    }
+
+    /**
+     * Reapply density scaling when an activity is resumed.
+     */
+    override fun onActivityResumed(activity: Activity) {
+        applyDensityToActivity(activity)
+    }
+
+    /**
+     * Reapply density scaling when an activity is started.
+     */
+    override fun onActivityStarted(activity: Activity) {
+        applyDensityToActivity(activity)
+    }
+
+    /**
+     * Applies the density configuration to a specific activity's resources.
+     */
+    private fun applyDensityToActivity(activity: Activity) {
+        try {
+            updateDensityDpi(activity.resources.configuration, activity.resources)
+        } catch (e: Exception) {
+            Timber.tag(TAG).w(e, "Failed to update density for activity")
+        }
+    }
+
+    companion object {
+        private val TAG = DensityConfiguration::class.java.simpleName
+    }
+}

--- a/app/src/main/kotlin/com/dpi/DensityScaler.kt
+++ b/app/src/main/kotlin/com/dpi/DensityScaler.kt
@@ -1,0 +1,45 @@
+package com.dpi
+
+import android.content.Context
+import timber.log.Timber
+
+/**
+ * DensityScaler - Main entry point for screen density scaling.
+ *
+ * Reads scale factor from user preferences with default of 1.0f (100% native).
+ *
+ * Supported scale factors:
+ * - 1.0f (100%) - Native density (default)
+ * - 0.75f (75%) - Compact
+ * - 0.65f (65%) - Very Compact
+ * - 0.55f (55%) - Ultra Compact
+ */
+class DensityScaler : BaseLifecycleContentProvider() {
+
+    override fun onCreate(): Boolean {
+        val context = context ?: return false
+        val scaleFactor = getScaleFactorFromPreferences(context)
+        DensityConfiguration(scaleFactor).applyDensityScaling(context)
+        return true
+    }
+
+    companion object {
+        private const val PREFS_NAME = "metrolist_settings"
+        private const val KEY_DENSITY_SCALE = "density_scale_factor"
+        private const val DEFAULT_SCALE_FACTOR = 1.0f
+
+        /**
+         * Reads the density scale factor from SharedPreferences.
+         * Uses SharedPreferences instead of DataStore for synchronous access during ContentProvider initialization.
+         */
+        private fun getScaleFactorFromPreferences(context: Context): Float {
+            return try {
+                val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                prefs.getFloat(KEY_DENSITY_SCALE, DEFAULT_SCALE_FACTOR)
+            } catch (e: Exception) {
+                Timber.tag("DensityScaler").w(e, "Failed to read scale factor from preferences")
+                DEFAULT_SCALE_FACTOR
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -21,6 +21,21 @@ val DarkModeKey = stringPreferencesKey("darkMode")
 val PureBlackKey = booleanPreferencesKey("pureBlack")
 val PureBlackMiniPlayerKey = booleanPreferencesKey("pureBlackMiniPlayer")
 val MiniPlayerOutlineKey = booleanPreferencesKey("miniPlayerOutline")
+val DensityScaleKey = floatPreferencesKey("density_scale_factor")
+val CustomDensityScaleKey = floatPreferencesKey("custom_density_scale_value")
+
+enum class DensityScale(val value: Float, val label: String) {
+    NATIVE(1.0f, "Native (100%)"),
+    SLIGHTLY_COMPACT(0.85f, "Slightly Compact (85%)"),
+    COMPACT(0.75f, "Compact (75%)"),
+    VERY_COMPACT(0.65f, "Very Compact (65%)"),
+    ULTRA_COMPACT(0.55f, "Ultra Compact (55%)");
+
+    companion object {
+        fun fromValue(value: Float): DensityScale = entries.find { it.value == value } ?: NATIVE
+    }
+}
+
 val DefaultOpenTabKey = stringPreferencesKey("defaultOpenTab")
 val SlimNavBarKey = booleanPreferencesKey("slimNavBar")
 val GridItemsSizeKey = stringPreferencesKey("gridItemSize")

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -121,6 +121,10 @@
     <string name="primary_color_style">Primary color</string>
     <string name="tertiary_color_style">Tertiary color</string>
     <string name="secondary_color_style">Secondary</string>
+    <string name="display_density">Display density</string>
+    <string name="restart">Restart</string>
+    <string name="restart_required">Restart required</string>
+    <string name="density_restart_message">The display density change will take effect after restarting the app. Do you want to restart now?</string>
     <string name="enable_wavy_slider">Enable wavy slider</string>
     <string name="wavy">Wavy</string>
     <string name="enable_swipe_thumbnail">Enable swipe to change song</string>


### PR DESCRIPTION
## Summary
- Adds display density scaling option in Settings > Appearance for more comfortable viewing on small screens
- Options: Native (100%), Slightly Compact (85%), Compact (75%), Very Compact (65%), Ultra Compact (55%)
- Changes require app restart to take effect

## Credits
Based on https://github.com/alltechdev/DensityScalerKotlin which was forked from https://github.com/DarthFlip/DensityScaler

## Test plan
- [ ] Go to Settings > Appearance > Misc > Display density
- [ ] Select different density options
- [ ] Restart app when prompted
- [ ] Verify UI scales appropriately



https://github.com/user-attachments/assets/984d476a-a8a6-45aa-8a59-ec5774a29009

