### PR TITLE
fix(ui): remove shadowElevation from AboutScreen to prevent ANR

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AboutScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AboutScreen.kt
@@ -179,8 +179,7 @@ private fun ContributorAvatar(
         modifier = modifier.size(sizeDp.dp),
         shape = shape,
         color = MaterialTheme.colorScheme.surfaceContainerHighest,
-        tonalElevation = 2.dp,
-        shadowElevation = 4.dp,
+        tonalElevation = 4.dp,
     ) {
         AsyncImage(
             model = avatarUrl,


### PR DESCRIPTION
Shadow tessellation on concave MaterialShapes polygons causes RenderThread to block for 5+ seconds, triggering ANR. Replace with tonalElevation which provides visual depth via color without expensive shadow geometry computation.