### PR TITLE
fix(ui): use solid color for chips placeholder shimmer in HomeScreen

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/shimmer/ShimmerHost.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/shimmer/ShimmerHost.kt
@@ -28,22 +28,27 @@ fun ShimmerHost(
     modifier: Modifier = Modifier,
     horizontalAlignment: Alignment.Horizontal = Alignment.Start,
     verticalArrangement: Arrangement.Vertical = Arrangement.Top,
+    showGradient: Boolean = true,
     content: @Composable ColumnScope.() -> Unit,
 ) {
+    val baseModifier = modifier
+        .shimmer()
+        .graphicsLayer(alpha = 0.99f)
+
     Column(
         horizontalAlignment = horizontalAlignment,
         verticalArrangement = verticalArrangement,
-        modifier =
-        modifier
-            .shimmer()
-            .graphicsLayer(alpha = 0.99f)
-            .drawWithContent {
+        modifier = if (showGradient) {
+            baseModifier.drawWithContent {
                 drawContent()
                 drawRect(
                     brush = Brush.verticalGradient(listOf(Color.Black, Color.Transparent)),
                     blendMode = BlendMode.DstIn,
                 )
-            },
+            }
+        } else {
+            baseModifier
+        },
         content = content,
     )
 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
@@ -969,7 +969,7 @@ fun HomeScreen(
 
                 if (isLoading && homePage?.chips.isNullOrEmpty()) {
                     item(key = "chips_shimmer") {
-                        ShimmerHost {
+                        ShimmerHost(showGradient = false) {
                             LazyRow(
                                 contentPadding = WindowInsets.systemBars
                                     .only(WindowInsetsSides.Horizontal)


### PR DESCRIPTION
Add `showGradient` parameter to `ShimmerHost` to allow disabling the vertical gradient overlay. Apply `showGradient = false` to the chips shimmer so placeholders render with a uniform color instead of a faded gradient appearance.