### PR TITLE
fix: Restart app after login to apply credentials immediately

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AboutScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AboutScreen.kt
@@ -254,6 +254,17 @@ fun AboutScreen(
             }
         )
 
+        Spacer(Modifier.height(8.dp))
+
+        Text(
+            text = "Avrumi Sternheim",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.secondary,
+            modifier = Modifier.clickable {
+                uriHandler.openUri("https://github.com/alltechdev")
+            }
+        )
+
         Spacer(Modifier.height(32.dp))
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AccountSettings.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
+import android.content.Intent
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
 import coil3.compose.AsyncImage
@@ -206,6 +207,11 @@ fun AccountSettings(
                             it.startsWith("***ACCOUNT CHANNEL HANDLE*** =") -> onAccountChannelHandleChange(it.substringAfter("="))
                         }
                     }
+                    // Restart app to apply new credentials throughout
+                    val intent = context.packageManager.getLaunchIntentForPackage(context.packageName)
+                    intent?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                    context.startActivity(intent)
+                    Runtime.getRuntime().exit(0)
                 },
                 onDismiss = { showTokenEditor = false },
                 singleLine = false,


### PR DESCRIPTION
## Summary
- Add app restart after advanced token login to ensure all auth data is applied throughout the app

## Test plan
- [x] Login via WebView - app restarts and uses WEB_REMIX immediately
- [ ] Login via advanced token editor - app restarts and applies credentials