### PR TITLE
feat(imports): redesign improve csv import ui

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialogOnline.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialogOnline.kt
@@ -59,19 +59,23 @@ import com.metrolist.music.viewmodels.PlaylistsViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import timber.log.Timber
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicInteger
 
 @Composable
 fun AddToPlaylistDialogOnline(
     isVisible: Boolean,
     allowSyncing: Boolean = true,
     initialTextFieldValue: String? = null,
-    songs: SnapshotStateList<Song>, // list of song ids. Songs should be inserted to database in this function.
+    songs: SnapshotStateList<Song>,
     onDismiss: () -> Unit,
     onProgressStart: (Boolean) -> Unit,
     onPercentageChange: (Int) -> Unit,
+    onSongChange: (String) -> Unit = {},
     viewModel: PlaylistsViewModel = hiltViewModel()
 ) {
     val database = LocalDatabase.current
@@ -98,7 +102,7 @@ fun AddToPlaylistDialogOnline(
         mutableStateOf<Playlist?>(null)
     }
     val songIds by remember {
-        mutableStateOf<List<String>?>(null) // list is not saveable
+        mutableStateOf<List<String>?>(null)
     }
     val duplicates by remember {
         mutableStateOf(emptyList<String>())
@@ -156,63 +160,59 @@ fun AddToPlaylistDialogOnline(
                         selectedPlaylist = playlist
                         coroutineScope.launch(Dispatchers.IO) {
                             onDismiss()
-                            val songsTot = songs.count().toDouble()
-                            var  songsIdx = 0.toDouble()
+                            val songsTot = songs.count()
+                            if (songsTot == 0) return@launch
+                            
+                            val songsIdx = AtomicInteger(0)
+                            val semaphore = kotlinx.coroutines.sync.Semaphore(15)
                             onProgressStart(true)
-                            songs.reversed().forEach{
-                                    song ->
-                                var allArtists = ""
-                                song.artists.forEach {
-                                        artist ->
-                                    allArtists += " ${URLDecoder.decode(artist.name, StandardCharsets.UTF_8.toString())}"
-                                }
-                                val query = "${song.title} - $allArtists"
+                            try {
+                                val jobs = songs.reversed().map { song ->
+                                    coroutineScope.launch {
+                                        semaphore.withPermit {
+                                            try {
+                                                var allArtists = ""
+                                                song.artists.forEach { artist ->
+                                                    allArtists += " ${URLDecoder.decode(artist.name, StandardCharsets.UTF_8.toString())}"
+                                                }
+                                                val query = "${song.title} - $allArtists"
 
-                                coroutineScope.launch {
-                                    try {
-                                        YouTube.search(query, YouTube.SearchFilter.FILTER_SONG)
-                                            .onSuccess { result ->
-                                                val items = result.items.distinctBy { it.id }
-                                                if (items.isNotEmpty()) {
-                                                    viewStateMap[YouTube.SearchFilter.FILTER_SONG.value] =
-                                                        ItemsPage(items, result.continuation)
-                                                    val itemsPage = viewStateMap.entries.firstOrNull()?.value
-                                                    val firstSong = itemsPage?.items?.firstOrNull() as? SongItem
-                                                    if (firstSong != null) {
-                                                        val firstSongMedia = firstSong.toMediaMetadata()
-                                                        val ids = listOf(firstSong.id)
-                                                        withContext(Dispatchers.IO) {
-                                                            try {
-                                                                database.insert(firstSongMedia)
-                                                            } catch (e: Exception) {
-                                                                Timber.tag("Exception inserting song in database:")
-                                                                    .e(e.toString())
+                                                YouTube.search(query, YouTube.SearchFilter.FILTER_SONG)
+                                                    .onSuccess { result ->
+                                                        val items = result.items.distinctBy { it.id }
+                                                        if (items.isNotEmpty()) {
+                                                            val firstSong = items.firstOrNull() as? SongItem
+                                                            if (firstSong != null) {
+                                                                val firstSongMedia = firstSong.toMediaMetadata()
+                                                                val ids = listOf(firstSong.id)
+                                                                withContext(Dispatchers.IO) {
+                                                                    try {
+                                                                        database.insert(firstSongMedia)
+                                                                    } catch (e: Exception) {
+                                                                        Timber.tag("Exception").e(e.toString())
+                                                                    }
+                                                                    database.addSongToPlaylist(playlist, ids)
+                                                                }
                                                             }
-                                                            database.addSongToPlaylist(playlist, ids)
                                                         }
                                                     }
-                                                    viewStateMap.clear()
-                                                }
-                                                songsIdx += 1
+                                                    .onFailure { reportException(it) }
+                                            } catch (e: Exception) {
+                                                Timber.tag("ERROR").v(e.toString())
+                                            } finally {
+                                                val completed = songsIdx.incrementAndGet()
+                                                onSongChange(song.title)
+                                                onPercentageChange(((completed.toDouble() / songsTot) * 100).toInt())
                                             }
-                                            .onFailure {
-                                                reportException(it)
-                                                songsIdx += 1
-                                            }
-
-                                        if (songsIdx.toInt() == songsTot.toInt() - 1) {
-                                            onProgressStart(false)
                                         }
-                                        onPercentageChange(((songsIdx / songsTot) * 100).toInt())
-
-                                    } catch (e: Exception){
-                                        Timber.tag("ERROR").v(e.toString())
                                     }
-
                                 }
-
+                                jobs.forEach { it.join() }
+                            } finally {
+                                withContext(Dispatchers.Main) {
+                                    onProgressStart(false)
+                                }
                             }
-
                         }
                     }
                 )
@@ -223,74 +223,70 @@ fun AddToPlaylistDialogOnline(
                     modifier = Modifier.clickable {
                         coroutineScope.launch(Dispatchers.IO) {
                             onDismiss()
-                            val songsTot = songs.count().toDouble()
-                            var  songsIdx = 0.toDouble()
-                            onProgressStart(true)
-                            songs.reversed().forEach{
-                                    song ->
-                                var allArtists = ""
-                                song.artists.forEach {
-                                        artist ->
-                                    allArtists += " ${URLDecoder.decode(artist.name, StandardCharsets.UTF_8.toString())}"
-                                }
-                                val query = "${song.title} - $allArtists"
+                            val songsTot = songs.count()
+                            if (songsTot == 0) return@launch
 
-                                coroutineScope.launch {
-                                    try {
-                                        YouTube.search(query, YouTube.SearchFilter.FILTER_SONG)
-                                            .onSuccess { result ->
-                                                val items = result.items.distinctBy { it.id }
-                                                if (items.isNotEmpty()) {
-                                                    viewStateMap[YouTube.SearchFilter.FILTER_SONG.value] =
-                                                        ItemsPage(items, result.continuation)
-                                                    val itemsPage = viewStateMap.entries.firstOrNull()?.value
-                                                    val firstSong = itemsPage?.items?.firstOrNull() as? SongItem
-                                                    if (firstSong != null) {
-                                                        val firstSongMedia = firstSong.toMediaMetadata()
-                                                        val firstSongEnt = firstSong.toMediaMetadata().toSongEntity()
-                                                        withContext(Dispatchers.IO) {
-                                                            try {
-                                                                database.insert(firstSongMedia)
-                                                                database.query {
-                                                                    update(firstSongEnt.toggleLike())
+                            val songsIdx = AtomicInteger(0)
+                            val semaphore = kotlinx.coroutines.sync.Semaphore(15)
+                            onProgressStart(true)
+                            try {
+                                val jobs = songs.reversed().map { song ->
+                                    coroutineScope.launch {
+                                        semaphore.withPermit {
+                                            try {
+                                                var allArtists = ""
+                                                song.artists.forEach { artist ->
+                                                    allArtists += " ${URLDecoder.decode(artist.name, StandardCharsets.UTF_8.toString())}"
+                                                }
+                                                val query = "${song.title} - $allArtists"
+
+                                                YouTube.search(query, YouTube.SearchFilter.FILTER_SONG)
+                                                    .onSuccess { result ->
+                                                        val items = result.items.distinctBy { it.id }
+                                                        if (items.isNotEmpty()) {
+                                                            val firstSong = items.firstOrNull() as? SongItem
+                                                            if (firstSong != null) {
+                                                                val firstSongMedia = firstSong.toMediaMetadata()
+                                                                val firstSongEnt = firstSong.toMediaMetadata().toSongEntity()
+                                                                withContext(Dispatchers.IO) {
+                                                                    try {
+                                                                        database.insert(firstSongMedia)
+                                                                        database.query {
+                                                                            update(firstSongEnt.toggleLike())
+                                                                        }
+                                                                    } catch (e: Exception) {
+                                                                        Timber.tag("Exception").e(e.toString())
+                                                                    }
                                                                 }
-                                                            } catch (e: Exception) {
-                                                                Timber.tag("Exception inserting song in database:")
-                                                                    .e(e.toString())
                                                             }
                                                         }
                                                     }
-                                                    viewStateMap.clear()
-                                                }
-                                                songsIdx += 1
+                                                    .onFailure { reportException(it) }
+                                            } catch (e: Exception) {
+                                                Timber.tag("ERROR").v(e.toString())
+                                            } finally {
+                                                val completed = songsIdx.incrementAndGet()
+                                                onSongChange(song.title)
+                                                onPercentageChange(((completed.toDouble() / songsTot) * 100).toInt())
                                             }
-                                            .onFailure {
-                                                reportException(it)
-                                                songsIdx += 1
-                                            }
-
-                                        if (songsIdx.toInt() == songsTot.toInt() - 1) {
-                                            onProgressStart(false)
                                         }
-                                        onPercentageChange(((songsIdx / songsTot) * 100).toInt())
-
-                                    } catch (e: Exception){
-                                        Timber.tag("ERROR").v(e.toString())
                                     }
-
                                 }
-
+                                jobs.forEach { it.join() }
+                            } finally {
+                                withContext(Dispatchers.Main) {
+                                    onProgressStart(false)
+                                }
                             }
-
                         }
                     },
                     title = stringResource(R.string.liked_songs),
                     thumbnailContent = {
                         Image(
-                            painter = painterResource(id = R.drawable.favorite), // The XML image
+                            painter = painterResource(id = R.drawable.favorite),
                             contentDescription = null,
-                            modifier = Modifier.size(40.dp), // Adjust size as needed
-                            colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground) // Optional tinting
+                            modifier = Modifier.size(40.dp),
+                            colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground)
                         )
                     },
                     trailingContent = {}

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/LoadingScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/LoadingScreen.kt
@@ -1,3 +1,4 @@
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 /**
  * Metrolist Project (C) 2026
  * Licensed under GPL-3.0 | See git history for contributors
@@ -5,37 +6,110 @@
 
 package com.metrolist.music.ui.menu
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearWavyProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.sp
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.metrolist.music.R
 
 @Composable
 fun LoadingScreen(
     isVisible: Boolean,
     value: Int,
+    songTitle: String? = null,
+    onCancel: (() -> Unit)? = null
 ) {
-    if (isVisible) {
-        Dialog (
-            onDismissRequest = {}
+    if (!isVisible) return
+
+    Dialog(
+        onDismissRequest = { },
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth(0.9f)
+                .clip(RoundedCornerShape(28.dp))
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center
-            ) {
+            Icon(
+                painter = painterResource(R.drawable.playlist_add),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.secondary,
+                modifier = Modifier.size(32.dp)
+            )
 
+            Text(
+                text = stringResource(R.string.importing_playlist),
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+
+            if (songTitle != null && songTitle.isNotBlank()) {
                 Text(
-                    text = stringResource(R.string.progress_percent, value.toString()),
-                    color = Color.White,
-                    fontSize = 26.sp,
+                    text = songTitle,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Center,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
+            } else {
+                Spacer(modifier = Modifier.height(24.dp))
+            }
 
+            Spacer(modifier = Modifier.height(8.dp))
+
+            LinearWavyProgressIndicator(
+                progress = { value / 100f },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(8.dp),
+            )
+
+            Text(
+                text = stringResource(R.string.progress_percent, value.toString()),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            if (onCancel != null) {
+                Spacer(modifier = Modifier.height(8.dp))
+                TextButton(
+                    onClick = onCancel,
+                    modifier = Modifier.align(Alignment.End)
+                ) {
+                    Text(stringResource(R.string.cancel))
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/BackupAndRestore.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/BackupAndRestore.kt
@@ -32,7 +32,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
@@ -69,7 +68,6 @@ import com.metrolist.music.viewmodels.BackupRestoreViewModel
 import com.metrolist.music.viewmodels.ConvertedSongLog
 import com.metrolist.music.viewmodels.CsvImportState
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -87,6 +85,7 @@ fun BackupAndRestore(
         mutableStateOf(false)
     }
 
+    var currentImportSong by rememberSaveable { mutableStateOf("") }
     var isProgressStarted by rememberSaveable {
         mutableStateOf(false)
     }
@@ -237,22 +236,14 @@ fun BackupAndRestore(
         songs = importedSongs,
         onDismiss = { showChoosePlaylistDialogOnline = false },
         onProgressStart = { newVal -> isProgressStarted = newVal },
-        onPercentageChange = { newPercentage -> progressPercentage = newPercentage }
+        onPercentageChange = { newPercentage -> progressPercentage = newPercentage },
+        onSongChange = { currentImportSong = it }
     )
-
-    LaunchedEffect(progressPercentage, isProgressStarted) {
-        if (isProgressStarted && progressPercentage == 99) {
-            delay(10000)
-            if (progressPercentage == 99) {
-                isProgressStarted = false
-                progressPercentage = 0
-            }
-        }
-    }
 
     LoadingScreen(
         isVisible = isProgressStarted,
         value = progressPercentage,
+        songTitle = currentImportSong,
     )
 
     // CSV column mapping dialog
@@ -415,19 +406,16 @@ fun BackupAndRestore(
                 if (!isLoadingAccountInfo && preview.hasAuthData && preview.accountName != null) {
                     Spacer(modifier = Modifier.height(16.dp))
 
-                    // Divider
                     HorizontalDivider(
                         color = MaterialTheme.colorScheme.outlineVariant
                     )
 
                     Spacer(modifier = Modifier.height(16.dp))
 
-                    // Account row with real info
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                         modifier = Modifier.fillMaxWidth()
                     ) {
-                        // Avatar - use actual image if available
                         if (preview.accountImageUrl != null) {
                             AsyncImage(
                                 model = preview.accountImageUrl,
@@ -456,7 +444,6 @@ fun BackupAndRestore(
 
                         Spacer(modifier = Modifier.size(16.dp))
 
-                        // Account name/email
                         Text(
                             text = preview.accountEmail ?: preview.accountName,
                             style = MaterialTheme.typography.bodyLarge,
@@ -466,7 +453,6 @@ fun BackupAndRestore(
 
                     Spacer(modifier = Modifier.height(16.dp))
 
-                    // Bottom divider
                     HorizontalDivider(
                         color = MaterialTheme.colorScheme.outlineVariant
                     )
@@ -475,4 +461,3 @@ fun BackupAndRestore(
         }
     }
 }
-

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -723,6 +723,8 @@
     <string name="youtube_url_column">YouTube URL Column (Optional)</string>
     <string name="continue_action">Continue</string>
     <string name="importing_csv">Importing CSV</string>
+    <string name="importing_playlist">Importing Playlist</string>
+
     <string name="importing_song">Importing %s</string>
     <string name="recently_converted">Recently Converted</string>
     <string name="column_label">Col %d</string>
@@ -828,4 +830,6 @@
     <string name="restore">Restore</string>
     <string name="checking_previous_account">Checking for previous account…</string>
     <string name="no_account_found">No account found</string>
+    <string name="restore_success">Restore completed successfully</string>
+    <string name="no_songs_found">No songs found. Invalid file, or perhaps no song matches were found.</string>
 </resources>


### PR DESCRIPTION
# Summary
Redesigned the loading screen used for importing playlists (m3u and CSV) to better match Material 3 guidelines. It now features a wavy progress indicator and displays the currently importing song title alongside the percentage.
I also fixed some reliability issues under the hood when importing large playlists. The original logic was launching an unbounded number of concurrent YouTube searches which could cause throttling and progress bar stuttering.
# Changes included:
- Replaced the old loading UI with a new Material 3 design (wavy indicator, current song title, percentage)
- Added a concurrency limit (15) and thread-safe progress tracking to the import logic
- Wired up an onSongChange callback so the loading dialog knows what song is currently being processed
- Made the CSV import function suspend properly with `withContext(Dispatchers.IO)`
- Removed the old `LaunchedEffect` progress workaround and replaced it with a proper finally block in the coroutine
<img src="https://github.com/user-attachments/assets/e76a4816-33e5-4cca-aea8-257ac3a73648" width="300" alt="Screen_Recording_20260225_181921_Metrolist Debug">