### PR TITLE
fix(crossfade): prevent ClassCastException on duration key migration

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -110,7 +110,7 @@ val StopMusicOnTaskClearKey = booleanPreferencesKey("stopMusicOnTaskClear")
 val ShufflePlaylistFirstKey = booleanPreferencesKey("shufflePlaylistFirst")
 val PreventDuplicateTracksInQueueKey = booleanPreferencesKey("preventDuplicateTracksInQueue")
 val CrossfadeEnabledKey = booleanPreferencesKey("crossfadeEnabled")
-val CrossfadeDurationKey = floatPreferencesKey("crossfadeDuration")
+val CrossfadeDurationKey = floatPreferencesKey("crossfadeDurationFloat")
 val CrossfadeGaplessKey = booleanPreferencesKey("crossfadeGapless")
 
 val MaxImageCacheSizeKey = intPreferencesKey("maxImageCacheSize")


### PR DESCRIPTION
# Summary
Fix startup crash caused by `crossfadeDuration` preferencekey

# The crash in question:
```
java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Float
	at xb.r.emit(r8-map-id-e53347fef2dd62b6a297148c04494485c69418fed07b686f9cfa840b880dab0f:1052)
	at we.t.invoke(r8-map-id-e53347fef2dd62b6a297148c04494485c69418fed07b686f9cfa840b880dab0f:5)
	at we.s.e(r8-map-id-e53347fef2dd62b6a297148c04494485c69418fed07b686f9cfa840b880dab0f:137)
	at we.s.emit(r8-map-id-e53347fef2dd62b6a297148c04494485c69418fed07b686f9cfa840b880dab0f:1)
	at tc.b.invokeSuspend(r8-map-id-e53347fef2dd62b6a297148c04494485c69418fed07b686f9cfa840b880dab0f:1001)
	at yd.a.resumeWith(r8-map-id-e53347fef2dd62b6a297148c04494485c69418fed07b686f9cfa840b880dab0f:9)
	at se.m0.run(r8-map-id-e53347fef2dd62b6a297148c04494485c69418fed07b686f9cfa840b880dab0f:114)
	at android.os.Handler.handleCallback(Handler.java:995)
	at android.os.Handler.dispatchMessage(Handler.java:103)
	at android.os.Looper.loopOnce(Looper.java:273)
	at android.os.Looper.loop(Looper.java:363)
	at android.app.ActivityThread.main(ActivityThread.java:10060)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:632)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:975)
	Suppressed: ye.f: [v1{Cancelling}@661003e, Dispatchers.Main]
```
One line of code in a PR is a little... Eh?