### PR TITLE
Fix: Crash when creating local or editable playlist

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/CreatePlaylistDialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/CreatePlaylistDialog.kt
@@ -36,6 +36,7 @@ import com.metrolist.music.extensions.isSyncEnabled
 import com.metrolist.music.utils.rememberPreference
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.LocalDateTime
 import java.util.logging.Logger
 
@@ -79,7 +80,9 @@ fun CreatePlaylistDialog(
                     insert(playlistEntity)
                 }
 
-                onPlaylistCreated?.invoke(playlistEntity.id)
+                withContext(Dispatchers.Main) {
+                    onPlaylistCreated?.invoke(playlistEntity.id)
+                }
             }
         },
         extraContent = {


### PR DESCRIPTION
Switch to Dispatchers.Main before invoking onPlaylistCreated callback in CreatePlaylistDialog. The callback updates Compose state and triggers navigation, both of which must run on the main thread. Running them from Dispatchers.IO caused IllegalStateException: setCurrentState must be called on the main thread.