### PR TITLE
fix(ui): make CSV import dialog scrollable

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/CsvColumnMappingDialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/CsvColumnMappingDialog.kt
@@ -70,7 +70,8 @@ fun CsvColumnMappingDialog(
                 .fillMaxWidth(0.95f)
                 .clip(RoundedCornerShape(16.dp))
                 .background(MaterialTheme.colorScheme.surface)
-                .padding(24.dp),
+                .padding(24.dp)
+                .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             Text(


### PR DESCRIPTION
## Problem
<!-- Describe the issue or limitation this PR addresses -->
When importing a CSV file with many columns (e.g., from Exportify), the column mapping dialog becomes too tall and the import buttons are not accessible as they are off-screen.

## Cause
<!-- Explain the root cause of the problem -->
The CsvColumnMappingDialog did not have vertical scrolling, so with many columns the buttons were hidden below the visible area.

## Solution
<!-- List the changes made to fix the issue -->
- Added vertical scroll modifier (`.verticalScroll(rememberScrollState())`) to the main Column in `CsvColumnMappingDialog.kt`

## Testing
<!-- Describe how the changes were tested -->
Built the app and verified the dialog scrolls vertically when there are many columns.

Fixes #2999