### PR TITLE
feat(changelog): implement changelog screen and auto-show on update

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -209,6 +209,7 @@ val PreferredLyricsProviderKey = stringPreferencesKey("lyricsProvider")
 val QueueEditLockKey = booleanPreferencesKey("queueEditLock")
 val ShowWrappedCardKey = booleanPreferencesKey("show_wrapped_card")
 val WrappedSeenKey = booleanPreferencesKey("wrapped_seen")
+val LastSeenVersionKey = stringPreferencesKey("lastSeenVersion")
 val RandomizeHomeOrderKey = booleanPreferencesKey("randomizeHomeOrder")
 
 val ShowLikedPlaylistKey = booleanPreferencesKey("show_liked_playlist")

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/ChangelogScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/ChangelogScreen.kt
@@ -1,0 +1,281 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.ui.screens.settings
+
+import androidx.compose.animation.*
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import com.metrolist.music.R
+import com.metrolist.music.BuildConfig
+import com.metrolist.music.utils.ReleaseInfo
+import com.metrolist.music.utils.Updater
+
+private val markdownLinkRegex = Regex("(@[a-zA-Z0-9_-]+)|(https?://[\\w-]+(\\.[\\w-]+)+[\\w.,@?^=%&:/~+#-]*[\\w@?^=%&/~+#-])")
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun ChangelogScreen(
+    onDismiss: () -> Unit
+) {
+    var releases by remember { mutableStateOf<List<ReleaseInfo>>(emptyList()) }
+    var isLoading by remember { mutableStateOf(true) }
+    val uriHandler = LocalUriHandler.current
+
+    LaunchedEffect(Unit) {
+        Updater.getAllReleases().onSuccess { allReleases ->
+            releases = allReleases.filter { release ->
+                Updater.compareVersions(BuildConfig.VERSION_NAME, release.tagName) >= 0
+            }
+            isLoading = false
+        }.onFailure {
+            isLoading = false
+        }
+    }
+
+    val sheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = false
+    )
+
+    val showFab by remember {
+        derivedStateOf { sheetState.targetValue != SheetValue.Hidden }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+        dragHandle = { BottomSheetDefaults.DragHandle() }
+    ) {
+        Box(modifier = Modifier.fillMaxWidth()) {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                contentPadding = PaddingValues(bottom = 80.dp)
+            ) {
+                item {
+                    Text(
+                        text = stringResource(R.string.changelog),
+                        style = MaterialTheme.typography.displaySmall,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.fillMaxWidth(),
+                        textAlign = TextAlign.Center
+                    )
+                }
+
+                item {
+                    val density = LocalDensity.current
+                    val stroke = remember(density) {
+                        Stroke(width = with(density) { 3.dp.toPx() }, cap = StrokeCap.Round)
+                    }
+                    LinearWavyProgressIndicator(
+                        progress = { 1f },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 32.dp),
+                        color = MaterialTheme.colorScheme.primary,
+                        trackColor = Color.Transparent,
+                        stroke = stroke,
+                        trackStroke = stroke,
+                        amplitude = { 1f }
+                    )
+                }
+
+                if (isLoading) {
+                    item {
+                        Box(modifier = Modifier.fillMaxWidth().height(200.dp), contentAlignment = Alignment.Center) {
+                            CircularProgressIndicator()
+                        }
+                    }
+                } else if (releases.isEmpty()) {
+                    item {
+                        Box(modifier = Modifier.fillMaxWidth().height(200.dp), contentAlignment = Alignment.Center) {
+                            Text(text = stringResource(R.string.changelog_empty))
+                        }
+                    }
+                } else {
+                    items(releases) { release ->
+                        ReleaseItem(release)
+                    }
+                }
+            }
+
+            androidx.compose.animation.AnimatedVisibility(
+                visible = showFab,
+                enter = fadeIn() + slideInVertically { it },
+                exit = fadeOut() + slideOutVertically { it },
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(16.dp)
+            ) {
+                val githubReleasesUrl = stringResource(R.string.github_releases_url)
+                ExtendedFloatingActionButton(
+                    onClick = { uriHandler.openUri(githubReleasesUrl) },
+                    icon = { Icon(painterResource(R.drawable.github), contentDescription = null, modifier = Modifier.size(24.dp)) },
+                    text = { Text(stringResource(R.string.view_on_github)) },
+                    containerColor = MaterialTheme.colorScheme.onPrimary,
+                    contentColor = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun ReleaseItem(release: ReleaseInfo) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Surface(
+                color = MaterialTheme.colorScheme.secondaryContainer,
+                shape = CircleShape
+            ) {
+                Text(
+                    text = release.tagName,
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+            }
+
+            Text(
+                text = release.releaseDate.split("T").firstOrNull() ?: "",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainer
+            ),
+            shape = RoundedCornerShape(16.dp)
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                MarkdownText(release.description)
+            }
+        }
+    }
+}
+
+@Suppress("DEPRECATION")
+@Composable
+fun MarkdownText(text: String) {
+    val lines = text.split("\n")
+    val uriHandler = LocalUriHandler.current
+
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        lines.filter { it.isNotBlank() }.forEach { line ->
+            val trimmedLine = line.trim()
+
+            if (trimmedLine.startsWith("#")) {
+                val level = trimmedLine.takeWhile { it == '#' }.length
+                val headerText = trimmedLine.substring(level).trim()
+                Box(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp), contentAlignment = Alignment.Center) {
+                    Text(
+                        text = headerText,
+                        style = when (level) {
+                            1 -> MaterialTheme.typography.headlineMedium
+                            2 -> MaterialTheme.typography.headlineSmall
+                            else -> MaterialTheme.typography.titleMedium
+                        },
+                        fontWeight = FontWeight.Bold,
+                        textAlign = TextAlign.Center
+                    )
+                }
+            } else {
+                val isListItem = trimmedLine.startsWith("- ") || trimmedLine.startsWith("* ")
+                val contentText = if (isListItem) {
+                    trimmedLine.substring(2).trim()
+                } else {
+                    trimmedLine
+                }
+
+                val annotatedString = buildAnnotatedString {
+                    var lastIndex = 0
+                    markdownLinkRegex.findAll(contentText).forEach { result ->
+                        append(contentText.substring(lastIndex, result.range.first))
+                        
+                        val match = result.value
+                        val link = if (match.startsWith("@")) "https://github.com/${match.substring(1)}" else match
+                        
+                        pushStringAnnotation(tag = "URL", annotation = link)
+                        withStyle(style = SpanStyle(
+                            color = MaterialTheme.colorScheme.primary, 
+                            fontWeight = if (match.startsWith("@")) FontWeight.Bold else FontWeight.Normal,
+                            textDecoration = if (match.startsWith("@")) TextDecoration.None else TextDecoration.Underline
+                        )) {
+                            append(match)
+                        }
+                        pop()
+                        lastIndex = result.range.last + 1
+                    }
+                    append(contentText.substring(lastIndex))
+                }
+
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    Row(modifier = Modifier.fillMaxWidth()) {
+                        if (isListItem) {
+                            Text(
+                                text = stringResource(R.string.list_bullet),
+                                modifier = Modifier.padding(end = 8.dp),
+                                style = MaterialTheme.typography.bodyLarge
+                            )
+                        }
+                        ClickableText(
+                            text = annotatedString,
+                            style = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurface),
+                            onClick = { offset ->
+                                annotatedString.getStringAnnotations(tag = "URL", start = offset, end = offset)
+                                    .firstOrNull()?.let { annotation ->
+                                        uriHandler.openUri(annotation.item)
+                                    }
+                            }
+                        )
+                    }
+                    
+                    if (isListItem) {
+                        Spacer(modifier = Modifier.height(4.dp))
+                        HorizontalDivider(
+                            thickness = 0.5.dp,
+                            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/SettingsScreen.kt
@@ -190,6 +190,14 @@ fun SettingsScreen(
                         onClick = { navController.navigate("settings/updater") }
                     )
                 )
+                val showChangelog = com.metrolist.music.LocalChangelogState.current
+                add(
+                    Material3SettingsItem(
+                        icon = painterResource(R.drawable.newspaper),
+                        title = { Text(stringResource(R.string.changelog)) },
+                        onClick = { showChangelog.value = true }
+                    )
+                )
                 add(
                     Material3SettingsItem(
                         icon = painterResource(R.drawable.info),

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/UpdaterSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/UpdaterSettings.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -60,6 +61,7 @@ fun UpdaterScreen(
     val (checkForUpdates, onCheckForUpdatesChange) = rememberPreference(CheckForUpdatesKey, true)
     val (updateNotifications, onUpdateNotificationsChange) = rememberPreference(UpdateNotificationsEnabledKey, true)
     
+    val context = LocalContext.current
     var isChecking by remember { mutableStateOf(false) }
     var updateAvailable by remember { mutableStateOf(false) }
     var latestVersion by remember { mutableStateOf<String?>(null) }
@@ -81,7 +83,7 @@ fun UpdaterScreen(
                         changelogContent = releaseInfo.description
                     }
                 }.onFailure {
-                    checkError = "Failed to check for updates: ${it.message}"
+                    checkError = context.getString(R.string.failed_to_check_updates, it.message ?: "Unknown error")
                 }
             }
             isChecking = false
@@ -110,13 +112,12 @@ fun UpdaterScreen(
 
         Spacer(Modifier.height(4.dp))
 
-        // Current Version Info
         Material3SettingsGroup(
-            title = "Current Version",
+            title = stringResource(R.string.current_version),
             items = listOf(
                 Material3SettingsItem(
                     title = {
-                        Text("Version: ${BuildConfig.VERSION_NAME}")
+                        Text(stringResource(R.string.version_format, BuildConfig.VERSION_NAME))
                     },
                     description = {
                         val arch = BuildConfig.ARCHITECTURE
@@ -129,9 +130,8 @@ fun UpdaterScreen(
         
         Spacer(Modifier.height(16.dp))
 
-        // Auto Update Settings
         Material3SettingsGroup(
-            title = "Update Settings",
+            title = stringResource(R.string.update_settings),
             items = buildList {
                 add(
                     Material3SettingsItem(
@@ -167,19 +167,18 @@ fun UpdaterScreen(
 
         Spacer(Modifier.height(16.dp))
 
-        // Manual Check
         Material3SettingsGroup(
-            title = "Check for Updates",
+            title = stringResource(R.string.check_for_updates_title),
             items = listOf(
                 Material3SettingsItem(
                     icon = painterResource(R.drawable.refresh),
                     title = { 
                         if (isChecking) {
-                            Text("Checking for updates...")
+                            Text(stringResource(R.string.checking_for_updates))
                         } else if (latestVersion != null) {
-                            Text("Latest: $latestVersion")
+                            Text(stringResource(R.string.latest_version_format, latestVersion!!))
                         } else {
-                            Text("Check for Updates")
+                            Text(stringResource(R.string.check_for_updates_button))
                         }
                     },
                     trailingContent = {
@@ -191,7 +190,7 @@ fun UpdaterScreen(
                         } else if (updateAvailable) {
                             Icon(
                                 painter = painterResource(R.drawable.download),
-                                contentDescription = "Update available",
+                                contentDescription = stringResource(R.string.update_available_title),
                                 tint = MaterialTheme.colorScheme.primary
                             )
                         }
@@ -219,7 +218,7 @@ fun UpdaterScreen(
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp)
             ) {
-                Text(if (showChangelog) "Hide Changelog" else "View Changelog")
+                Text(if (showChangelog) stringResource(R.string.hide_changelog) else stringResource(R.string.view_changelog))
             }
 
             if (showChangelog && changelogContent != null) {

--- a/app/src/main/kotlin/com/metrolist/music/utils/Updater.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/Updater.kt
@@ -45,7 +45,7 @@ object Updater {
      * Compares two version strings.
      * Returns: 1 if v1 > v2, -1 if v1 < v2, 0 if equal
      */
-    private fun compareVersions(v1: String, v2: String): Int {
+    fun compareVersions(v1: String, v2: String): Int {
         val v1Parts = v1.removePrefix("v").split(".").map { it.toIntOrNull() ?: 0 }
         val v2Parts = v2.removePrefix("v").split(".").map { it.toIntOrNull() ?: 0 }
         val maxLength = maxOf(v1Parts.size, v2Parts.size)

--- a/app/src/main/res/drawable/newspaper.xml
+++ b/app/src/main/res/drawable/newspaper.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M80,840L80,120L147,187L213,120L280,187L347,120L413,187L480,120L547,187L613,120L680,187L747,120L813,187L880,120L880,840L80,840ZM160,760L440,760L440,520L160,520L160,760ZM520,760L800,760L800,680L520,680L520,760ZM520,600L800,600L800,520L520,520L520,600ZM160,440L800,440L800,320L160,320L160,440Z"/>
+</vector>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -229,6 +229,21 @@
     <string name="open_app_settings_error">Couldn\'t open app settings</string>
 
     <string name="release_notes">Release notes</string>
+    <string name="changelog">Changelog</string>
+    <string name="changelog_empty">No changelogs available</string>
+    <string name="github_releases_url">https://github.com/MetrolistGroup/Metrolist/releases</string>
+    <string name="list_bullet">•</string>
+    <string name="view_on_github">View on GitHub</string>
+    <string name="current_version">Current version</string>
+    <string name="version_format">Version: %s</string>
+    <string name="update_settings">Update settings</string>
+    <string name="check_for_updates_title">Check for updates</string>
+    <string name="checking_for_updates">Checking for updates…</string>
+    <string name="latest_version_format">Latest: %s</string>
+    <string name="check_for_updates_button">Check for updates</string>
+    <string name="hide_changelog">Hide changelog</string>
+    <string name="view_changelog">View changelog</string>
+    <string name="failed_to_check_updates">Failed to check for updates: %s</string>
 
     <string name="all_time">All time</string>
     <string name="past_24_hours">Past 24 hours</string>


### PR DESCRIPTION
## Summary
This PR implements a Material 3 Changelog screen that notifies users of new features and fixes after an app update.
### Key Features
- **Auto-Show on Update**: Detects version changes and automatically presents the changelog to the user upon launch.
- **Material 3 Bottom Sheet**: A responsive changelog, also featuring GitHub-linked FAB alongside the entire feature.
- **Custom Markdown Parser**: A lightweight parser for GitHub release notes supporting headers, lists, and auto-linking for @mentions and URLs.
- **Settings**: Added a "Changelog" item in the Settings screen for manual access.
### Technical Improvements
- **Performance**: Optimized rendering by hoisting regex compilation out of the Compose phase.
- **Threading**: Migrated DataStore version checks to a non-blocking flow to ensure zero impact on app startup time.
- **Stability**: Used `rememberSaveable` to ensure the changelog state persists correctly across screen rotations.
### Verification Results
- Verified auto-show logic on both clean installations and version upgrades.
- Confirmed build succeeds via `./gradlew :app:assembleuniversalFossDebug`.
- Validated UI behavior across different screen orientations
### Screenshots
| Changelog Expanded | Changelog |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/e3708f1d-316c-47aa-a7c2-ca44285a3f93" width="300" /> | <img src="https://github.com/user-attachments/assets/b426c189-43ee-4974-a545-77f242933ed3" width="300" /> |