### PR TITLE
feat: Added a playlist range selection

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -191,9 +191,11 @@ fun AutoPlaylistScreen(
                     restore = { it.toMutableStateList() },
                 ),
         ) { mutableStateListOf() }
+    var selectionAnchorSongId by rememberSaveable { mutableStateOf<String?>(null) }
     val onExitSelectionMode = {
         inSelectMode = false
         selection.clear()
+        selectionAnchorSongId = null
     }
 
     if (isSearching) {
@@ -480,6 +482,10 @@ fun AutoPlaylistScreen(
                 selection.remove(songId)
             }
         }
+
+        if (selectionAnchorSongId != null && filteredSongs.none { it.id == selectionAnchorSongId }) {
+            selectionAnchorSongId = filteredSongs.firstOrNull { it.id in selection }?.id
+        }
     }
 
     val state = rememberLazyListState()
@@ -622,6 +628,25 @@ fun AutoPlaylistScreen(
                                                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                                 inSelectMode = true
                                                 onCheckedChange(true)
+                                                selectionAnchorSongId = song.id
+                                            } else {
+                                                val anchorIndex =
+                                                    selectionAnchorSongId?.let { anchorSongId ->
+                                                        filteredSongs.indexOfFirst { it.id == anchorSongId }
+                                                    } ?: -1
+
+                                                if (anchorIndex == -1) {
+                                                    onCheckedChange(true)
+                                                    selectionAnchorSongId = song.id
+                                                } else {
+                                                    val range = if (anchorIndex <= index) anchorIndex..index else index..anchorIndex
+                                                    for (rangeIndex in range) {
+                                                        val rangeSongId = filteredSongs[rangeIndex].id
+                                                        if (rangeSongId !in selection) {
+                                                            selection.add(rangeSongId)
+                                                        }
+                                                    }
+                                                }
                                             }
                                         },
                                     ).animateItem(),

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/CachePlaylistScreen.kt
@@ -144,9 +144,11 @@ fun CachePlaylistScreen(
             restore = { it.toMutableStateList() }
         )
     ) { mutableStateListOf() }
+    var selectionAnchorSongId by rememberSaveable { mutableStateOf<String?>(null) }
     val onExitSelectionMode = {
         inSelectMode = false
         selection.clear()
+        selectionAnchorSongId = null
     }
 
     var isSearching by remember { mutableStateOf(false) }
@@ -182,6 +184,10 @@ fun CachePlaylistScreen(
             if (filteredSongs.find { it.id == songId } == null) {
                 selection.remove(songId)
             }
+        }
+
+        if (selectionAnchorSongId != null && filteredSongs.none { it.id == selectionAnchorSongId }) {
+            selectionAnchorSongId = filteredSongs.firstOrNull { it.id in selection }?.id
         }
     }
 
@@ -311,6 +317,24 @@ fun CachePlaylistScreen(
                                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                         inSelectMode = true
                                         onCheckedChange(true)
+                                        selectionAnchorSongId = song.id
+                                    } else {
+                                        val anchorIndex = selectionAnchorSongId?.let { anchorSongId ->
+                                            filteredSongs.indexOfFirst { it.id == anchorSongId }
+                                        } ?: -1
+
+                                        if (anchorIndex == -1) {
+                                            onCheckedChange(true)
+                                            selectionAnchorSongId = song.id
+                                        } else {
+                                            val range = if (anchorIndex <= index) anchorIndex..index else index..anchorIndex
+                                            for (rangeIndex in range) {
+                                                val rangeSongId = filteredSongs[rangeIndex].id
+                                                if (rangeSongId !in selection) {
+                                                    selection.add(rangeSongId)
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             )

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -227,9 +227,11 @@ fun LocalPlaylistScreen(
             restore = { it.toMutableStateList() }
         )
     ) { mutableStateListOf() }
+    var selectionAnchorMapId by rememberSaveable { mutableStateOf<Int?>(null) }
     val onExitSelectionMode = {
         inSelectMode = false
         selection.clear()
+        selectionAnchorMapId = null
     }
 
     if (isSearching) {
@@ -253,6 +255,10 @@ fun LocalPlaylistScreen(
             if (songs.find { it.map.id == mapId } == null) {
                 selection.remove(Integer.valueOf(mapId))
             }
+        }
+
+        if (selectionAnchorMapId != null && songs.none { it.map.id == selectionAnchorMapId }) {
+            selectionAnchorMapId = songs.firstOrNull { it.map.id in selection }?.map?.id
         }
     }
 
@@ -532,8 +538,10 @@ fun LocalPlaylistScreen(
                 }
             }
 
+            val displayedSongs = if (isSearching) filteredSongs else mutableSongs
+
             itemsIndexed(
-                items = if (isSearching) filteredSongs else mutableSongs,
+                items = displayedSongs,
                 key = { _, song -> song.map.id },
             ) { index, song ->
                 ReorderableItem(
@@ -663,6 +671,24 @@ fun LocalPlaylistScreen(
                                             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                             inSelectMode = true
                                             onCheckedChange(true)
+                                            selectionAnchorMapId = song.map.id
+                                        } else {
+                                            val anchorIndex = selectionAnchorMapId?.let { anchorMapId ->
+                                                displayedSongs.indexOfFirst { it.map.id == anchorMapId }
+                                            } ?: -1
+
+                                            if (anchorIndex == -1) {
+                                                onCheckedChange(true)
+                                                selectionAnchorMapId = song.map.id
+                                            } else {
+                                                val range = if (anchorIndex <= index) anchorIndex..index else index..anchorIndex
+                                                for (rangeIndex in range) {
+                                                    val rangeMapId = displayedSongs[rangeIndex].map.id
+                                                    if (rangeMapId !in selection) {
+                                                        selection.add(rangeMapId)
+                                                    }
+                                                }
+                                            }
                                         }
                                     },
                                 ),

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -163,9 +163,11 @@ fun OnlinePlaylistScreen(
                     restore = { it.toMutableStateList() },
                 ),
         ) { mutableStateListOf() }
