### PR TITLE
fix(protobuf): prevent R8 from stripping lite message fields

### DIFF
--- a/app/generate_proto.sh
+++ b/app/generate_proto.sh
@@ -16,7 +16,7 @@ fi
 mkdir -p "$OUT_DIR"
 
 # Generate Java and Kotlin code (lite version for Android)
-protoc --java_out=lite:"$OUT_DIR" --kotlin_out="$OUT_DIR" \
+protoc --java_out=lite:"$OUT_DIR" --kotlin_out=lite:"$OUT_DIR" \
     -I="$PROTO_DIR" \
     "$PROTO_DIR/listentogether.proto"
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -93,6 +93,14 @@
 -dontwarn jdk.dynalink.**
 
 ## Listen Together Protobuf
+# Keep all protobuf lite generated message classes. R8 renames/removes the internal
+# fields (e.g. username_, type_) that protobuf lite accesses via reflection in its
+# dynamicMethod(). Using the GeneratedMessageLite superclass as the anchor ensures
+# every message class is covered regardless of package, even after code generation.
+-keep class * extends com.google.protobuf.GeneratedMessageLite { *; }
+-keep class * extends com.google.protobuf.GeneratedMessageLite$Builder { *; }
+-keep class * extends com.google.protobuf.Internal$EnumLite { *; }
+# Package-level fallback (covers cases where the class is loaded by class name)
 -keep class com.metrolist.music.listentogether.proto.** { *; }
 -keepclassmembers class com.metrolist.music.listentogether.proto.** { *; }
 


### PR DESCRIPTION
## Problem
"Error encoding message" crashes when creating or joining a Listen Together room in release builds. R8 minification renames/removes internal fields (`username_`, `type_`) from protobuf lite generated classes, causing reflection-based field lookups inside `dynamicMethod()` to fail at runtime.

## Cause
Protobuf lite generated message classes (e.g. `CreateRoomPayload`, `Envelope`) access their fields by name via reflection in `dynamicMethod()`. R8 does not know these fields are accessed reflectively, so it obfuscates them during minification — turning `CreateRoomPayload.username_` and `Envelope.type_` into unreachable names. The existing ProGuard rule targeting `com.metrolist.music.listentogether.proto.**` was not being matched by R8, evidenced by the classes still being renamed to `nb.k` and `nb.m` in the obfuscated output.

## Solution
- **`app/proguard-rules.pro`**: Added the canonical protobuf lite keep rule anchored on the `GeneratedMessageLite` superclass. This matches every generated message class regardless of package name or where the generated sources live, ensuring all internal fields survive R8 minification.
- **`app/generate_proto.sh`**: Fixed the `--kotlin_out` flag to use the `lite:` prefix (`--kotlin_out=lite:`). Without it, the Kotlin output references full protobuf `Message` APIs that do not exist in the Android lite runtime.

## Testing
- Built `assembleuniversalFossDebug` — no compilation errors.
- The ProGuard fix takes effect in release builds (`isMinifyEnabled = true`). Verify by installing a release APK and confirming the Listen Together "Create Room" flow completes without `Error encoding message` in the logs.

## Related Issues
- Closes #3087  
- Related to #3087