### PR TITLE
fix: Next song when picking a random song is the same

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/queues/YouTubeQueue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/queues/YouTubeQueue.kt
@@ -24,8 +24,14 @@ class YouTubeQueue(
     override suspend fun getInitialStatus(): Queue.Status {
         return withContext(IO) {
             var lastException: Throwable? = null
-            
-            // Try with original endpoint first (allows YouTube to personalize recommendations)
+
+            if (endpoint.videoId != null && endpoint.playlistId == null) {
+                endpoint = WatchEndpoint(
+                    videoId = endpoint.videoId,
+                    playlistId = "RDAMVM${endpoint.videoId}"
+                )
+            }
+
             for (attempt in 0..maxRetries) {
                 try {
                     val nextResult = YouTube.next(endpoint, continuation).getOrThrow()
@@ -39,13 +45,6 @@ class YouTubeQueue(
                     )
                 } catch (e: Exception) {
                     lastException = e
-                    // If first attempt fails and we have a videoId, try with fallback radio params
-                    if (attempt == 0 && endpoint.videoId != null && endpoint.playlistId == null) {
-                        endpoint = WatchEndpoint(
-                            videoId = endpoint.videoId,
-                            playlistId = "RDAMVM${endpoint.videoId}"
-                        )
-                    }
                 }
             }
             throw lastException ?: Exception("Failed to get initial status")
@@ -57,7 +56,7 @@ class YouTubeQueue(
     override suspend fun nextPage(): List<MediaItem> {
         return withContext(IO) {
             var lastException: Throwable? = null
-            
+
             for (attempt in 0..maxRetries) {
                 try {
                     val nextResult = YouTube.next(endpoint, continuation).getOrThrow()
@@ -80,11 +79,14 @@ class YouTubeQueue(
     companion object {
         /**
          * Creates a radio queue based on a song.
-         * Uses only videoId to let YouTube personalize recommendations based on user's listening history.
+         * Explicitly requests the RDAMVM playlist to trigger automotive/radio mixing.
          */
         fun radio(song: MediaMetadata): YouTubeQueue {
             return YouTubeQueue(
-                WatchEndpoint(videoId = song.id),
+                WatchEndpoint(
+                    videoId = song.id,
+                    playlistId = "RDAMVM${song.id}"
+                ),
                 song
             )
         }


### PR DESCRIPTION
## Problem
When clicking "Random" on the Home Screen or starting a Radio from a single search result, the next song played is the same exact song or playback stops entirely.

## Cause
`YouTubeQueue.radio(song)` was only passing the song's `videoId` without a `playlistId`. YouTube's API recently started successfully returning a queue with only that single song instead of the expected automix radio queue.

## Solution
- Modified `YouTubeQueue.radio()` to explicitly pass the automix radio playlist ID (`RDAMVM` + `videoId`) allowing YouTube to generate the infinite radio mix.
- Added a check in `YouTubeQueue`'s `getInitialStatus()` to automatically inject the `RDAMVM` playlist if only a `videoId` is provided.

## Testing
1. Started the app and clicked "Random" button -> Verified infinite radio mix works and transitioning to "Next" plays a different song.
2. Searched for a song, played it directly -> Verified playing the single track boots up a radio mix as expected.

## Related Issues
- Closes #3135
