### PR TITLE
feat(stats): add Play all action for stats page.

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/StatsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/StatsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -82,6 +83,10 @@ fun StatsScreen(
     val mostPlayedAlbums by viewModel.mostPlayedAlbums.collectAsState()
     val firstEvent by viewModel.firstEvent.collectAsState()
     val currentDate = LocalDateTime.now()
+    val orderedMostPlayedSongs = remember(mostPlayedSongsStats, mostPlayedSongs) {
+        val songsById = mostPlayedSongs.associateBy { it.song.id }
+        mostPlayedSongsStats.mapNotNull { statsSong -> songsById[statsSong.id] }
+    }
 
     val coroutineScope = rememberCoroutineScope()
     val lazyListState = rememberLazyListState()
@@ -247,6 +252,19 @@ fun StatsScreen(
             item(key = "mostPlayedSongs") {
                 NavigationTitle(
                     title = "${mostPlayedSongsStats.size} ${stringResource(id = R.string.songs)}",
+                    onPlayAllClick =
+                    if (orderedMostPlayedSongs.isNotEmpty()) {
+                        {
+                            playerConnection.playQueue(
+                                ListQueue(
+                                    title = context.getString(R.string.most_played_songs),
+                                    items = orderedMostPlayedSongs.map { it.toMediaMetadata().toMediaItem() },
+                                )
+                            )
+                        }
+                    } else {
+                        null
+                    },
                     modifier = Modifier.animateItem(),
                 )
 
@@ -279,22 +297,25 @@ fun StatsScreen(
                                             if (song.id == mediaMetadata?.id) {
                                                 playerConnection.togglePlayPause()
                                             } else {
+                                                val preloadSong = orderedMostPlayedSongs.getOrNull(index)
                                                 playerConnection.playQueue(
                                                     YouTubeQueue(
                                                         endpoint = WatchEndpoint(song.id),
-                                                        preloadItem = mostPlayedSongs[index].toMediaMetadata(),
+                                                        preloadItem = preloadSong?.toMediaMetadata(),
                                                     ),
                                                 )
                                             }
                                         },
                                         onLongClick = {
                                             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                            menuState.show {
-                                                SongMenu(
-                                                    originalSong = mostPlayedSongs[index],
-                                                    navController = navController,
-                                                    onDismiss = menuState::dismiss,
-                                                )
+                                            orderedMostPlayedSongs.getOrNull(index)?.let { selectedSong ->
+                                                menuState.show {
+                                                    SongMenu(
+                                                        originalSong = selectedSong,
+                                                        navController = navController,
+                                                        onDismiss = menuState::dismiss,
+                                                    )
+                                                }
                                             }
                                         },
                                     ).animateItem(),
@@ -404,8 +425,7 @@ fun StatsScreen(
         }
 
         // FAB to shuffle most played songs
-        if (mostPlayedSongs.isNotEmpty()) {
-            val mostPlayedSongsTitle = stringResource(R.string.most_played_songs)
+        if (orderedMostPlayedSongs.isNotEmpty()) {
             HideOnScrollFAB(
                 visible = true,
                 lazyListState = lazyListState,
@@ -413,8 +433,8 @@ fun StatsScreen(
                 onClick = {
                     playerConnection.playQueue(
                         ListQueue(
-                            title = mostPlayedSongsTitle,
-                            items = mostPlayedSongs.map { it.toMediaMetadata().toMediaItem() }.shuffled(),
+                            title = context.getString(R.string.most_played_songs),
+                            items = orderedMostPlayedSongs.map { it.toMediaMetadata().toMediaItem() }.shuffled(),
                         ),
                     )
                 },


### PR DESCRIPTION
## Problem
The stats page songs section has no bulk action to queue all listed songs in order, so users can only start playback per-song (or use shuffle).

## Cause
The songs category header in `StatsScreen` did not expose a `Play all` action, and there was no single ordered source used for queue-related actions in that section.

## Solution
- Added a `Play all` action to the stats songs header (`NavigationTitle` `onPlayAllClick`).
- Added an ordered source list derived from stats ranking (`mostPlayedSongsStats` mapped to full song entities by id).
- Wired `Play all` to start a **fresh queue** via `playerConnection.playQueue(ListQueue(...))` in on-screen order.
- Reused the same ordered source for related song actions (preload/menu mapping and shuffle source consistency).

## Testing
- Built successfully with:
  - `./gradlew :app:assembleFossDebug`
- Installed and launched on emulator.
- Manual verification step:
  - Open Stats -> Songs -> tap **Play all** and confirm queue order matches the visible ranked list.

## Screenshots:
<img width="1080" height="2400" alt="Screenshot_20260306_220529" src="https://github.com/user-attachments/assets/14417264-01b4-4b2e-bf78-bdf685e405a8" />


## Related Issues
- Closes #3158
- Related to #3158