### PR TITLE
fix(home): navigate playlists from home screen to the correct route

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
@@ -768,13 +768,7 @@ fun HomeScreen(
 
                             is AlbumItem -> navController.navigate("album/${item.id}")
                             is ArtistItem -> navController.navigate("artist/${item.id}")
-                            is PlaylistItem -> {
-                                if (item.id.startsWith("VL") || item.id.startsWith("PL") || item.id.startsWith("LL") || item.id.startsWith("RDC")) {
-                                    navController.navigate("online_playlist/${item.id.removePrefix("VL")}")
-                                } else {
-                                    navController.navigate("local_playlist/${item.id}")
-                                }
-                            }
+                            is PlaylistItem -> navController.navigate("online_playlist/${item.id}")
                         }
                     },
                     onLongClick = {
@@ -1147,13 +1141,7 @@ fun HomeScreen(
                                                                                         )
                                                                                         is AlbumItem -> navController.navigate("album/${item.id}")
                                                                                         is ArtistItem -> navController.navigate("artist/${item.id}")
-                                                                                        is PlaylistItem -> {
-                                                                                            if (item.id.startsWith("VL") || item.id.startsWith("PL") || item.id.startsWith("LL") || item.id.startsWith("RDC")) {
-                                                                                                navController.navigate("online_playlist/${item.id.removePrefix("VL")}")
-                                                                                            } else {
-                                                                                                navController.navigate("local_playlist/${item.id}")
-                                                                                            }
-                                                                                        }
+                                                                                        is PlaylistItem -> navController.navigate("online_playlist/${item.id}")
                                                                                     }
                                                                                 },
                                                                                 onLongClick = {


### PR DESCRIPTION
PlaylistItem IDs from the YouTube home page already have the "VL" prefix stripped at the parsing layer (HomePage.kt). The previous navigation logic relied on startsWith("VL"/"PL"/"LL"/"RDC") checks which silently missed IDs like "LM" (Liked Music) and "RDAT..."/"RDQM..." (mix playlists), routing them to local_playlist instead of online_playlist and resulting in an empty screen.

All PlaylistItem objects on the HomeScreen are online YouTube playlists, so navigate directly to online_playlist with the already-clean ID.