+    var selectionAnchorSongId by rememberSaveable { mutableStateOf<String?>(null) }
     val onExitSelectionMode = {
         inSelectMode = false
         selection.clear()
+        selectionAnchorSongId = null
     }
 
     val focusRequester = remember { FocusRequester() }
@@ -176,6 +178,10 @@ fun OnlinePlaylistScreen(
             if (filteredSongs.find { it.second.id == songId } == null) {
                 selection.remove(songId)
             }
+        }
+
+        if (selectionAnchorSongId != null && filteredSongs.none { it.second.id == selectionAnchorSongId }) {
+            selectionAnchorSongId = filteredSongs.firstOrNull { it.second.id in selection }?.second?.id
         }
     }
 
@@ -300,6 +306,25 @@ fun OnlinePlaylistScreen(
                                                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                                 inSelectMode = true
                                                 onCheckedChange(true)
+                                                selectionAnchorSongId = songItem.id
+                                            } else {
+                                                val anchorIndex =
+                                                    selectionAnchorSongId?.let { anchorSongId ->
+                                                        filteredSongs.indexOfFirst { it.second.id == anchorSongId }
+                                                    } ?: -1
+
+                                                if (anchorIndex == -1) {
+                                                    onCheckedChange(true)
+                                                    selectionAnchorSongId = songItem.id
+                                                } else {
+                                                    val range = if (anchorIndex <= index) anchorIndex..index else index..anchorIndex
+                                                    for (rangeIndex in range) {
+                                                        val rangeSongId = filteredSongs[rangeIndex].second.id
+                                                        if (rangeSongId !in selection) {
+                                                            selection.add(rangeSongId)
+                                                        }
+                                                    }
+                                                }
                                             }
                                         },
                                     ).animateItem(),

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/TopPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/TopPlaylistScreen.kt
@@ -141,9 +141,11 @@ fun TopPlaylistScreen(
             restore = { it.toMutableStateList() }
         )
     ) { mutableStateListOf() }
+    var selectionAnchorSongId by rememberSaveable { mutableStateOf<String?>(null) }
     val onExitSelectionMode = {
         inSelectMode = false
         selection.clear()
+        selectionAnchorSongId = null
     }
 
     val filteredSongs = remember(songs, query) {
@@ -159,6 +161,10 @@ fun TopPlaylistScreen(
             if (filteredSongs.find { it.id == songId } == null) {
                 selection.remove(songId)
             }
+        }
+
+        if (selectionAnchorSongId != null && filteredSongs.none { it.id == selectionAnchorSongId }) {
+            selectionAnchorSongId = filteredSongs.firstOrNull { it.id in selection }?.id
         }
     }
 
@@ -365,6 +371,24 @@ fun TopPlaylistScreen(
                                             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                             inSelectMode = true
                                             onCheckedChange(true)
+                                            selectionAnchorSongId = song.id
+                                        } else {
+                                            val anchorIndex = selectionAnchorSongId?.let { anchorSongId ->
+                                                filteredSongs.indexOfFirst { it.id == anchorSongId }
+                                            } ?: -1
+
+                                            if (anchorIndex == -1) {
+                                                onCheckedChange(true)
+                                                selectionAnchorSongId = song.id
+                                            } else {
+                                                val range = if (anchorIndex <= index) anchorIndex..index else index..anchorIndex
+                                                for (rangeIndex in range) {
+                                                    val rangeSongId = filteredSongs[rangeIndex].id
+                                                    if (rangeSongId !in selection) {
+                                                        selection.add(rangeSongId)
+                                                    }
+                                                }
+                                            }
                                         }
                                     },
                                 )


### PR DESCRIPTION
## Problem
Metrolist supports multi-select in playlist-like screens, but once selection mode is active, long-pressing another song does nothing. Users must tap each item one by one, which is slow for selecting contiguous ranges (e.g., removing a full album from a playlist).

## Cause
The long-press handlers on playlist song items only initialize selection mode (if (!inSelectMode)), and ignore long-press events while already in selection mode. There is no "anchor + target" range-selection logic.

## Solution
- Added range selection on long-press for playlist screens:
  - OnlinePlaylistScreen
  - AutoPlaylistScreen
  - TopPlaylistScreen
  - CachePlaylistScreen
  - LocalPlaylistScreen

- Introduced a selection anchor state per screen (selectionAnchorSongId / selectionAnchorMapId) to remember the first long-pressed item.

- Updated long-press behavior:
  - First long-press: enters selection mode, selects the item, sets anchor.
  - Subsequent long-press in selection mode: selects all items between anchor and current item (inclusive).

- Added safe fallback when anchor is no longer present in the current visible list.
- Cleared anchor when exiting selection mode to avoid stale state.


## Testing
- Built successfully with:
  - ./gradlew :app:assembleFossDebug
  
- Verified behavior logically in all affected screens(manual in emulator):
  - first long-press enters select mode,
  - second long-press selects contiguous range,
  - selection remains stable when filtered/visible list changes.

## Related Issues
- Closes #3127 
- Related to #3127 