### PR TITLE
fix(lastfm): adjust width of login dialog

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/LastFMSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/LastFMSettings.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
 import androidx.navigation.NavController
 import com.metrolist.lastfm.LastFM
 import com.metrolist.music.LocalPlayerAwareWindowInsets
@@ -128,6 +129,7 @@ fun LastFMSettings(
         var tempPassword by rememberSaveable { mutableStateOf("") }
 
         AlertDialog(
+            properties = DialogProperties(usePlatformDefaultWidth = false),
             onDismissRequest = {
                 if (!isLoggingIn) {
                     showLoginDialog = false
@@ -138,7 +140,6 @@ fun LastFMSettings(
             text = {
                 Column(
                     modifier = Modifier
-                        .fillMaxWidth()
                         .verticalScroll(rememberScrollState()),
                     verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
@@ -151,7 +152,6 @@ fun LastFMSettings(
                         label = { Text(stringResource(R.string.username)) },
                         singleLine = true,
                         enabled = !isLoggingIn,
-                        modifier = Modifier.fillMaxWidth()
                     )
                     OutlinedTextField(
                         value = tempPassword,
@@ -164,7 +164,6 @@ fun LastFMSettings(
                         visualTransformation = PasswordVisualTransformation(),
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
                         enabled = !isLoggingIn,
-                        modifier = Modifier.fillMaxWidth()
                     )
 
                     // Show error message if login failed


### PR DESCRIPTION
## Problem
the lastfm integration's lastfm dialog doesn't really match the width of other dialogs...
![IMG_20260307_112725](https://github.com/user-attachments/assets/ce1b5489-6db8-4f6b-bc9d-a16ee441002d)

## Solution
do NOT use fillmaxwidth
![IMG_20260307_112709](https://github.com/user-attachments/assets/a4df4988-bcf5-4947-8148-dc979c70815c)
