### PR TITLE
Fixed Like logic in SongMenu.

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
@@ -353,7 +353,7 @@ fun SongMenu(
                         }
                     } else {
                         // Regular song: toggle like
-                        playerConnection::toggleLike()
+                        (playerConnection::toggleLike)()
                     }
                 },
             ) {


### PR DESCRIPTION
## Problem
Songs are not auto downloading when liked from some SongMenu (with auto download on).

## Cause
Inconsistent like logic across menus.

## Solution
Changed it to use the dedicated function.

## Testing
This change has not been tested.
I can't compile the app, i would appreciate anyone testing this change.

## Related Issues
- Closes #752 