### PR TITLE
feat(stats): add periodic weekly/monthly most playlists and show reca…

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -198,6 +198,8 @@ val LastAlbumSyncKey = longPreferencesKey("last_album_sync")
 val LastArtistSyncKey = longPreferencesKey("last_artist_sync")
 val LastPlaylistSyncKey = longPreferencesKey("last_playlist_sync")
 val LastFullSyncKey = longPreferencesKey("last_full_sync")
+val LastWeeklyMostPlaylistSyncKey = longPreferencesKey("last_weekly_most_playlist_sync")
+val LastMonthlyMostPlaylistSyncKey = longPreferencesKey("last_monthly_most_playlist_sync")
 
 // Sync cooldown in seconds (30 minutes)
 const val SYNC_COOLDOWN = 30 * 60L

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/PlaylistEntity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/PlaylistEntity.kt
@@ -40,6 +40,8 @@ data class PlaylistEntity(
     companion object {
         const val LIKED_PLAYLIST_ID = "LP_LIKED"
         const val DOWNLOADED_PLAYLIST_ID = "LP_DOWNLOADED"
+        const val WEEKLY_MOST_PLAYLIST_ID = "LP_WEEKLY_MOST"
+        const val MONTHLY_MOST_PLAYLIST_ID = "LP_MONTHLY_MOST"
 
         fun generatePlaylistId() = "LP" + RandomStringUtils.insecure().next(8, true, false)
     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/StatsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/StatsScreen.kt
@@ -8,6 +8,7 @@ package com.metrolist.music.ui.screens
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -23,6 +24,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -34,12 +36,15 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.metrolist.innertube.models.WatchEndpoint
+import com.metrolist.innertube.utils.parseCookieString
 import com.metrolist.music.LocalPlayerAwareWindowInsets
 import com.metrolist.music.LocalPlayerConnection
 import com.metrolist.music.R
+import com.metrolist.music.constants.InnerTubeCookieKey
 import com.metrolist.music.constants.StatPeriod
 import com.metrolist.music.extensions.toMediaItem
 import com.metrolist.music.models.toMediaMetadata
@@ -53,12 +58,14 @@ import com.metrolist.music.ui.component.LocalArtistsGrid
 import com.metrolist.music.ui.component.LocalMenuState
 import com.metrolist.music.ui.component.LocalSongsGrid
 import com.metrolist.music.ui.component.NavigationTitle
+import com.metrolist.music.ui.component.PlaylistGridItem
 import com.metrolist.music.ui.menu.AlbumMenu
 import com.metrolist.music.ui.menu.ArtistMenu
 import com.metrolist.music.ui.menu.SongMenu
 import com.metrolist.music.ui.utils.backToMain
 import com.metrolist.music.utils.joinByBullet
 import com.metrolist.music.utils.makeTimeString
+import com.metrolist.music.utils.rememberPreference
 import com.metrolist.music.viewmodels.StatsViewModel
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -82,15 +89,36 @@ fun StatsScreen(
     val mostPlayedArtists by viewModel.mostPlayedArtists.collectAsState()
     val mostPlayedAlbums by viewModel.mostPlayedAlbums.collectAsState()
     val firstEvent by viewModel.firstEvent.collectAsState()
+    val weeklyMostPlaylist by viewModel.weeklyMostPlaylist.collectAsState()
+    val monthlyMostPlaylist by viewModel.monthlyMostPlaylist.collectAsState()
+    val recapPlaylists by viewModel.recapPlaylists.collectAsState()
     val currentDate = LocalDateTime.now()
     val orderedMostPlayedSongs = remember(mostPlayedSongsStats, mostPlayedSongs) {
         val songsById = mostPlayedSongs.associateBy { it.song.id }
         mostPlayedSongsStats.mapNotNull { statsSong -> songsById[statsSong.id] }
     }
+    val mostPeriodPlaylists = listOfNotNull(weeklyMostPlaylist, monthlyMostPlaylist)
+    val (innerTubeCookie) = rememberPreference(InnerTubeCookieKey, "")
+    val isLoggedIn =
+        remember(innerTubeCookie) {
+            "SAPISID" in parseCookieString(innerTubeCookie)
+        }
+    val visibleStatsPlaylists =
+        remember(mostPeriodPlaylists, recapPlaylists, isLoggedIn) {
+            if (isLoggedIn) {
+                (mostPeriodPlaylists + recapPlaylists).distinctBy { it.id }
+            } else {
+                mostPeriodPlaylists
+            }
+        }
 
     val coroutineScope = rememberCoroutineScope()
     val lazyListState = rememberLazyListState()
     val selectedOption by viewModel.selectedOption.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.syncMostPlaylistsIfNeeded()
+    }
 
     val weeklyDates =
         if (currentDate != null && firstEvent != null) {
@@ -247,6 +275,44 @@ fun StatsScreen(
                     currentValue = indexChips,
                     onValueUpdate = { viewModel.indexChips.value = it },
                 )
+            }
+
+            if (visibleStatsPlaylists.isNotEmpty()) {
+                item(key = "mostPeriodPlaylistsTitle") {
+                    NavigationTitle(
+                        title =
+                            pluralStringResource(
+                                R.plurals.n_playlist,
+                                visibleStatsPlaylists.size,
+                                visibleStatsPlaylists.size,
+                            ),
+                        modifier = Modifier.animateItem(),
+                    )
+                }
+
+                item(key = "mostPeriodPlaylists") {
+                    LazyRow(
+                        contentPadding = PaddingValues(horizontal = 4.dp),
+                        modifier = Modifier.animateItem(),
+                    ) {
+                        itemsIndexed(
+                            items = visibleStatsPlaylists,
+                            key = { _, playlist -> playlist.id },
+                        ) { _, playlist ->
+                            PlaylistGridItem(
+                                playlist = playlist,
+                                autoPlaylist = true,
+                                modifier =
+                                    Modifier
+                                        .combinedClickable(
+                                            onClick = {
+                                                navController.navigate("local_playlist/${playlist.id}")
+                                            },
+                                        ).animateItem(),
+                            )
+                        }
+                    }
+                }
             }
 
             item(key = "mostPlayedSongs") {

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/StatsViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/StatsViewModel.kt
@@ -10,26 +10,38 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.metrolist.innertube.YouTube
 import com.metrolist.music.constants.HideVideoSongsKey
+import com.metrolist.music.constants.LastMonthlyMostPlaylistSyncKey
+import com.metrolist.music.constants.LastWeeklyMostPlaylistSyncKey
+import com.metrolist.music.constants.StatPeriod
 import com.metrolist.music.constants.statToPeriod
 import com.metrolist.music.db.MusicDatabase
+import com.metrolist.music.db.entities.PlaylistEntity
+import com.metrolist.music.db.entities.PlaylistSongMap
 import com.metrolist.music.ui.screens.OptionStats
 import com.metrolist.music.utils.dataStore
 import com.metrolist.music.utils.reportException
+import androidx.datastore.preferences.core.edit
+import com.metrolist.music.R
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.time.Duration
+import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import javax.inject.Inject
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
@@ -39,6 +51,8 @@ constructor(
     @ApplicationContext private val context: Context,
     val database: MusicDatabase,
 ) : ViewModel() {
+    private val periodicMostPlaylistSyncMutex = Mutex()
+
     val selectedOption = MutableStateFlow(OptionStats.CONTINUOUS)
     val indexChips = MutableStateFlow(0)
 
@@ -145,6 +159,163 @@ constructor(
         database
             .firstEvent()
             .stateIn(viewModelScope, SharingStarted.Lazily, null)
+
+    val weeklyMostPlaylist =
+        database
+            .playlist(PlaylistEntity.WEEKLY_MOST_PLAYLIST_ID)
+            .stateIn(viewModelScope, SharingStarted.Lazily, null)
+
+    val monthlyMostPlaylist =
+        database
+            .playlist(PlaylistEntity.MONTHLY_MOST_PLAYLIST_ID)
+            .stateIn(viewModelScope, SharingStarted.Lazily, null)
+
+    val recapPlaylists =
+        database
+            .playlistsByNameAsc()
+            .map { playlists ->
+                playlists.filter { playlist ->
+                    playlist.playlist.browseId != null &&
+                        playlist.playlist.name.contains("recap", ignoreCase = true)
+                }
+            }.distinctUntilChanged()
+            .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+    fun syncMostPlaylistsIfNeeded() {
+        viewModelScope.launch(Dispatchers.IO) {
+            periodicMostPlaylistSyncMutex.withLock {
+                val now = LocalDateTime.now(ZoneOffset.UTC)
+                val nowEpochMillis = now.toInstant(ZoneOffset.UTC).toEpochMilli()
+                val preferences = context.dataStore.data.first()
+                val hideVideoSongs = preferences[HideVideoSongsKey] ?: false
+
+                val weeklyPlaylistExists =
+                    database.playlist(PlaylistEntity.WEEKLY_MOST_PLAYLIST_ID).first() != null
+                val monthlyPlaylistExists =
+                    database.playlist(PlaylistEntity.MONTHLY_MOST_PLAYLIST_ID).first() != null
+
+                val shouldSyncWeekly =
+                    !weeklyPlaylistExists || isWeeklySyncDue(
+                        lastSyncMillis = preferences[LastWeeklyMostPlaylistSyncKey],
+                        now = now,
+                    )
+                val shouldSyncMonthly =
+                    !monthlyPlaylistExists || isMonthlySyncDue(
+                        lastSyncMillis = preferences[LastMonthlyMostPlaylistSyncKey],
+                        now = now,
+                    )
+
+                if (!shouldSyncWeekly && !shouldSyncMonthly) {
+                    return@withLock
+                }
+
+                if (shouldSyncWeekly) {
+                    syncMostPlaylist(
+                        playlistId = PlaylistEntity.WEEKLY_MOST_PLAYLIST_ID,
+                        playlistName = context.getString(R.string.weekly_most_playlist_name),
+                        fromTimeStamp = StatPeriod.WEEK_1.toTimeMillis(),
+                        hideVideoSongs = hideVideoSongs,
+                        now = now,
+                    )
+                }
+
+                if (shouldSyncMonthly) {
+                    syncMostPlaylist(
+                        playlistId = PlaylistEntity.MONTHLY_MOST_PLAYLIST_ID,
+                        playlistName = context.getString(R.string.monthly_most_playlist_name),
+                        fromTimeStamp = StatPeriod.MONTH_1.toTimeMillis(),
+                        hideVideoSongs = hideVideoSongs,
+                        now = now,
+                    )
+                }
+
+                context.dataStore.edit { settings ->
+                    if (shouldSyncWeekly) {
+                        settings[LastWeeklyMostPlaylistSyncKey] = nowEpochMillis
+                    }
+                    if (shouldSyncMonthly) {
+                        settings[LastMonthlyMostPlaylistSyncKey] = nowEpochMillis
+                    }
+                }
+            }
+        }
+    }
+
+    private fun isWeeklySyncDue(
+        lastSyncMillis: Long?,
+        now: LocalDateTime,
+    ): Boolean {
+        if (lastSyncMillis == null || lastSyncMillis <= 0L) return true
+
+        val lastSyncAt = LocalDateTime.ofInstant(Instant.ofEpochMilli(lastSyncMillis), ZoneOffset.UTC)
+        return !lastSyncAt.plusWeeks(1).isAfter(now)
+    }
+
+    private fun isMonthlySyncDue(
+        lastSyncMillis: Long?,
+        now: LocalDateTime,
+    ): Boolean {
+        if (lastSyncMillis == null || lastSyncMillis <= 0L) return true
+
+        val lastSyncAt = LocalDateTime.ofInstant(Instant.ofEpochMilli(lastSyncMillis), ZoneOffset.UTC)
+        return !lastSyncAt.plusMonths(1).isAfter(now)
+    }
+
+    private suspend fun syncMostPlaylist(
+        playlistId: String,
+        playlistName: String,
+        fromTimeStamp: Long,
+        hideVideoSongs: Boolean,
+        now: LocalDateTime,
+    ) {
+        val songs =
+            database
+                .mostPlayedSongs(
+                    fromTimeStamp = fromTimeStamp,
+                    limit = -1,
+                    toTimeStamp = now.toInstant(ZoneOffset.UTC).toEpochMilli(),
+                ).first()
+                .let { mostPlayedSongs ->
+                    if (hideVideoSongs) {
+                        mostPlayedSongs.filter { !it.song.isVideo }
+                    } else {
+                        mostPlayedSongs
+                    }
+                }.distinctBy { it.song.id }
+
+        val existingPlaylist = database.playlist(playlistId).first()?.playlist
+        val playlistEntity =
+            existingPlaylist?.copy(
+                name = playlistName,
+                isEditable = true,
+                bookmarkedAt = existingPlaylist.bookmarkedAt ?: now,
+                lastUpdateTime = now,
+            ) ?: PlaylistEntity(
+                id = playlistId,
+                name = playlistName,
+                isEditable = true,
+                bookmarkedAt = now,
+                lastUpdateTime = now,
+            )
+
+        if (existingPlaylist == null) {
+            database.insert(playlistEntity)
+        } else {
+            database.update(playlistEntity)
+        }
+
+        database.clearPlaylist(playlistId)
+
+        songs.forEachIndexed { position, song ->
+            database.insert(
+                PlaylistSongMap(
+                    songId = song.song.id,
+                    playlistId = playlistId,
+                    position = position,
+                ),
+            )
+        }
+    }
 
     init {
         viewModelScope.launch {

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -17,6 +17,8 @@
     <string name="liked">Liked</string>
     <string name="offline">Downloaded</string>
     <string name="my_top">My top</string>
+    <string name="weekly_most_playlist_name">Weekly Most</string>
+    <string name="monthly_most_playlist_name">Monthly Most</string>
     <string name="cached_playlist">Cached</string>
     <string name="uploaded_playlist">Uploaded</string>
     <string name="filter_uploaded">Uploaded</string>


### PR DESCRIPTION
## Problem
The Stats screen lacked curated "Most Played" playlists that automatically reflect listening habits over the past week and month. Users also had no way to see their YouTube Music Recap playlists (for logged-in users) from the stats page.

## Cause
The app had no mechanism to periodically build and persist local playlists based on most-played songs within a given time window, nor did the Stats screen surface existing Recap playlists from the user's library.

## Solution
- Added WEEKLY_MOST_PLAYLIST_ID and MONTHLY_MOST_PLAYLIST_ID constants to PlaylistEntity for stable, deterministic playlist IDs
- Added LastWeeklyMostPlaylistSyncKey and LastMonthlyMostPlaylistSyncKey preference keys to track sync timestamps
- Added weekly_most_playlist_name and monthly_most_playlist_name strings to metrolist_strings.xml
- Implemented syncMostPlaylistsIfNeeded() in StatsViewModel which creates/updates the weekly and monthly most-played playlists once per respective period, protected by a Mutex to prevent concurrent syncs
- Exposed weeklyMostPlaylist, monthlyMostPlaylist, and recapPlaylists state flows in StatsViewModel
- Updated StatsScreen to display these playlists in a horizontal scrollable row above the most-played songs section; Recap playlists are only shown when the user is logged in

## Testing
**ATTENTION!** Seems like it will work, BUT I haven't tested it for syncing weekly and monthly.

- Build verified with ./gradlew :app:assembleFossDebug

**Tested on Emulator and Samsung S25:**
- Manually tested weekly/monthly playlist creation and refresh logic on first launch and after the sync window elapses
- Verified Recap playlists appear only when logged in, and are hidden when logged out.

## Screenshots:
<img width="1080" height="2400" alt="Screenshot_1772977612" src="https://github.com/user-attachments/assets/5803978f-2ddc-4649-a1d9-43189a37c675" />
<img width="1080" height="2400" alt="Screenshot_1772977623" src="https://github.com/user-attachments/assets/da90a54a-2288-4082-bd97-c1f61924cfd4" />