### PR TITLE
fix: n-transform extraction for uploaded/restricted songs

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -252,7 +252,7 @@ object YTPlayerUtils {
                 if (needsNTransform) {
                     try {
                         Timber.tag(logTag).d("Applying n-transform to stream URL for ${currentClient.clientName}")
-                        streamUrl = EjsNTransformSolver.transformNParamInUrl(streamUrl!!)
+                        streamUrl = CipherDeobfuscator.transformNParamInUrl(streamUrl!!)
 
                         // Append pot= parameter (base64 - do NOT Uri.encode)
                         if ((currentClient.useWebPoTokens || isPrivatelyOwnedTrack) && sessionId != null) {

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/FunctionNameExtractor.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/FunctionNameExtractor.kt
@@ -58,6 +58,7 @@ object FunctionNameExtractor {
     }
 
     fun extractNFunctionInfo(playerJs: String): NFunctionInfo? {
+        // Try existing patterns first (0-3)
         for ((index, pattern) in N_FUNCTION_PATTERNS.withIndex()) {
             val match = pattern.find(playerJs)
             if (match != null) {
@@ -84,6 +85,23 @@ object FunctionNameExtractor {
                 }
             }
         }
+
+        // Pattern 5 (Feb 2025): Match exact n-transform context
+        // Matches: e=v4c[0](e),f[M[42]] - where same var used on both sides, followed by set operation
+        val exactContextPattern = Regex("""(\w)=([a-zA-Z0-9${'$'}_]+)\[0\]\(\1\),\w+\[M\[42\]\]""")
+        val exactMatch = exactContextPattern.find(playerJs)
+        if (exactMatch != null) {
+            val varName = exactMatch.groupValues[1]
+            val arrayName = exactMatch.groupValues[2]
+
+            // Verify this array exists as "var ARRAY=[FUNC]"
+            val defPattern = Regex("""var\s+${Regex.escape(arrayName)}\s*=\s*\[([a-zA-Z0-9${'$'}_]+)\]""")
+            val defMatch = defPattern.find(playerJs)
+            val funcName = defMatch?.groupValues?.get(1) ?: "unknown"
+            Timber.tag(TAG).d("N-function found with pattern 4: array=$arrayName, func=$funcName, var=$varName")
+            return NFunctionInfo(arrayName, 0)
+        }
+
         Timber.tag(TAG).e("Could not find n-transform function name")
         return null
     }


### PR DESCRIPTION
## Problem
Uploaded songs (MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK), age-restricted songs, and some restricted content return HTTP 403 when streaming. The n-parameter in stream URLs is not being transformed correctly.

## Cause
YouTube changed their player.js structure in Feb 2026. The n-transform function is now stored in an array pattern:
```javascript
var v4c=[yzP];  // Function stored in array
e=v4c[0](e),f[M[42]](M[26],e)  // Called as array[0](param)
```

The `EjsNTransformSolver` uses bundled JS files (`yt.solver.core.js`, `meriyah.js`, `astring.js`) to preprocess player.js and extract the n-function. This preprocessor cannot handle the new obfuscation pattern and fails silently. Fixing it would require updating the bundled `yt.solver.core.js` script.

## Solution
- Switch from `EjsNTransformSolver` to `CipherDeobfuscator` for n-param transformation (uses WebView with function export/brute-force discovery)
- Add exact context pattern to `FunctionNameExtractor` that matches the specific n-transform call site: `e=ARRAY[0](e),f[M[42]]`
- This pattern avoids false positives by requiring the same variable on both sides and the M[42] (set) operation

## Testing
- Built and installed universalFossDebug APK
- Played uploaded songs that were previously returning 403
- Tested age-restricted content
- Verified n-transform logs show correct array discovery (v4c[0])
- Streams return 200 instead of 403