### PR TITLE
fix: remove parentheses and brackets from song title during lyrics search

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsHelper.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsHelper.kt
@@ -119,7 +119,7 @@ constructor(
             // If network check fails, try to proceed anyway
             true
         }
-        
+
         if (!isNetworkAvailable) {
             // Still proceed but return not found to avoid hanging
             return LyricsWithProvider(LYRICS_NOT_FOUND, "Unknown")
@@ -127,14 +127,15 @@ constructor(
 
         val scope = CoroutineScope(SupervisorJob())
         val deferred = scope.async {
+            val cleanedTitle = LyricsUtils.cleanTitleForSearch(mediaMetadata.title)
             for (provider in lyricsProviders) {
                 if (provider.isEnabled(context)) {
                     try {
                         Timber.tag("LyricsHelper")
-                            .d("Trying provider: ${provider.name} for ${mediaMetadata.title}")
+                            .d("Trying provider: ${provider.name} for $cleanedTitle")
                         val result = provider.getLyrics(
                             mediaMetadata.id,
-                            mediaMetadata.title,
+                            cleanedTitle,
                             mediaMetadata.artists.joinToString { it.name },
                             mediaMetadata.duration,
                             mediaMetadata.album?.title,
@@ -190,7 +191,7 @@ constructor(
             // If network check fails, try to proceed anyway
             true
         }
-        
+
         if (!isNetworkAvailable) {
             // Still try to proceed in case of false negative
             return
@@ -198,10 +199,11 @@ constructor(
 
         val allResult = mutableListOf<LyricsResult>()
         currentLyricsJob = CoroutineScope(SupervisorJob()).launch {
+            val cleanedTitle = LyricsUtils.cleanTitleForSearch(songTitle)
             lyricsProviders.forEach { provider ->
                 if (provider.isEnabled(context)) {
                     try {
-                        provider.getAllLyrics(mediaId, songTitle, songArtists, duration, album) { lyrics ->
+                        provider.getAllLyrics(mediaId, cleanedTitle, songArtists, duration, album) { lyrics ->
                             val result = LyricsResult(provider.name, lyrics)
                             allResult += result
                             callback(result)

--- a/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsUtils.kt
@@ -16,11 +16,15 @@ import java.util.Locale
 object LyricsUtils {
     val LINE_REGEX = "((\\[\\d\\d:\\d\\d\\.\\d{2,3}\\] ?)+)(.+)".toRegex()
     val TIME_REGEX = "\\[(\\d\\d):(\\d\\d)\\.(\\d{2,3})\\]".toRegex()
-    
+
+    fun cleanTitleForSearch(title: String): String {
+        return title.replace(Regex("\\s*[(\\[].*?[)\\]]"), "").trim()
+    }
+
     // Regex for rich sync format: [MM:SS.mm]<MM:SS.mm> word <MM:SS.mm> word ...
     private val RICH_SYNC_LINE_REGEX = "\\[(\\d{1,2}):(\\d{2})\\.(\\d{2,3})\\](.+)".toRegex()
     private val RICH_SYNC_WORD_REGEX = "<(\\d{1,2}):(\\d{2})\\.(\\d{2,3})>\\s*([^<]+)".toRegex()
-    
+
     // Regex for agent and background markers
     private val AGENT_REGEX = "\\{agent:([^}]+)\\}".toRegex()
     private val BACKGROUND_REGEX = "^\\{bg\\}".toRegex()
@@ -357,93 +361,93 @@ object LyricsUtils {
 
         // Decode HTML entities (e.g. &#x27; -> ', &amp; -> &)
         val decodedLyrics = decodeHtmlEntities(unescapedLyrics)
-        
+
         val lines = decodedLyrics.lines()
             .filter { it.isNotBlank() && !it.trim().startsWith("[offset:") }
-        
+
         // Check if this is rich sync format (contains <MM:SS.mm> patterns)
         val isRichSync = lines.any { line ->
-            RICH_SYNC_LINE_REGEX.matches(line.trim()) && 
+            RICH_SYNC_LINE_REGEX.matches(line.trim()) &&
             RICH_SYNC_WORD_REGEX.containsMatchIn(line)
         }
-        
+
         return if (isRichSync) {
             parseRichSyncLyrics(lines)
         } else {
             parseStandardLyrics(lines)
         }
     }
-    
+
     /**
      * Parse rich sync lyrics format: [MM:SS.mm]<MM:SS.mm> word <MM:SS.mm> word ...
      * This format provides word-by-word timing for karaoke-style highlighting
      */
     private fun parseRichSyncLyrics(lines: List<String>): List<LyricsEntry> {
         val result = mutableListOf<LyricsEntry>()
-        
+
         lines.forEachIndexed { index, line ->
             val matchResult = RICH_SYNC_LINE_REGEX.matchEntire(line.trim())
             if (matchResult != null) {
                 val minutes = matchResult.groupValues[1].toLongOrNull() ?: 0L
                 val seconds = matchResult.groupValues[2].toLongOrNull() ?: 0L
                 val centiseconds = matchResult.groupValues[3].toLongOrNull() ?: 0L
-                
+
                 // Convert to milliseconds
                 val millisPart = if (matchResult.groupValues[3].length == 3) centiseconds else centiseconds * 10
                 val lineTimeMs = minutes * DateUtils.MINUTE_IN_MILLIS + seconds * DateUtils.SECOND_IN_MILLIS + millisPart
-                
+
                 var content = matchResult.groupValues[4].trimStart()
-                
+
                 // Parse agent marker {agent:v1}
                 val agentMatch = AGENT_REGEX.find(content)
                 val agent = agentMatch?.groupValues?.get(1)
                 if (agentMatch != null) {
                     content = content.replaceFirst(AGENT_REGEX, "")
                 }
-                
+
                 // Parse background marker {bg}
                 val isBackground = BACKGROUND_REGEX.containsMatchIn(content)
                 if (isBackground) {
                     content = content.replaceFirst(BACKGROUND_REGEX, "")
                 }
-                
+
                 // Parse word-level timestamps from content
                 val wordTimings = parseRichSyncWords(content, index, lines)
-                
+
                 // Extract plain text (remove all <MM:SS.mm> tags)
                 val plainText = content.replace(Regex("<\\d{1,2}:\\d{2}\\.\\d{2,3}>\\s*"), "").trim()
-                
+
                 if (plainText.isNotBlank()) {
                     result.add(LyricsEntry(lineTimeMs, plainText, wordTimings, agent = agent, isBackground = isBackground))
                 }
             }
         }
-        
+
         return result.sorted()
     }
-    
+
     /**
      * Parse word timestamps from rich sync content
      * Format: <MM:SS.mm> word <MM:SS.mm> word ...
      */
     private fun parseRichSyncWords(content: String, currentIndex: Int, allLines: List<String>): List<WordTimestamp>? {
         val wordMatches = RICH_SYNC_WORD_REGEX.findAll(content).toList()
-        
+
         if (wordMatches.isEmpty()) return null
-        
+
         val wordTimings = mutableListOf<WordTimestamp>()
-        
+
         wordMatches.forEachIndexed { index, match ->
             val minutes = match.groupValues[1].toLongOrNull() ?: 0L
             val seconds = match.groupValues[2].toLongOrNull() ?: 0L
             val fraction = match.groupValues[3].toLongOrNull() ?: 0L
-            
+
             // Convert to seconds (Double)
             val fractionPart = if (match.groupValues[3].length == 3) fraction / 1000.0 else fraction / 100.0
             val startTimeSeconds = minutes * 60.0 + seconds + fractionPart
-            
+
             val wordText = match.groupValues[4].trim()
-            
+
             // Calculate end time: use next word's start time, or estimate from next line
             val endTimeSeconds = if (index < wordMatches.size - 1) {
                 val nextMatch = wordMatches[index + 1]
@@ -457,38 +461,38 @@ object LyricsUtils {
                 val nextLineTime = getNextLineStartTime(currentIndex, allLines)
                 nextLineTime ?: (startTimeSeconds + 0.5) // Default 500ms duration for last word
             }
-            
+
             if (wordText.isNotBlank()) {
                 wordTimings.add(WordTimestamp(wordText, startTimeSeconds, endTimeSeconds))
             }
         }
-        
+
         return if (wordTimings.isNotEmpty()) wordTimings else null
     }
-    
+
     /**
      * Get the start time of the next line for calculating the last word's end time
      */
     private fun getNextLineStartTime(currentIndex: Int, allLines: List<String>): Double? {
         if (currentIndex + 1 >= allLines.size) return null
-        
+
         val nextLine = allLines[currentIndex + 1].trim()
         val matchResult = RICH_SYNC_LINE_REGEX.matchEntire(nextLine) ?: return null
-        
+
         val minutes = matchResult.groupValues[1].toLongOrNull() ?: return null
         val seconds = matchResult.groupValues[2].toLongOrNull() ?: return null
         val fraction = matchResult.groupValues[3].toLongOrNull() ?: 0L
-        
+
         val fractionPart = if (matchResult.groupValues[3].length == 3) fraction / 1000.0 else fraction / 100.0
         return minutes * 60.0 + seconds + fractionPart
     }
-    
+
     /**
      * Parse standard synced lyrics format: [MM:SS.mm] text
      */
     private fun parseStandardLyrics(lines: List<String>): List<LyricsEntry> {
         val result = mutableListOf<LyricsEntry>()
-        
+
         var i = 0
         while (i < lines.size) {
             val line = lines[i]
@@ -501,7 +505,7 @@ object LyricsUtils {
                             parseWordTimestamps(nextLine.trim().removeSurrounding("<", ">"))
                         } else null
                     } else null
-                    
+
                     if (wordTimestamps != null) {
                         result.addAll(entries.map { entry ->
                             LyricsEntry(entry.time, entry.text, wordTimestamps, agent = entry.agent, isBackground = entry.isBackground)
@@ -515,7 +519,7 @@ object LyricsUtils {
         }
         return result.sorted()
     }
-    
+
     private fun parseWordTimestamps(data: String): List<WordTimestamp>? {
         if (data.isBlank()) return null
         return try {
@@ -542,14 +546,14 @@ object LyricsUtils {
         val times = matchResult.groupValues[1]
         var text = matchResult.groupValues[3]
         val timeMatchResults = TIME_REGEX.findAll(times)
-        
+
         // Parse agent marker {agent:v1}
         val agentMatch = AGENT_REGEX.find(text)
         val agent = agentMatch?.groupValues?.get(1)
         if (agentMatch != null) {
             text = text.replaceFirst(AGENT_REGEX, "")
         }
-        
+
         // Parse background marker {bg}
         val isBackground = BACKGROUND_REGEX.containsMatchIn(text)
         if (isBackground) {


### PR DESCRIPTION
## Problem
Lyrics search often returns incorrect or irrelevant results (e.g., Chinese or Japanese lyrics for Western songs) when the song title contains metadata.

## Cause
Song titles often contain metadata in parentheses or brackets like `(feat. ...)`, `(Remastered)`, `[Original Mix]`, etc. These extra strings interfere with the search queries of various lyrics providers, leading to poor match quality or mismatching.

## Solution
Implemented a `cleanTitleForSearch` function in `LyricsUtils` that strips all content within parentheses `()` and square brackets `[]` from the song title. `LyricsHelper` now uses this cleaned title when querying lyrics providers.

## Testing
- Verified that titles like "Song Name (feat. Artist)" are cleaned to "Song Name".
- Confirmed improved lyrics match accuracy for several tracks previously returning incorrect results.

Closes #3041

