### PR TITLE
Changes to m3u playlist export

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/utils/PlaylistExporter.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/PlaylistExporter.kt
@@ -66,11 +66,9 @@ object PlaylistExporter {
                         val song = playlistSong.song.song
                         val artists = playlistSong.song.artists
                         append("#EXTINF:${song.duration},")
-                        append("${artists.joinToString(" - ") { it.name }} - ${song.title}")
+                        append("${artists.joinToString(";") { it.name }} - ${song.title}")
                         append("\n")
-                        // For M3U, we would typically include a URL, but since we don't have direct URLs,
-                        // we'll use a placeholder that indicates this is a YouTube Music track
-                        append("#YTM:${song.id}\n")
+                        append("https://youtube.com/watch?v=${song.id}\n")
                     }
                 }
 


### PR DESCRIPTION
## Problem
- Authors are seperated by ' - ', but should be seperated by ';'.
- I'm not sure why the video url is not included, because the video id is sufficient to do that.

## Cause
yes

## Solution
- Split multiple authors with ';' instead of ' - '
- Append youtube url with the video id

## Testing
Exported a test playlist in emulator
