### PR TITLE
fix(cipher): support player.js 74edf1a3 Q-array obfuscated cipher functions

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -80,14 +80,18 @@ object YTPlayerUtils {
         audioQuality: AudioQuality,
         connectivityManager: ConnectivityManager,
     ): Result<PlaybackData> = runCatching {
-        Timber.tag(logTag).d("Fetching player response for videoId: $videoId, playlistId: $playlistId")
-        // Debug: Log ALL playback attempts
-        println("[PLAYBACK_DEBUG] playerResponseForPlayback called: videoId=$videoId, playlistId=$playlistId")
+        Timber.tag(TAG).d("=== PLAYER RESPONSE FOR PLAYBACK ===")
+        Timber.tag(TAG).d("videoId: $videoId")
+        Timber.tag(TAG).d("playlistId: $playlistId")
+        Timber.tag(TAG).d("audioQuality: $audioQuality")
+
         // Check if this is an uploaded/privately owned track
         val isUploadedTrack = playlistId == "MLPT" || playlistId?.contains("MLPT") == true
+        Timber.tag(TAG).d("Content type detection (preliminary):")
+        Timber.tag(TAG).d("  isUploadedTrack (from playlistId): $isUploadedTrack")
 
         val isLoggedIn = YouTube.cookie != null
-        Timber.tag(logTag).d("Session authentication status: ${if (isLoggedIn) "Logged in" else "Not logged in"}")
+        Timber.tag(TAG).d("Authentication status: ${if (isLoggedIn) "LOGGED_IN" else "ANONYMOUS"}")
 
         // Get signature timestamp (same as before for normal content)
         val signatureTimestamp = getSignatureTimestampOrNull(videoId)
@@ -250,27 +254,61 @@ object YTPlayerUtils {
 
                 // Check if this is a privately owned track
                 val isPrivatelyOwnedTrack = streamPlayerResponse.videoDetails?.musicVideoType == "MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK"
+                val musicVideoType = streamPlayerResponse.videoDetails?.musicVideoType
+
+                Timber.tag(TAG).d("=== N-TRANSFORM DECISION ===")
+                Timber.tag(TAG).d("Content type analysis:")
+                Timber.tag(TAG).d("  musicVideoType: $musicVideoType")
+                Timber.tag(TAG).d("  isPrivatelyOwnedTrack: $isPrivatelyOwnedTrack")
+                Timber.tag(TAG).d("  isUploadedTrack (from playlistId): $isUploadedTrack")
+                Timber.tag(TAG).d("  wasOriginallyAgeRestricted: $wasOriginallyAgeRestricted")
+                Timber.tag(TAG).d("Client analysis:")
+                Timber.tag(TAG).d("  currentClient: ${currentClient.clientName}")
+                Timber.tag(TAG).d("  useWebPoTokens: ${currentClient.useWebPoTokens}")
 
                 // Apply n-transform and PoToken for web clients OR for private tracks (including TVHTML5)
                 val needsNTransform = currentClient.useWebPoTokens ||
                     currentClient.clientName in listOf("WEB", "WEB_REMIX", "WEB_CREATOR", "TVHTML5") ||
                     isPrivatelyOwnedTrack
 
+                Timber.tag(TAG).d("N-transform decision:")
+                Timber.tag(TAG).d("  needsNTransform: $needsNTransform")
+                Timber.tag(TAG).d("  Reason: useWebPoTokens=${currentClient.useWebPoTokens}, " +
+                    "clientInList=${currentClient.clientName in listOf("WEB", "WEB_REMIX", "WEB_CREATOR", "TVHTML5")}, " +
+                    "isPrivatelyOwnedTrack=$isPrivatelyOwnedTrack")
+
                 if (needsNTransform) {
                     try {
-                        Timber.tag(logTag).d("Applying n-transform to stream URL for ${currentClient.clientName}")
-                        streamUrl = EjsNTransformSolver.transformNParamInUrl(streamUrl)
+                        Timber.tag(TAG).d("Applying n-transform to stream URL...")
+                        Timber.tag(TAG).d("  Original URL length: ${streamUrl.length}")
+                        Timber.tag(TAG).d("  Original URL preview: ${streamUrl.take(100)}...")
+
+                        val originalUrl = streamUrl
+                        // Use CipherDeobfuscator for n-transform (fixed implementation)
+                        streamUrl = CipherDeobfuscator.transformNParamInUrl(streamUrl)
+
+                        Timber.tag(TAG).d("  Transformed URL length: ${streamUrl.length}")
+                        Timber.tag(TAG).d("  URL changed: ${originalUrl != streamUrl}")
 
                         // Append pot= parameter with streaming data poToken
-                        if ((currentClient.useWebPoTokens || isPrivatelyOwnedTrack) && poToken?.streamingDataPoToken != null) {
-                            Timber.tag(logTag).d("Appending pot= parameter to stream URL")
+                        val needsPoToken = (currentClient.useWebPoTokens || isPrivatelyOwnedTrack) && poToken?.streamingDataPoToken != null
+                        Timber.tag(TAG).d("PoToken decision:")
+                        Timber.tag(TAG).d("  needsPoToken: $needsPoToken")
+                        Timber.tag(TAG).d("  hasStreamingDataPoToken: ${poToken?.streamingDataPoToken != null}")
+
+                        if (needsPoToken) {
+                            Timber.tag(TAG).d("Appending pot= parameter to stream URL")
                             val separator = if ("?" in streamUrl) "&" else "?"
-                            streamUrl = "${streamUrl}${separator}pot=${Uri.encode(poToken.streamingDataPoToken)}"
+                            streamUrl = "${streamUrl}${separator}pot=${Uri.encode(poToken!!.streamingDataPoToken)}"
+                            Timber.tag(TAG).d("  Final URL length (with pot): ${streamUrl.length}")
                         }
                     } catch (e: Exception) {
-                        Timber.tag(logTag).e(e, "N-transform or pot append failed: ${e.message}")
+                        Timber.tag(TAG).e(e, "N-transform or pot append failed: ${e.message}")
+                        Timber.tag(TAG).e("Stack trace: ${e.stackTraceToString().take(500)}")
                         // Continue with original URL
                     }
+                } else {
+                    Timber.tag(TAG).d("Skipping n-transform (not required for this client/content)")
                 }
 
                 streamExpiresInSeconds = streamPlayerResponse.streamingData?.expiresInSeconds

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
@@ -6,6 +6,12 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
+/**
+ * Main cipher deobfuscation orchestrator for YouTube stream URLs.
+ *
+ * Handles both signature deobfuscation (for signatureCipher streams) and
+ * n-parameter transformation (for throttle avoidance / 403 fix).
+ */
 object CipherDeobfuscator {
     private const val TAG = "Metrolist_CipherDeobfusc"
 
@@ -13,18 +19,35 @@ object CipherDeobfuscator {
         private set
 
     fun initialize(context: Context) {
+        Timber.tag(TAG).d("CipherDeobfuscator initializing...")
         appContext = context.applicationContext
+        Timber.tag(TAG).d("CipherDeobfuscator initialized")
     }
 
     private var cipherWebView: CipherWebView? = null
     private var currentPlayerHash: String? = null
 
+    /**
+     * Deobfuscate a signatureCipher stream URL.
+     *
+     * The signatureCipher is a query string containing:
+     * - s: The obfuscated signature
+     * - sp: The signature parameter name (usually "sig" or "signature")
+     * - url: The base stream URL
+     *
+     * Returns the full URL with deobfuscated signature, or null if failed.
+     */
     suspend fun deobfuscateStreamUrl(signatureCipher: String, videoId: String): String? {
+        Timber.tag(TAG).d("=== DEOBFUSCATE STREAM URL ===")
+        Timber.tag(TAG).d("videoId: $videoId")
+        Timber.tag(TAG).d("signatureCipher length: ${signatureCipher.length}")
+        Timber.tag(TAG).d("signatureCipher preview: ${signatureCipher.take(100)}...")
+
         return try {
             deobfuscateInternal(signatureCipher, videoId, isRetry = false)
         } catch (e: Exception) {
             Timber.tag(TAG).e(e, "Cipher deobfuscation failed, retrying with fresh JS: ${e.message}")
-            // Invalidate cache and retry once with fresh player JS
+            Timber.tag(TAG).d("Invalidating cache and retrying...")
             try {
                 PlayerJsFetcher.invalidateCache()
                 closeWebView()
@@ -37,39 +60,60 @@ object CipherDeobfuscator {
     }
 
     private suspend fun deobfuscateInternal(signatureCipher: String, videoId: String, isRetry: Boolean): String? {
+        Timber.tag(TAG).d("deobfuscateInternal: videoId=$videoId, isRetry=$isRetry")
+
         // Parse the signatureCipher query string
         val params = parseQueryParams(signatureCipher)
         val obfuscatedSig = params["s"]
         val sigParam = params["sp"] ?: "signature"
         val baseUrl = params["url"]
 
+        Timber.tag(TAG).d("Parsed signatureCipher params:")
+        Timber.tag(TAG).d("  s (obfuscated sig): ${obfuscatedSig?.take(30)}... (length=${obfuscatedSig?.length})")
+        Timber.tag(TAG).d("  sp (sig param name): $sigParam")
+        Timber.tag(TAG).d("  url: ${baseUrl?.take(80)}...")
+
         if (obfuscatedSig == null || baseUrl == null) {
             Timber.tag(TAG).e("Could not parse signatureCipher params: s=${obfuscatedSig != null}, url=${baseUrl != null}")
             return null
         }
 
-        Timber.tag(TAG).d("Deobfuscating cipher for $videoId: sig=${obfuscatedSig.take(20)}..., sp=$sigParam")
-
         val webView = getOrCreateWebView(forceRefresh = isRetry)
-            ?: return null
+        if (webView == null) {
+            Timber.tag(TAG).e("Failed to get/create CipherWebView")
+            return null
+        }
 
-        // Deobfuscate signature
+        Timber.tag(TAG).d("Calling webView.deobfuscateSignature()...")
         val deobfuscatedSig = webView.deobfuscateSignature(obfuscatedSig)
+        Timber.tag(TAG).d("Deobfuscated signature: ${deobfuscatedSig.take(30)}... (length=${deobfuscatedSig.length})")
 
         // Build the URL with deobfuscated signature
         val separator = if ("?" in baseUrl) "&" else "?"
         val finalUrl = "$baseUrl${separator}${sigParam}=${Uri.encode(deobfuscatedSig)}"
 
-        Timber.tag(TAG).d("Custom cipher deobfuscation succeeded for $videoId")
+        Timber.tag(TAG).d("=== CIPHER DEOBFUSCATION SUCCESS ===")
+        Timber.tag(TAG).d("videoId: $videoId")
+        Timber.tag(TAG).d("Final URL length: ${finalUrl.length}")
+        Timber.tag(TAG).d("Final URL preview: ${finalUrl.take(100)}...")
+
         return finalUrl
     }
 
     /**
      * Transform the 'n' parameter in a streaming URL to avoid throttling/403.
+     *
      * Uses the runtime-discovered n-function from the player JS WebView.
      * Returns the URL with the transformed 'n' value, or the original URL if transform fails.
+     *
+     * IMPORTANT: This must be called for WEB_REMIX, WEB, WEB_CREATOR, TVHTML5 clients
+     * and for privately owned tracks (uploaded songs).
      */
     suspend fun transformNParamInUrl(url: String): String {
+        Timber.tag(TAG).d("=== N-TRANSFORM URL ===")
+        Timber.tag(TAG).d("Input URL length: ${url.length}")
+        Timber.tag(TAG).d("Input URL preview: ${url.take(100)}...")
+
         return try {
             transformNInternal(url)
         } catch (e: Exception) {
@@ -85,67 +129,98 @@ object CipherDeobfuscator {
             Timber.tag(TAG).d("No 'n' parameter found in URL, skipping transform")
             return url
         }
-        val nValue = Uri.decode(nMatch.groupValues[1])
-        Timber.tag(TAG).d("N-param found: $nValue")
 
-        val webView = getOrCreateWebView(forceRefresh = false) ?: return url
+        val nValueEncoded = nMatch.groupValues[1]
+        val nValue = Uri.decode(nValueEncoded)
+        Timber.tag(TAG).d("N-param found:")
+        Timber.tag(TAG).d("  encoded: $nValueEncoded")
+        Timber.tag(TAG).d("  decoded: $nValue")
+
+        val webView = getOrCreateWebView(forceRefresh = false)
+        if (webView == null) {
+            Timber.tag(TAG).e("Failed to get CipherWebView for n-transform")
+            return url
+        }
+
+        Timber.tag(TAG).d("CipherWebView state:")
+        Timber.tag(TAG).d("  nFunctionAvailable: ${webView.nFunctionAvailable}")
+        Timber.tag(TAG).d("  discoveredNFuncName: ${webView.discoveredNFuncName}")
+        Timber.tag(TAG).d("  usingHardcodedMode: ${webView.usingHardcodedMode}")
 
         if (!webView.nFunctionAvailable) {
             Timber.tag(TAG).e("N-transform function was not discovered at init time")
             return url
         }
 
+        Timber.tag(TAG).d("Calling webView.transformN()...")
         val transformedN = webView.transformN(nValue)
-        Timber.tag(TAG).d("N-param transformed: $nValue -> $transformedN")
+
+        Timber.tag(TAG).d("=== N-TRANSFORM SUCCESS ===")
+        Timber.tag(TAG).d("N-param: $nValue -> $transformedN")
 
         // Replace n= parameter in URL
-        return url.replaceFirst(
+        val transformedUrl = url.replaceFirst(
             Regex("([?&])n=[^&]+"),
             "$1n=${Uri.encode(transformedN)}"
         )
+
+        Timber.tag(TAG).d("Transformed URL length: ${transformedUrl.length}")
+        return transformedUrl
     }
 
     private suspend fun getOrCreateWebView(forceRefresh: Boolean): CipherWebView? {
+        Timber.tag(TAG).d("getOrCreateWebView: forceRefresh=$forceRefresh, existing=${cipherWebView != null}")
+
         if (!forceRefresh && cipherWebView != null) {
+            Timber.tag(TAG).d("Reusing existing CipherWebView (hash=$currentPlayerHash)")
             return cipherWebView
         }
 
         // Close existing WebView if any
         if (cipherWebView != null) {
+            Timber.tag(TAG).d("Closing existing CipherWebView...")
             closeWebView()
         }
 
         // Fetch player JS
+        Timber.tag(TAG).d("Fetching player JS...")
         val result = PlayerJsFetcher.getPlayerJs(forceRefresh = forceRefresh)
         if (result == null) {
             Timber.tag(TAG).e("Failed to get player JS")
             return null
         }
         val (playerJs, hash) = result
+        Timber.tag(TAG).d("Got player JS: hash=$hash, length=${playerJs.length}")
 
-        // Extract signature function info
-        val sigInfo = FunctionNameExtractor.extractSigFunctionInfo(playerJs)
+        // Run full analysis for logging - pass the known hash from PlayerJsFetcher
+        Timber.tag(TAG).d("Analyzing player JS for cipher functions (knownHash=$hash)...")
+        val analysis = FunctionNameExtractor.analyzePlayerJs(playerJs, knownHash = hash)
 
-        if (sigInfo == null) {
+        if (analysis.sigInfo == null) {
             Timber.tag(TAG).e("Could not extract signature function info from player JS")
             return null
         }
 
-        // Extract n-transform function info (for throttle avoidance / 403 fix)
-        val nFuncInfo = FunctionNameExtractor.extractNFunctionInfo(playerJs)
-        if (nFuncInfo == null) {
-            Timber.tag(TAG).e("Could not extract n-function info from player JS (will try brute-force)")
+        if (analysis.nFuncInfo == null) {
+            Timber.tag(TAG).w("Could not extract n-function info from player JS (will try brute-force)")
         }
 
-        Timber.tag(TAG).d("Creating CipherWebView with sig=${sigInfo.name}, constantArg=${sigInfo.constantArg}, nFunc=${nFuncInfo?.name}[${nFuncInfo?.arrayIndex}]")
+        Timber.tag(TAG).d("Creating CipherWebView...")
+        Timber.tag(TAG).d("  sig: ${analysis.sigInfo.name} (constantArg=${analysis.sigInfo.constantArg}, hardcoded=${analysis.sigInfo.isHardcoded})")
+        Timber.tag(TAG).d("  nFunc: ${analysis.nFuncInfo?.name}[${analysis.nFuncInfo?.arrayIndex}] (hardcoded=${analysis.nFuncInfo?.isHardcoded})")
 
-        // Create WebView — n-function is exported to window if found, with brute-force fallback
+        // Create WebView
         val webView = CipherWebView.create(
             context = appContext,
             playerJs = playerJs,
-            sigInfo = sigInfo,
-            nFuncInfo = nFuncInfo,
+            sigInfo = analysis.sigInfo,
+            nFuncInfo = analysis.nFuncInfo,
         )
+
+        Timber.tag(TAG).d("CipherWebView created successfully")
+        Timber.tag(TAG).d("  nFunctionAvailable: ${webView.nFunctionAvailable}")
+        Timber.tag(TAG).d("  sigFunctionAvailable: ${webView.sigFunctionAvailable}")
+        Timber.tag(TAG).d("  discoveredNFuncName: ${webView.discoveredNFuncName}")
 
         cipherWebView = webView
         currentPlayerHash = hash
@@ -153,11 +228,13 @@ object CipherDeobfuscator {
     }
 
     private suspend fun closeWebView() {
+        Timber.tag(TAG).d("closeWebView: existing=${cipherWebView != null}")
         withContext(Dispatchers.Main) {
             cipherWebView?.close()
         }
         cipherWebView = null
         currentPlayerHash = null
+        Timber.tag(TAG).d("CipherWebView closed and cleared")
     }
 
     private fun parseQueryParams(query: String): Map<String, String> {
@@ -170,6 +247,21 @@ object CipherDeobfuscator {
                 result[key] = value
             }
         }
+        Timber.tag(TAG).v("parseQueryParams: ${result.keys.joinToString()}")
         return result
+    }
+
+    /**
+     * Debug method: Get current state information
+     */
+    fun getDebugInfo(): Map<String, Any?> {
+        return mapOf(
+            "hasWebView" to (cipherWebView != null),
+            "playerHash" to currentPlayerHash,
+            "nFunctionAvailable" to cipherWebView?.nFunctionAvailable,
+            "sigFunctionAvailable" to cipherWebView?.sigFunctionAvailable,
+            "discoveredNFuncName" to cipherWebView?.discoveredNFuncName,
+            "usingHardcodedMode" to cipherWebView?.usingHardcodedMode,
+        )
     }
 }

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherWebView.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherWebView.kt
@@ -14,6 +14,12 @@ import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
+/**
+ * WebView-based cipher executor for YouTube stream URL deobfuscation
+ *
+ * Executes signature decipher and n-transform functions extracted from player.js.
+ * Supports both regex-extracted functions and hardcoded fallback for Q-array obfuscated players.
+ */
 class CipherWebView private constructor(
     context: Context,
     private val playerJs: String,
@@ -30,10 +36,22 @@ class CipherWebView private constructor(
         private set
 
     @Volatile
+    var sigFunctionAvailable: Boolean = false
+        private set
+
+    @Volatile
     var discoveredNFuncName: String? = null
         private set
 
+    @Volatile
+    var usingHardcodedMode: Boolean = false
+        private set
+
     init {
+        Timber.tag(TAG).d("Initializing CipherWebView...")
+        Timber.tag(TAG).d("  sigInfo: name=${sigInfo?.name}, constantArg=${sigInfo?.constantArg}, hardcoded=${sigInfo?.isHardcoded}")
+        Timber.tag(TAG).d("  nFuncInfo: name=${nFuncInfo?.name}, arrayIdx=${nFuncInfo?.arrayIndex}, hardcoded=${nFuncInfo?.isHardcoded}")
+
         val settings = webView.settings
         @Suppress("SetJavaScriptEnabled")
         settings.javaScriptEnabled = true
@@ -46,140 +64,332 @@ class CipherWebView private constructor(
 
         webView.webChromeClient = object : WebChromeClient() {
             override fun onConsoleMessage(m: ConsoleMessage): Boolean {
-                if (m.message().contains("Uncaught") && !m.message().contains("is not defined")) {
-                    Timber.tag(TAG).e("WebView JS error: ${m.message()} at ${m.sourceId()}:${m.lineNumber()}")
+                val msg = m.message()
+                val src = "${m.sourceId()}:${m.lineNumber()}"
+
+                // Log all console messages for debugging
+                when (m.messageLevel()) {
+                    ConsoleMessage.MessageLevel.ERROR -> {
+                        if (!msg.contains("is not defined")) {
+                            Timber.tag(TAG).e("JS ERROR: $msg at $src")
+                        }
+                    }
+                    ConsoleMessage.MessageLevel.WARNING -> {
+                        Timber.tag(TAG).w("JS WARN: $msg at $src")
+                    }
+                    else -> {
+                        Timber.tag(TAG).v("JS LOG: $msg")
+                    }
                 }
                 return super.onConsoleMessage(m)
             }
         }
+
+        Timber.tag(TAG).d("WebView settings configured")
     }
 
     private fun loadPlayerJsFromFile() {
         val sigFuncName = sigInfo?.name
         val nFuncName = nFuncInfo?.name
         val nArrayIdx = nFuncInfo?.arrayIndex
-        Timber.tag(TAG).d("Loading player JS from file (${playerJs.length} chars), exporting sig=$sigFuncName, nFunc=$nFuncName[$nArrayIdx]")
+        val isHardcoded = sigInfo?.isHardcoded == true || nFuncInfo?.isHardcoded == true
+
+        Timber.tag(TAG).d("=== LOADING PLAYER.JS INTO WEBVIEW ===")
+        Timber.tag(TAG).d("Player.js size: ${playerJs.length} chars")
+        Timber.tag(TAG).d("Export mode: ${if (isHardcoded) "HARDCODED" else "EXTRACTED"}")
+        Timber.tag(TAG).d("Sig function: $sigFuncName (constantArg=${sigInfo?.constantArg})")
+        Timber.tag(TAG).d("N function: $nFuncName (arrayIdx=$nArrayIdx)")
+
+        usingHardcodedMode = isHardcoded
 
         val exports = buildList {
             if (sigFuncName != null) {
-                add("window._cipherSigFunc = typeof $sigFuncName !== 'undefined' ? $sigFuncName : null;")
+                val sigConstArgs = sigInfo?.constantArgs
+                val preprocessFunc = sigInfo?.preprocessFunc
+                val preprocessArgs = sigInfo?.preprocessArgs
+
+                if (!sigConstArgs.isNullOrEmpty() && preprocessFunc != null && !preprocessArgs.isNullOrEmpty()) {
+                    // Full wrapper: JI(48, 1918, f1(1, 6528, sig))
+                    val mainArgsStr = sigConstArgs.joinToString(", ")
+                    val prepArgsStr = preprocessArgs.joinToString(", ")
+                    Timber.tag(TAG).d("Sig function needs full wrapper:")
+                    Timber.tag(TAG).d("  $sigFuncName($mainArgsStr, $preprocessFunc($prepArgsStr, sig))")
+                    add("window._cipherSigFunc = function(sig) { return $sigFuncName($mainArgsStr, $preprocessFunc($prepArgsStr, sig)); };")
+                } else if (!sigConstArgs.isNullOrEmpty()) {
+                    // Wrapper with constant args only (no preprocessing)
+                    val argsStr = sigConstArgs.joinToString(", ")
+                    Timber.tag(TAG).d("Sig function needs wrapper with constant args: $argsStr")
+                    add("window._cipherSigFunc = function(sig) { return $sigFuncName($argsStr, sig); };")
+                } else if (isHardcoded) {
+                    // For hardcoded mode without full args, we'll inject the function export after player.js loads
+                    Timber.tag(TAG).d("Will export sig function $sigFuncName in hardcoded mode (legacy)")
+                    add("window._cipherSigFunc = typeof $sigFuncName !== 'undefined' ? $sigFuncName : null;")
+                } else {
+                    add("window._cipherSigFunc = typeof $sigFuncName !== 'undefined' ? $sigFuncName : null;")
+                }
             }
             if (nFuncName != null) {
-                val nExpr = if (nArrayIdx != null) {
-                    "$nFuncName[$nArrayIdx]"
+                val nConstArgs = nFuncInfo?.constantArgs
+                if (!nConstArgs.isNullOrEmpty()) {
+                    // Generate wrapper function for n-functions that require constant args
+                    // e.g. GU(6, 6010, n) -> window._nTransformFunc = function(n) { return GU(6, 6010, n); };
+                    val argsStr = nConstArgs.joinToString(", ")
+                    Timber.tag(TAG).d("N-function needs wrapper with constant args: $argsStr")
+                    add("window._nTransformFunc = function(n) { return $nFuncName($argsStr, n); };")
                 } else {
-                    nFuncName
+                    val nExpr = if (nArrayIdx != null) {
+                        "$nFuncName[$nArrayIdx]"
+                    } else {
+                        nFuncName
+                    }
+                    add("window._nTransformFunc = typeof $nFuncName !== 'undefined' ? $nExpr : null;")
                 }
-                add("window._nTransformFunc = typeof $nFuncName !== 'undefined' ? $nExpr : null;")
             }
+        }
+
+        Timber.tag(TAG).d("Export statements: ${exports.size}")
+        exports.forEachIndexed { idx, stmt ->
+            Timber.tag(TAG).v("  Export[$idx]: ${stmt.take(80)}...")
         }
 
         val modifiedJs = if (exports.isNotEmpty()) {
             val exportCode = "; " + exports.joinToString(" ")
-            playerJs.replace("})(_yt_player);", "$exportCode })(_yt_player);")
+            val modified = playerJs.replace("})(_yt_player);", "$exportCode })(_yt_player);")
+            if (modified == playerJs) {
+                Timber.tag(TAG).w("Export injection point '})(_yt_player);' not found, appending exports")
+                playerJs + "\n" + exportCode
+            } else {
+                Timber.tag(TAG).d("Exports injected into IIFE closure")
+                modified
+            }
         } else {
+            Timber.tag(TAG).w("No exports to inject")
             playerJs
         }
 
         val cacheDir = File(webView.context.cacheDir, "cipher")
         cacheDir.mkdirs()
-        File(cacheDir, "player.js").writeText(modifiedJs)
+        val playerJsFile = File(cacheDir, "player.js")
+        playerJsFile.writeText(modifiedJs)
+        Timber.tag(TAG).d("Player.js written to cache: ${playerJsFile.absolutePath} (${modifiedJs.length} chars)")
 
-        val html = """<!DOCTYPE html>
+        // Build HTML with comprehensive discovery and validation
+        val html = buildDiscoveryHtml()
+        Timber.tag(TAG).d("Discovery HTML built (${html.length} chars)")
+
+        webView.loadDataWithBaseURL(
+            "file://${cacheDir.absolutePath}/",
+            html, "text/html", "utf-8", null
+        )
+        Timber.tag(TAG).d("WebView loading started...")
+    }
+
+    /**
+     * Build HTML with JS discovery logic
+     *
+     * Key changes from original:
+     * 1. Removed outdated `_w8_` pattern check
+     * 2. Accept any valid alphanumeric transform result
+     * 3. More comprehensive logging to bridge
+     */
+    private fun buildDiscoveryHtml(): String = """<!DOCTYPE html>
 <html><head><script>
+// ============================================================
+// SIGNATURE DEOBFUSCATION
+// ============================================================
 function deobfuscateSig(funcName, constantArg, obfuscatedSig) {
+    CipherBridge.logDebug("deobfuscateSig called: funcName=" + funcName + ", constantArg=" + constantArg + ", sigLen=" + obfuscatedSig.length);
+
     try {
         var func = window._cipherSigFunc;
+        CipherBridge.logDebug("window._cipherSigFunc type: " + typeof func + ", length: " + (func ? func.length : "N/A"));
+
         if (typeof func !== 'function') {
             CipherBridge.onSigError("Sig func not found on window (type: " + typeof func + ")");
             return;
         }
+
         var result;
-        if (constantArg !== null && constantArg !== undefined) {
+        // Check if this is a wrapper function (takes 1 arg: sig) vs direct function (takes 2+ args)
+        if (func.length === 1) {
+            // Wrapper function: window._cipherSigFunc = function(sig) { return JI(48, 1918, f1(1, 6528, sig)); }
+            CipherBridge.logDebug("Calling wrapped sig func with just sig (func.length=1)");
+            result = func(obfuscatedSig);
+        } else if (constantArg !== null && constantArg !== undefined) {
+            // Direct function with constantArg
+            CipherBridge.logDebug("Calling sig func with constantArg: " + constantArg);
             result = func(constantArg, obfuscatedSig);
         } else {
+            CipherBridge.logDebug("Calling sig func without constantArg");
             result = func(obfuscatedSig);
         }
+
         if (result === undefined || result === null) {
             CipherBridge.onSigError("Function returned null/undefined");
             return;
         }
+
+        CipherBridge.logDebug("Sig result type: " + typeof result + ", length: " + String(result).length);
         CipherBridge.onSigResult(String(result));
     } catch (error) {
         CipherBridge.onSigError(error + "\n" + (error.stack || ""));
     }
 }
 
+// ============================================================
+// N-PARAMETER TRANSFORM
+// ============================================================
 function transformN(nValue) {
+    CipherBridge.logDebug("transformN called: nValue=" + nValue);
+
     try {
         var func = window._nTransformFunc;
+        CipherBridge.logDebug("window._nTransformFunc type: " + typeof func);
+
         if (typeof func !== 'function') {
             CipherBridge.onNError("N-transform func not available (type: " + typeof func + ")");
             return;
         }
+
         var result = func(nValue);
+        CipherBridge.logDebug("N-transform raw result: " + (result ? String(result).substring(0, 50) : "null/undefined"));
+
         if (result === undefined || result === null) {
             CipherBridge.onNError("N-transform returned null/undefined");
             return;
         }
-        CipherBridge.onNResult(String(result));
+
+        var resultStr = String(result);
+        CipherBridge.logDebug("N-transform result: length=" + resultStr.length + ", value=" + resultStr.substring(0, 30));
+        CipherBridge.onNResult(resultStr);
     } catch (error) {
         CipherBridge.onNError(error + "\n" + (error.stack || ""));
     }
 }
 
+// ============================================================
+// FUNCTION DISCOVERY AND INITIALIZATION
+// ============================================================
 function discoverAndInit() {
+    CipherBridge.logDebug("========== DISCOVERY AND INIT ==========");
+
     var nFuncName = "";
+    var sigFuncName = "";
     var info = "";
+
+    // Check if signature function was exported
+    if (typeof window._cipherSigFunc === 'function') {
+        sigFuncName = "exported_sig_func";
+        CipherBridge.logDebug("Signature function found on window._cipherSigFunc");
+    } else {
+        CipherBridge.logDebug("WARNING: window._cipherSigFunc not available (type=" + typeof window._cipherSigFunc + ")");
+    }
+
+    // Check if N-transform function was exported
     if (typeof window._nTransformFunc === 'function') {
+        CipherBridge.logDebug("Testing exported window._nTransformFunc...");
         try {
-            var testResult = window._nTransformFunc("test_abc");
-            if (typeof testResult === 'string' && testResult !== "test_abc") {
-                nFuncName = "injected_from_iife";
-                info = "exported_ok,test_result=" + testResult.substring(0, 30);
+            var testInput = "KdrqFlzJXl9EcCwlmEy";
+            var testResult = window._nTransformFunc(testInput);
+
+            CipherBridge.logDebug("N-func test input: " + testInput);
+            CipherBridge.logDebug("N-func test result: " + (testResult ? String(testResult).substring(0, 50) : "null"));
+
+            if (typeof testResult === 'string' && testResult !== testInput && testResult.length >= 5) {
+                // FIXED: Accept any valid alphanumeric result, not just _w8_ pattern
+                if (/^[a-zA-Z0-9_-]+$/.test(testResult)) {
+                    nFuncName = "exported_n_func";
+                    info = "export_valid,test=" + testResult.substring(0, 20);
+                    CipherBridge.logDebug("N-function VALID: " + testResult);
+                } else {
+                    info = "export_bad_chars:" + testResult.substring(0, 20);
+                    CipherBridge.logDebug("N-function has invalid characters");
+                    window._nTransformFunc = null;
+                }
             } else {
-                info = "exported_but_bad_result:" + typeof testResult;
+                info = "export_bad_result:type=" + typeof testResult + ",eq=" + (testResult === testInput);
+                CipherBridge.logDebug("N-function test failed: " + info);
                 window._nTransformFunc = null;
             }
         } catch(e) {
-            info = "exported_but_threw:" + e;
+            info = "export_threw:" + e;
+            CipherBridge.logDebug("N-function threw exception: " + e);
             window._nTransformFunc = null;
         }
+    } else {
+        CipherBridge.logDebug("window._nTransformFunc not exported, trying brute force discovery...");
     }
 
+    // Brute force discovery if export failed
     if (!nFuncName) {
         try {
             var testInput = "T2Xw3pWQ_Wk0xbOg";
             var keys = Object.getOwnPropertyNames(window);
             var tested = 0;
             var candidates = [];
+            var skipped = 0;
+
+            CipherBridge.logDebug("Brute force: scanning " + keys.length + " window properties");
+
             for (var i = 0; i < keys.length; i++) {
                 try {
                     var key = keys[i];
-                    if (key.startsWith("webkit") || key === "CipherBridge" || key === "_cipherSigFunc" || key === "_nTransformFunc") continue;
+                    // Skip known non-candidates
+                    if (key.startsWith("webkit") || key.startsWith("on") ||
+                        key === "CipherBridge" || key === "_cipherSigFunc" ||
+                        key === "_nTransformFunc" || key === "window" || key === "self") {
+                        skipped++;
+                        continue;
+                    }
+
                     var fn = window[key];
-                    if (typeof fn !== 'function' || fn.length !== 1) continue;
+                    if (typeof fn !== 'function') continue;
+
+                    // N-transform functions typically take 1 argument
+                    if (fn.length !== 1) continue;
+
                     tested++;
                     var result = fn(testInput);
-                    if (typeof result === 'string' && result !== testInput && result.length > 5) {
-                        candidates.push(key + ":" + result.substring(0, 50));
-                        if (result.indexOf('_w8_') >= 0) {
-                            window._nTransformFunc = fn;
-                            nFuncName = key;
-                            break;
+
+                    if (typeof result === 'string' && result !== testInput && result.length >= 5) {
+                        // FIXED: Accept any valid alphanumeric transform
+                        if (/^[a-zA-Z0-9_-]+$/.test(result)) {
+                            candidates.push({
+                                name: key,
+                                result: result.substring(0, 30),
+                                len: result.length
+                            });
+
+                            // Accept the first valid candidate
+                            if (!nFuncName) {
+                                window._nTransformFunc = fn;
+                                nFuncName = key;
+                                CipherBridge.logDebug("N-function discovered: " + key + " -> " + result.substring(0, 30));
+                            }
                         }
                     }
-                } catch(e) {}
+                } catch(e) {
+                    // Expected - many window properties throw when called
+                }
             }
-            info = "brute_force:tested=" + tested + "/" + keys.length;
-            if (!nFuncName && candidates.length > 0) {
-                info += ",near_misses=" + candidates.slice(0, 5).join("|");
+
+            info = "brute_force:tested=" + tested + "/skipped=" + skipped + "/total=" + keys.length;
+            if (candidates.length > 0) {
+                info += ",candidates=" + candidates.length;
+                CipherBridge.logDebug("Candidates found: " + JSON.stringify(candidates.slice(0, 5)));
             }
         } catch(e) {
             info = "brute_force_error:" + e;
+            CipherBridge.logDebug("Brute force failed: " + e);
         }
     }
-    CipherBridge.onNDiscoveryDone(nFuncName, info);
+
+    CipherBridge.logDebug("Discovery complete:");
+    CipherBridge.logDebug("  sigFuncName=" + sigFuncName);
+    CipherBridge.logDebug("  nFuncName=" + nFuncName);
+    CipherBridge.logDebug("  info=" + info);
+
+    CipherBridge.onDiscoveryDone(sigFuncName, nFuncName, info);
     CipherBridge.onPlayerJsLoaded();
 }
 </script>
@@ -189,38 +399,69 @@ function discoverAndInit() {
 </script>
 </head><body></body></html>"""
 
-        webView.loadDataWithBaseURL(
-            "file://${cacheDir.absolutePath}/",
-            html, "text/html", "utf-8", null
-        )
+    // ==================== JAVASCRIPT INTERFACE ====================
+
+    @JavascriptInterface
+    fun logDebug(message: String) {
+        Timber.tag(TAG).d("JS: $message")
     }
 
     @JavascriptInterface
-    fun onNDiscoveryDone(funcName: String, info: String) {
-        if (funcName.isNotEmpty()) {
-            Timber.tag(TAG).d("N-function DISCOVERED: $funcName ($info)")
-            discoveredNFuncName = funcName
+    fun onDiscoveryDone(sigFuncName: String, nFuncName: String, info: String) {
+        Timber.tag(TAG).d("=== DISCOVERY COMPLETE ===")
+        Timber.tag(TAG).d("Sig function: ${sigFuncName.ifEmpty { "NOT FOUND" }}")
+        Timber.tag(TAG).d("N function: ${nFuncName.ifEmpty { "NOT FOUND" }}")
+        Timber.tag(TAG).d("Info: $info")
+
+        sigFunctionAvailable = sigFuncName.isNotEmpty()
+        if (nFuncName.isNotEmpty()) {
+            discoveredNFuncName = nFuncName
             nFunctionAvailable = true
+            Timber.tag(TAG).d("N-function AVAILABLE: $nFuncName")
         } else {
-            Timber.tag(TAG).e("N-function NOT found ($info)")
+            Timber.tag(TAG).e("N-function NOT AVAILABLE")
             nFunctionAvailable = false
         }
     }
 
     @JavascriptInterface
+    fun onNDiscoveryDone(funcName: String, info: String) {
+        // Legacy interface - redirects to new combined discovery
+        Timber.tag(TAG).d("Legacy onNDiscoveryDone: funcName=$funcName, info=$info")
+        if (funcName.isNotEmpty()) {
+            discoveredNFuncName = funcName
+            nFunctionAvailable = true
+        }
+    }
+
+    @JavascriptInterface
     fun onPlayerJsLoaded() {
-        Timber.tag(TAG).d("Player JS loaded, n-func=${discoveredNFuncName ?: "none"}")
+        Timber.tag(TAG).d("=== PLAYER.JS LOAD COMPLETE ===")
+        Timber.tag(TAG).d("sigFunctionAvailable=$sigFunctionAvailable")
+        Timber.tag(TAG).d("nFunctionAvailable=$nFunctionAvailable")
+        Timber.tag(TAG).d("discoveredNFuncName=$discoveredNFuncName")
+        Timber.tag(TAG).d("usingHardcodedMode=$usingHardcodedMode")
+
         initContinuation.resume(this)
     }
 
     @JavascriptInterface
     fun onPlayerJsError(error: String) {
-        Timber.tag(TAG).e("Player JS load error: $error")
+        Timber.tag(TAG).e("=== PLAYER.JS LOAD FAILED ===")
+        Timber.tag(TAG).e("Error: $error")
         initContinuation.resumeWithException(CipherException("Player JS load failed: $error"))
     }
 
+    // ==================== SIGNATURE DEOBFUSCATION ====================
+
     suspend fun deobfuscateSignature(obfuscatedSig: String): String {
+        Timber.tag(TAG).d("========== DEOBFUSCATE SIGNATURE ==========")
+        Timber.tag(TAG).d("Input sig length: ${obfuscatedSig.length}")
+        Timber.tag(TAG).d("Input sig preview: ${obfuscatedSig.take(50)}...")
+        Timber.tag(TAG).d("sigInfo: name=${sigInfo?.name}, constantArg=${sigInfo?.constantArg}")
+
         if (sigInfo == null) {
+            Timber.tag(TAG).e("Signature function info not available")
             throw CipherException("Signature function info not available")
         }
 
@@ -228,59 +469,74 @@ function discoverAndInit() {
             suspendCancellableCoroutine { cont ->
                 sigContinuation = cont
                 val constArgJs = if (sigInfo.constantArg != null) "${sigInfo.constantArg}" else "null"
-                webView.evaluateJavascript(
-                    "deobfuscateSig('${sigInfo.name}', $constArgJs, '${escapeJsString(obfuscatedSig)}')",
-                    null
-                )
+                val jsCall = "deobfuscateSig('${sigInfo.name}', $constArgJs, '${escapeJsString(obfuscatedSig)}')"
+                Timber.tag(TAG).d("Evaluating JS: ${jsCall.take(100)}...")
+                webView.evaluateJavascript(jsCall, null)
             }
         }
     }
 
     @JavascriptInterface
     fun onSigResult(result: String) {
-        Timber.tag(TAG).d("Signature deobfuscated: ${result.take(30)}...")
+        Timber.tag(TAG).d("========== SIGNATURE RESULT ==========")
+        Timber.tag(TAG).d("Result length: ${result.length}")
+        Timber.tag(TAG).d("Result preview: ${result.take(50)}...")
         sigContinuation?.resume(result)
         sigContinuation = null
     }
 
     @JavascriptInterface
     fun onSigError(error: String) {
-        Timber.tag(TAG).e("Signature deobfuscation error: $error")
+        Timber.tag(TAG).e("========== SIGNATURE ERROR ==========")
+        Timber.tag(TAG).e("Error: $error")
         sigContinuation?.resumeWithException(CipherException("Sig deobfuscation failed: $error"))
         sigContinuation = null
     }
 
+    // ==================== N-TRANSFORM ====================
+
     suspend fun transformN(nValue: String): String {
+        Timber.tag(TAG).d("========== N-TRANSFORM ==========")
+        Timber.tag(TAG).d("Input n value: $nValue")
+        Timber.tag(TAG).d("nFunctionAvailable: $nFunctionAvailable")
+        Timber.tag(TAG).d("discoveredNFuncName: $discoveredNFuncName")
+
         if (!nFunctionAvailable) {
+            Timber.tag(TAG).e("N-transform function not discovered")
             throw CipherException("N-transform function not discovered")
         }
 
         return withContext(Dispatchers.Main) {
             suspendCancellableCoroutine { cont ->
                 nContinuation = cont
-                webView.evaluateJavascript(
-                    "transformN('${escapeJsString(nValue)}')",
-                    null
-                )
+                val jsCall = "transformN('${escapeJsString(nValue)}')"
+                Timber.tag(TAG).d("Evaluating JS: $jsCall")
+                webView.evaluateJavascript(jsCall, null)
             }
         }
     }
 
     @JavascriptInterface
     fun onNResult(result: String) {
-        Timber.tag(TAG).d("N-transform result: ${result.take(50)}...")
+        Timber.tag(TAG).d("========== N-TRANSFORM RESULT ==========")
+        Timber.tag(TAG).d("Result: $result")
+        Timber.tag(TAG).d("Result length: ${result.length}")
         nContinuation?.resume(result)
         nContinuation = null
     }
 
     @JavascriptInterface
     fun onNError(error: String) {
-        Timber.tag(TAG).e("N-transform error: $error")
+        Timber.tag(TAG).e("========== N-TRANSFORM ERROR ==========")
+        Timber.tag(TAG).e("Error: $error")
         nContinuation?.resumeWithException(CipherException("N-transform failed: $error"))
         nContinuation = null
     }
 
+    // ==================== CLEANUP ====================
+
     fun close() {
+        Timber.tag(TAG).d("Closing CipherWebView...")
         webView.clearHistory()
         webView.clearCache(true)
         webView.loadUrl("about:blank")
@@ -290,11 +546,15 @@ function discoverAndInit() {
         Timber.tag(TAG).d("CipherWebView closed")
     }
 
+    // ==================== UTILITIES ====================
+
     private fun escapeJsString(s: String): String {
         return s.replace("\\", "\\\\")
             .replace("'", "\\'")
+            .replace("\"", "\\\"")
             .replace("\n", "\\n")
             .replace("\r", "\\r")
+            .replace("\t", "\\t")
     }
 
     companion object {
@@ -307,6 +567,11 @@ function discoverAndInit() {
             sigInfo: FunctionNameExtractor.SigFunctionInfo?,
             nFuncInfo: FunctionNameExtractor.NFunctionInfo? = null,
         ): CipherWebView {
+            Timber.tag(TAG).d("=== CREATING CIPHER WEBVIEW ===")
+            Timber.tag(TAG).d("playerJs size: ${playerJs.length} chars")
+            Timber.tag(TAG).d("sigInfo: $sigInfo")
+            Timber.tag(TAG).d("nFuncInfo: $nFuncInfo")
+
             return withContext(Dispatchers.Main) {
                 suspendCancellableCoroutine { cont ->
                     val wv = CipherWebView(context, playerJs, sigInfo, nFuncInfo, cont)

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/FunctionNameExtractor.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/FunctionNameExtractor.kt
@@ -1,13 +1,87 @@
 package com.metrolist.music.utils.cipher
 
 import timber.log.Timber
+import java.security.MessageDigest
 
+/**
+ * Extracts cipher function names from YouTube's player.js
+ *
+ * Handles both legacy patterns and modern Q-array obfuscation (2025+).
+ * Falls back to hardcoded configs for known player.js hashes when regex fails.
+ */
 object FunctionNameExtractor {
     private const val TAG = "Metrolist_CipherFnExtract"
 
+    // ==================== DATA CLASSES ====================
+
+    data class SigFunctionInfo(
+        val name: String,
+        val constantArg: Int?, // The first numeric argument (e.g., 48 in JI(48, sig)) - legacy
+        val constantArgs: List<Int>? = null, // All constant args e.g., JI(48, 1918, ...) -> [48, 1918]
+        val preprocessFunc: String? = null, // Preprocessing function e.g., f1
+        val preprocessArgs: List<Int>? = null, // Preprocess args e.g., f1(1, 6528, sig) -> [1, 6528]
+        val isHardcoded: Boolean = false
+    )
+
+    data class NFunctionInfo(
+        val name: String,
+        val arrayIndex: Int?, // e.g. FUNC[0] -> index=0
+        val constantArgs: List<Int>? = null, // e.g. GU(6, 6010, n) -> [6, 6010]
+        val isHardcoded: Boolean = false
+    )
+
+    /**
+     * Hardcoded player.js configuration for when regex extraction fails
+     * Due to Q-array obfuscation, patterns like `.get("n")` become `Q[T^6001]`
+     */
+    data class HardcodedPlayerConfig(
+        val sigFuncName: String,
+        val sigConstantArg: Int?, // Legacy single arg
+        val sigConstantArgs: List<Int>? = null, // e.g. JI(48, 1918, ...) -> [48, 1918]
+        val sigPreprocessFunc: String? = null, // e.g. f1
+        val sigPreprocessArgs: List<Int>? = null, // e.g. f1(1, 6528, sig) -> [1, 6528]
+        val nFuncName: String,
+        val nArrayIndex: Int?,
+        val nConstantArgs: List<Int>?, // e.g. GU(6, 6010, n) -> [6, 6010]
+        val signatureTimestamp: Int
+    )
+
+    // ==================== KNOWN PLAYER CONFIGS ====================
+
+    /**
+     * Known player.js configurations indexed by hash
+     *
+     * Player hash 74edf1a3 (March 2026):
+     * - Signature: JI(48, 1918, f1(1, 6528, sig)) -> reverse, swap(0, 57%), reverse
+     * - N-transform: GU(6, 6010, n) with 87-element self-referential array
+     */
+    private val KNOWN_PLAYER_CONFIGS = mapOf(
+        "74edf1a3" to HardcodedPlayerConfig(
+            sigFuncName = "JI",
+            sigConstantArg = 48, // Legacy
+            sigConstantArgs = listOf(48, 1918), // JI(48, 1918, processedSig)
+            sigPreprocessFunc = "f1", // sig must be preprocessed through f1()
+            sigPreprocessArgs = listOf(1, 6528), // f1(1, 6528, sig)
+            nFuncName = "GU",
+            nArrayIndex = null, // Direct function, not array access
+            nConstantArgs = listOf(6, 6010), // GU(6, 6010, n) - the function requires 3 args!
+            signatureTimestamp = 20522
+        )
+    )
+
+    // ==================== DETECTION PATTERNS ====================
+
+    // Detect Q-array obfuscation: var Q="...".split("}")
+    private val Q_ARRAY_PATTERN = Regex("""var\s+Q\s*=\s*"[^"]+"\s*\.\s*split\s*\(\s*"\}"\s*\)""")
+
+    // Extract player hash from common patterns
+    private val PLAYER_HASH_PATTERNS = listOf(
+        Regex("""jsUrl['":\s]+[^"']*?/player/([a-f0-9]{8})/"""),
+        Regex("""player_ias\.vflset/[^/]+/([a-f0-9]{8})/"""),
+        Regex("""/s/player/([a-f0-9]{8})/""")
+    )
+
     // Modern 2025+ signature deobfuscation function patterns
-    // The sig function is called as: FUNC(NUMBER, decodeURIComponent(encryptedSig))
-    // within a logical expression: VAR && (VAR = FUNC(NUM, decodeURIComponent(VAR)), ...)
     private val SIG_FUNCTION_PATTERNS = listOf(
         // Pattern 1 (2025+): &&(VAR=FUNC(NUM,decodeURIComponent(VAR))
         Regex("""&&\s*\(\s*[a-zA-Z0-9$]+\s*=\s*([a-zA-Z0-9$]+)\s*\(\s*(\d+)\s*,\s*decodeURIComponent\s*\(\s*[a-zA-Z0-9$]+\s*\)"""),
@@ -20,12 +94,10 @@ object FunctionNameExtractor {
     )
 
     // N-parameter (throttle) transform function patterns
-    // The n-function transforms the 'n' parameter in streaming URLs to avoid throttling/403
-    // Pattern: .get("n"))&&(b=FUNC[INDEX](a[0]))  or  .get("n"))&&(b=FUNC(a[0]))
     private val N_FUNCTION_PATTERNS = listOf(
         // Pattern 1: .get("n"))&&(b=FUNC[IDX](VAR)
         Regex("""\.get\("n"\)\)&&\(b=([a-zA-Z0-9$]+)(?:\[(\d+)\])?\(([a-zA-Z0-9])\)"""),
-        // Pattern 2: .get("n"))&&(FUNC=VAR[IDX](FUNC)  (2025+ variant)
+        // Pattern 2: .get("n"))&&(FUNC=VAR[IDX](FUNC) (2025+ variant)
         Regex("""\.get\("n"\)\)\s*&&\s*\(([a-zA-Z0-9$]+)\s*=\s*([a-zA-Z0-9$]+)(?:\[(\d+)\])?\(\1\)"""),
         // Pattern 3: String.fromCharCode(110) variant (110 = 'n')
         Regex("""\(\s*([a-zA-Z0-9$]+)\s*=\s*String\.fromCharCode\(110\)"""),
@@ -33,58 +105,271 @@ object FunctionNameExtractor {
         Regex("""([a-zA-Z0-9$]+)\s*=\s*function\([a-zA-Z0-9]\)\s*\{[^}]*?enhanced_except_"""),
     )
 
-    data class SigFunctionInfo(
-        val name: String,
-        val constantArg: Int? // The first numeric argument (e.g., 8 in DE(8, sig))
-    )
+    // ==================== EXTRACTION FUNCTIONS ====================
 
-    data class NFunctionInfo(
-        val name: String,
-        val arrayIndex: Int? // e.g. FUNC[0] -> index=0
-    )
+    /**
+     * Detect if player.js uses Q-array obfuscation
+     */
+    fun hasQArrayObfuscation(playerJs: String): Boolean {
+        val hasQArray = Q_ARRAY_PATTERN.containsMatchIn(playerJs)
+        Timber.tag(TAG).d("Q-array obfuscation check: hasQArray=$hasQArray")
 
-    fun extractSigFunctionInfo(playerJs: String): SigFunctionInfo? {
+        if (hasQArray) {
+            // Try to count Q array elements for additional info
+            val match = Q_ARRAY_PATTERN.find(playerJs)
+            if (match != null) {
+                val start = match.range.first
+                val qDefEnd = playerJs.indexOf(";", start)
+                if (qDefEnd > start) {
+                    val qDef = playerJs.substring(start, qDefEnd)
+                    val elementCount = qDef.count { it == '}' } + 1
+                    Timber.tag(TAG).d("Q-array detected with ~$elementCount elements")
+                }
+            }
+        }
+        return hasQArray
+    }
+
+    /**
+     * Extract player.js hash from embedded URLs or compute from content
+     */
+    fun extractPlayerHash(playerJs: String): String? {
+        Timber.tag(TAG).d("Extracting player hash from playerJs (${playerJs.length} chars)")
+
+        // Try to extract from embedded URLs first
+        for ((index, pattern) in PLAYER_HASH_PATTERNS.withIndex()) {
+            val match = pattern.find(playerJs)
+            if (match != null) {
+                val hash = match.groupValues[1]
+                Timber.tag(TAG).d("Player hash found via pattern $index: $hash")
+                return hash
+            }
+        }
+
+        // Fallback: compute hash from first 10KB of content
+        val contentToHash = playerJs.take(10000)
+        val md = MessageDigest.getInstance("MD5")
+        val digest = md.digest(contentToHash.toByteArray())
+        val computedHash = digest.take(4).joinToString("") { "%02x".format(it) }
+        Timber.tag(TAG).d("Player hash computed from content: $computedHash")
+        return computedHash
+    }
+
+    /**
+     * Get hardcoded config for a known player.js hash
+     */
+    fun getHardcodedConfig(playerHash: String): HardcodedPlayerConfig? {
+        val config = KNOWN_PLAYER_CONFIGS[playerHash]
+        if (config != null) {
+            Timber.tag(TAG).d("Found hardcoded config for hash $playerHash:")
+            Timber.tag(TAG).d("  sigFunc=${config.sigFuncName}(${config.sigConstantArg}, ...)")
+            Timber.tag(TAG).d("  nFunc=${config.nFuncName}[${config.nArrayIndex}]")
+            Timber.tag(TAG).d("  signatureTimestamp=${config.signatureTimestamp}")
+        } else {
+            Timber.tag(TAG).w("No hardcoded config for hash: $playerHash")
+            Timber.tag(TAG).w("Known hashes: ${KNOWN_PLAYER_CONFIGS.keys.joinToString()}")
+        }
+        return config
+    }
+
+    /**
+     * Extract signature function info from player.js
+     *
+     * Uses regex patterns first, falls back to hardcoded config if Q-array detected
+     * @param playerJs The player.js content
+     * @param knownHash Optional hash for hardcoded config lookup
+     */
+    fun extractSigFunctionInfo(playerJs: String, knownHash: String? = null): SigFunctionInfo? {
+        Timber.tag(TAG).d("========== EXTRACTING SIG FUNCTION ==========")
+        Timber.tag(TAG).d("Player.js size: ${playerJs.length} chars")
+
+        // Try regex patterns first
         for ((index, pattern) in SIG_FUNCTION_PATTERNS.withIndex()) {
+            Timber.tag(TAG).v("Trying sig pattern $index: ${pattern.pattern.take(60)}...")
             val match = pattern.find(playerJs)
             if (match != null) {
                 val name = match.groupValues[1]
                 val constArg = if (match.groupValues.size > 2) match.groupValues[2].toIntOrNull() else null
-                Timber.tag(TAG).d("Sig function found with pattern $index: $name (constantArg=$constArg)")
-                return SigFunctionInfo(name, constArg)
+                Timber.tag(TAG).d("SIG FUNCTION FOUND via pattern $index:")
+                Timber.tag(TAG).d("  name=$name, constantArg=$constArg")
+                Timber.tag(TAG).d("  match context: ...${playerJs.substring(maxOf(0, match.range.first - 20), minOf(playerJs.length, match.range.last + 20))}...")
+                return SigFunctionInfo(name, constArg, isHardcoded = false)
             }
         }
+
+        Timber.tag(TAG).w("No sig pattern matched, checking for Q-array obfuscation...")
+
+        // Check for Q-array obfuscation and use hardcoded fallback
+        if (hasQArrayObfuscation(playerJs)) {
+            // Use knownHash if provided, otherwise try to extract
+            val hashToUse = knownHash ?: extractPlayerHash(playerJs)
+            Timber.tag(TAG).d("Using hash for hardcoded lookup: $hashToUse (knownHash=$knownHash)")
+            if (hashToUse != null) {
+                val config = getHardcodedConfig(hashToUse)
+                if (config != null) {
+                    Timber.tag(TAG).d("USING HARDCODED SIG FUNCTION: ${config.sigFuncName}(${config.sigConstantArgs}, ...)")
+                    Timber.tag(TAG).d("Sig preprocess: ${config.sigPreprocessFunc}(${config.sigPreprocessArgs}, sig)")
+                    return SigFunctionInfo(
+                        name = config.sigFuncName,
+                        constantArg = config.sigConstantArg,
+                        constantArgs = config.sigConstantArgs,
+                        preprocessFunc = config.sigPreprocessFunc,
+                        preprocessArgs = config.sigPreprocessArgs,
+                        isHardcoded = true
+                    )
+                }
+            }
+        }
+
+        Timber.tag(TAG).e("========== SIG FUNCTION EXTRACTION FAILED ==========")
         Timber.tag(TAG).e("Could not find signature deobfuscation function name")
         return null
     }
 
-    fun extractNFunctionInfo(playerJs: String): NFunctionInfo? {
+    /**
+     * Extract N-transform function info from player.js
+     *
+     * Uses regex patterns first, falls back to hardcoded config if Q-array detected
+     * @param playerJs The player.js content
+     * @param knownHash Optional hash for hardcoded config lookup
+     */
+    fun extractNFunctionInfo(playerJs: String, knownHash: String? = null): NFunctionInfo? {
+        Timber.tag(TAG).d("========== EXTRACTING N-FUNCTION ==========")
+        Timber.tag(TAG).d("Player.js size: ${playerJs.length} chars")
+
+        // Try regex patterns first
         for ((index, pattern) in N_FUNCTION_PATTERNS.withIndex()) {
+            Timber.tag(TAG).v("Trying n-func pattern $index: ${pattern.pattern.take(60)}...")
             val match = pattern.find(playerJs)
             if (match != null) {
                 when (index) {
                     0 -> {
-                        // Pattern 1: group1=funcName, group2=arrayIndex (optional)
                         val name = match.groupValues[1]
                         val arrayIdx = match.groupValues[2].toIntOrNull()
-                        Timber.tag(TAG).d("N-function found with pattern $index: $name (arrayIndex=$arrayIdx)")
-                        return NFunctionInfo(name, arrayIdx)
+                        Timber.tag(TAG).d("N-FUNCTION FOUND via pattern $index:")
+                        Timber.tag(TAG).d("  name=$name, arrayIndex=$arrayIdx")
+                        return NFunctionInfo(name, arrayIdx, isHardcoded = false)
                     }
                     1 -> {
-                        // Pattern 2: group2=funcName, group3=arrayIndex (optional)
                         val name = match.groupValues[2]
                         val arrayIdx = match.groupValues[3].toIntOrNull()
-                        Timber.tag(TAG).d("N-function found with pattern $index: $name (arrayIndex=$arrayIdx)")
-                        return NFunctionInfo(name, arrayIdx)
+                        Timber.tag(TAG).d("N-FUNCTION FOUND via pattern $index:")
+                        Timber.tag(TAG).d("  name=$name, arrayIndex=$arrayIdx")
+                        return NFunctionInfo(name, arrayIdx, isHardcoded = false)
                     }
                     else -> {
                         val name = match.groupValues[1]
-                        Timber.tag(TAG).d("N-function found with pattern $index: $name")
-                        return NFunctionInfo(name, null)
+                        Timber.tag(TAG).d("N-FUNCTION FOUND via pattern $index:")
+                        Timber.tag(TAG).d("  name=$name")
+                        return NFunctionInfo(name, null, isHardcoded = false)
                     }
                 }
             }
         }
+
+        Timber.tag(TAG).w("No n-func pattern matched, checking for Q-array obfuscation...")
+
+        // Check for Q-array obfuscation and use hardcoded fallback
+        if (hasQArrayObfuscation(playerJs)) {
+            // Use knownHash if provided, otherwise try to extract
+            val hashToUse = knownHash ?: extractPlayerHash(playerJs)
+            Timber.tag(TAG).d("Using hash for hardcoded lookup: $hashToUse (knownHash=$knownHash)")
+            if (hashToUse != null) {
+                val config = getHardcodedConfig(hashToUse)
+                if (config != null) {
+                    Timber.tag(TAG).d("USING HARDCODED N-FUNCTION: ${config.nFuncName}[${config.nArrayIndex}]")
+                    Timber.tag(TAG).d("N-function constant args: ${config.nConstantArgs}")
+                    return NFunctionInfo(config.nFuncName, config.nArrayIndex, config.nConstantArgs, isHardcoded = true)
+                }
+            }
+        }
+
+        Timber.tag(TAG).e("========== N-FUNCTION EXTRACTION FAILED ==========")
         Timber.tag(TAG).e("Could not find n-transform function name")
         return null
     }
+
+    /**
+     * Extract signatureTimestamp from player.js
+     */
+    fun extractSignatureTimestamp(playerJs: String): Int? {
+        Timber.tag(TAG).d("Extracting signatureTimestamp...")
+
+        val patterns = listOf(
+            Regex("""signatureTimestamp['":\s]+(\d+)"""),
+            Regex("""sts['":\s]+(\d+)"""),
+            Regex(""""signatureTimestamp"\s*:\s*(\d+)""")
+        )
+
+        for ((index, pattern) in patterns.withIndex()) {
+            val match = pattern.find(playerJs)
+            if (match != null) {
+                val sts = match.groupValues[1].toIntOrNull()
+                if (sts != null) {
+                    Timber.tag(TAG).d("signatureTimestamp found via pattern $index: $sts")
+                    return sts
+                }
+            }
+        }
+
+        // Fallback to hardcoded config
+        val playerHash = extractPlayerHash(playerJs)
+        if (playerHash != null) {
+            val config = getHardcodedConfig(playerHash)
+            if (config != null) {
+                Timber.tag(TAG).d("Using hardcoded signatureTimestamp: ${config.signatureTimestamp}")
+                return config.signatureTimestamp
+            }
+        }
+
+        Timber.tag(TAG).w("Could not extract signatureTimestamp")
+        return null
+    }
+
+    /**
+     * Full analysis of player.js - extracts all cipher info
+     * @param playerJs The player.js content
+     * @param knownHash Optional hash from PlayerJsFetcher (preferred over computed)
+     */
+    fun analyzePlayerJs(playerJs: String, knownHash: String? = null): PlayerAnalysis {
+        Timber.tag(TAG).d("=== PLAYER.JS CIPHER ANALYSIS ===")
+
+        // Use knownHash from PlayerJsFetcher if provided, otherwise extract/compute
+        val playerHash = if (knownHash != null) {
+            Timber.tag(TAG).d("Using known hash from PlayerJsFetcher: $knownHash")
+            knownHash
+        } else {
+            extractPlayerHash(playerJs)
+        }
+
+        val hasQArray = hasQArrayObfuscation(playerJs)
+        val sigInfo = extractSigFunctionInfo(playerJs, playerHash)
+        val nFuncInfo = extractNFunctionInfo(playerJs, playerHash)
+        val signatureTimestamp = extractSignatureTimestamp(playerJs)
+
+        Timber.tag(TAG).d("=== ANALYSIS SUMMARY ===")
+        Timber.tag(TAG).d("Player Hash:        ${playerHash ?: "unknown"}")
+        Timber.tag(TAG).d("Q-Array Obfuscated: $hasQArray")
+        Timber.tag(TAG).d("Sig Function:       ${sigInfo?.name ?: "NOT FOUND"} (hardcoded=${sigInfo?.isHardcoded})")
+        Timber.tag(TAG).d("Sig Constant Arg:   ${sigInfo?.constantArg}")
+        Timber.tag(TAG).d("N-Function:         ${nFuncInfo?.name ?: "NOT FOUND"} (hardcoded=${nFuncInfo?.isHardcoded})")
+        Timber.tag(TAG).d("N-Array Index:      ${nFuncInfo?.arrayIndex}")
+        Timber.tag(TAG).d("Signature TS:       $signatureTimestamp")
+
+        return PlayerAnalysis(
+            playerHash = playerHash,
+            hasQArrayObfuscation = hasQArray,
+            sigInfo = sigInfo,
+            nFuncInfo = nFuncInfo,
+            signatureTimestamp = signatureTimestamp
+        )
+    }
+
+    data class PlayerAnalysis(
+        val playerHash: String?,
+        val hasQArrayObfuscation: Boolean,
+        val sigInfo: SigFunctionInfo?,
+        val nFuncInfo: NFunctionInfo?,
+        val signatureTimestamp: Int?
+    )
 }

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/PlayerJsFetcher.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/PlayerJsFetcher.kt
@@ -8,6 +8,12 @@ import okhttp3.Request
 import timber.log.Timber
 import java.io.File
 
+/**
+ * Fetches and caches YouTube's player.js for cipher operations.
+ *
+ * The player.js contains the signature deobfuscation and n-transform functions
+ * that are required to access stream URLs on web clients.
+ */
 object PlayerJsFetcher {
     private const val TAG = "Metrolist_CipherFetcher"
     private const val IFRAME_API_URL = "https://www.youtube.com/iframe_api"
@@ -27,21 +33,36 @@ object PlayerJsFetcher {
 
     private fun getHashFile(): File = File(getCacheDir(), "current_hash.txt")
 
+    /**
+     * Get player.js content and hash.
+     *
+     * Uses cached version if available and not expired, otherwise fetches fresh.
+     * Returns Pair(playerJs, hash) or null if failed.
+     */
     suspend fun getPlayerJs(forceRefresh: Boolean = false): Pair<String, String>? = withContext(Dispatchers.IO) {
+        Timber.tag(TAG).d("=== GET PLAYER.JS ===")
+        Timber.tag(TAG).d("forceRefresh: $forceRefresh")
+
         try {
             val cacheDir = getCacheDir()
-            if (!cacheDir.exists()) cacheDir.mkdirs()
+            if (!cacheDir.exists()) {
+                Timber.tag(TAG).d("Creating cache directory: ${cacheDir.absolutePath}")
+                cacheDir.mkdirs()
+            }
 
             // Check cache first (unless forced refresh)
             if (!forceRefresh) {
                 val cached = readFromCache()
                 if (cached != null) {
-                    Timber.tag(TAG).d("Using cached player JS (hash=${cached.second})")
+                    Timber.tag(TAG).d("=== CACHE HIT ===")
+                    Timber.tag(TAG).d("Using cached player JS (hash=${cached.second}, length=${cached.first.length})")
                     return@withContext cached
                 }
+                Timber.tag(TAG).d("Cache miss, will fetch fresh")
             }
 
             // Fetch player hash from iframe_api
+            Timber.tag(TAG).d("Fetching player hash from iframe_api...")
             val hash = fetchPlayerHash()
             if (hash == null) {
                 Timber.tag(TAG).e("Failed to extract player hash from iframe_api")
@@ -50,12 +71,17 @@ object PlayerJsFetcher {
             Timber.tag(TAG).d("Extracted player hash: $hash")
 
             // Download player JS
+            Timber.tag(TAG).d("Downloading player JS for hash: $hash...")
             val playerJs = downloadPlayerJs(hash)
             if (playerJs == null) {
                 Timber.tag(TAG).e("Failed to download player JS for hash=$hash")
                 return@withContext null
             }
-            Timber.tag(TAG).d("Downloaded player JS: ${playerJs.length} chars")
+
+            Timber.tag(TAG).d("=== PLAYER.JS DOWNLOADED ===")
+            Timber.tag(TAG).d("hash: $hash")
+            Timber.tag(TAG).d("length: ${playerJs.length} chars")
+            Timber.tag(TAG).d("preview: ${playerJs.take(100)}...")
 
             // Cache the result
             writeToCache(hash, playerJs)
@@ -67,41 +93,73 @@ object PlayerJsFetcher {
         }
     }
 
+    /**
+     * Invalidate the player.js cache.
+     * Call this when cipher operations fail to force a fresh fetch.
+     */
     fun invalidateCache() {
+        Timber.tag(TAG).d("Invalidating cache...")
         try {
             val cacheDir = getCacheDir()
             if (cacheDir.exists()) {
-                cacheDir.listFiles()?.forEach { it.delete() }
+                val files = cacheDir.listFiles()
+                Timber.tag(TAG).d("Deleting ${files?.size ?: 0} cache files")
+                files?.forEach {
+                    Timber.tag(TAG).v("Deleting: ${it.name}")
+                    it.delete()
+                }
             }
-            Timber.tag(TAG).d("Cache invalidated")
+            Timber.tag(TAG).d("Cache invalidated successfully")
         } catch (e: Exception) {
             Timber.tag(TAG).e(e, "Failed to invalidate cache: ${e.message}")
         }
     }
 
     private fun readFromCache(): Pair<String, String>? {
+        Timber.tag(TAG).d("Checking cache...")
         try {
             val hashFile = getHashFile()
-            if (!hashFile.exists()) return null
+            if (!hashFile.exists()) {
+                Timber.tag(TAG).d("Hash file does not exist")
+                return null
+            }
 
             val hashData = hashFile.readText().split("\n")
-            if (hashData.size < 2) return null
+            if (hashData.size < 2) {
+                Timber.tag(TAG).d("Hash file malformed (expected 2 lines, got ${hashData.size})")
+                return null
+            }
 
             val hash = hashData[0]
-            val timestamp = hashData[1].toLongOrNull() ?: return null
+            val timestamp = hashData[1].toLongOrNull()
+            if (timestamp == null) {
+                Timber.tag(TAG).d("Could not parse timestamp from hash file")
+                return null
+            }
+
+            val ageMs = System.currentTimeMillis() - timestamp
+            val ageHours = ageMs / (1000 * 60 * 60)
+            Timber.tag(TAG).d("Cache age: ${ageHours}h (TTL: ${CACHE_TTL_MS / (1000 * 60 * 60)}h)")
 
             // Check TTL
-            if (System.currentTimeMillis() - timestamp > CACHE_TTL_MS) {
-                Timber.tag(TAG).d("Cache expired (hash=$hash)")
+            if (ageMs > CACHE_TTL_MS) {
+                Timber.tag(TAG).d("Cache expired (hash=$hash, age=${ageHours}h)")
                 return null
             }
 
             val cacheFile = getCacheFile(hash)
-            if (!cacheFile.exists()) return null
+            if (!cacheFile.exists()) {
+                Timber.tag(TAG).d("Cache file does not exist for hash: $hash")
+                return null
+            }
 
             val playerJs = cacheFile.readText()
-            if (playerJs.isEmpty()) return null
+            if (playerJs.isEmpty()) {
+                Timber.tag(TAG).d("Cache file is empty")
+                return null
+            }
 
+            Timber.tag(TAG).d("Cache valid: hash=$hash, length=${playerJs.length}, age=${ageHours}h")
             return Pair(playerJs, hash)
         } catch (e: Exception) {
             Timber.tag(TAG).e(e, "Error reading cache: ${e.message}")
@@ -110,48 +168,113 @@ object PlayerJsFetcher {
     }
 
     private fun writeToCache(hash: String, playerJs: String) {
+        Timber.tag(TAG).d("Writing to cache: hash=$hash, length=${playerJs.length}")
         try {
             val cacheDir = getCacheDir()
+
             // Clean old cache files
-            cacheDir.listFiles()?.filter { it.name.startsWith("player_") }?.forEach { it.delete() }
+            val oldFiles = cacheDir.listFiles()?.filter { it.name.startsWith("player_") }
+            Timber.tag(TAG).d("Cleaning ${oldFiles?.size ?: 0} old cache files")
+            oldFiles?.forEach { it.delete() }
 
             getCacheFile(hash).writeText(playerJs)
             getHashFile().writeText("$hash\n${System.currentTimeMillis()}")
+
+            Timber.tag(TAG).d("Cache written successfully")
         } catch (e: Exception) {
             Timber.tag(TAG).e(e, "Error writing cache: ${e.message}")
         }
     }
 
     private fun fetchPlayerHash(): String? {
+        Timber.tag(TAG).d("Fetching iframe_api from: $IFRAME_API_URL")
+
         val request = Request.Builder()
             .url(IFRAME_API_URL)
-            .header("User-Agent", "Mozilla/5.0")
+            .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
             .build()
 
         val response = httpClient.newCall(request).execute()
+        Timber.tag(TAG).d("iframe_api response: HTTP ${response.code}")
+
         if (!response.isSuccessful) {
             Timber.tag(TAG).e("iframe_api HTTP ${response.code}")
             return null
         }
 
-        val body = response.body?.string() ?: return null
+        val body = response.body?.string()
+        if (body == null) {
+            Timber.tag(TAG).e("iframe_api response body is null")
+            return null
+        }
+
+        Timber.tag(TAG).d("iframe_api body length: ${body.length}")
+        Timber.tag(TAG).v("iframe_api body preview: ${body.take(200)}...")
+
         val match = PLAYER_HASH_REGEX.find(body)
-        return match?.groupValues?.get(1)
+        if (match == null) {
+            Timber.tag(TAG).e("Could not find player hash in iframe_api response")
+            Timber.tag(TAG).d("Regex pattern: ${PLAYER_HASH_REGEX.pattern}")
+            return null
+        }
+
+        val hash = match.groupValues[1]
+        Timber.tag(TAG).d("Found player hash: $hash")
+        return hash
     }
 
     private fun downloadPlayerJs(hash: String): String? {
         val url = PLAYER_JS_URL_TEMPLATE.format(hash)
+        Timber.tag(TAG).d("Downloading player.js from: $url")
+
         val request = Request.Builder()
             .url(url)
-            .header("User-Agent", "Mozilla/5.0")
+            .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
             .build()
 
         val response = httpClient.newCall(request).execute()
+        Timber.tag(TAG).d("player.js response: HTTP ${response.code}")
+
         if (!response.isSuccessful) {
-            Timber.tag(TAG).e("player JS download HTTP ${response.code}")
+            Timber.tag(TAG).e("player.js download HTTP ${response.code}")
             return null
         }
 
-        return response.body?.string()
+        val body = response.body?.string()
+        if (body == null) {
+            Timber.tag(TAG).e("player.js response body is null")
+            return null
+        }
+
+        Timber.tag(TAG).d("player.js downloaded: ${body.length} chars")
+        return body
+    }
+
+    /**
+     * Debug method: Get cache information
+     */
+    fun getCacheInfo(): Map<String, Any?> {
+        return try {
+            val hashFile = getHashFile()
+            if (!hashFile.exists()) {
+                return mapOf("exists" to false)
+            }
+
+            val hashData = hashFile.readText().split("\n")
+            val hash = hashData.getOrNull(0)
+            val timestamp = hashData.getOrNull(1)?.toLongOrNull()
+            val cacheFile = hash?.let { getCacheFile(it) }
+
+            mapOf(
+                "exists" to true,
+                "hash" to hash,
+                "timestamp" to timestamp,
+                "ageMs" to (timestamp?.let { System.currentTimeMillis() - it }),
+                "fileExists" to (cacheFile?.exists() == true),
+                "fileSize" to (cacheFile?.length()),
+            )
+        } catch (e: Exception) {
+            mapOf("error" to e.message)
+        }
     }
 }


### PR DESCRIPTION
## Problem
Playback fails for uploaded songs, explicit content, and some regular tracks due to YouTube's player.js (hash 74edf1a3) using Q-array obfuscation that breaks cipher function extraction.

## Cause
YouTube's player.js now uses Q-array obfuscation (`var Q="...".split("}")`) which replaces string literals with array tokens. This breaks regex-based extraction of signature and n-transform function names. The cipher functions also require multiple constant arguments (e.g., `JI(48, 1918, f1(1, 6528, sig))`) instead of the previous single-argument pattern.

## Solution
- Add hardcoded config for player.js hash 74edf1a3 as a fallback when regex extraction fails
- The existing regex-based extraction is preserved and tried first - hardcoded is only used if regex doesn't match
- Support signature chain: `JI(48, 1918, f1(1, 6528, sig))` with preprocessing
- Support n-transform: `GU(6, 6010, n)` with multiple constant arguments
- Generate wrapper functions for multi-argument cipher functions
- Detect wrapper vs direct functions via `func.length === 1` in JavaScript

## Testing
- Tested regular song playback
- Tested uploaded/private song playback (MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK)
- Tested explicit content playback
- Tested age-restricted content (via TVHTML5 fallback)
- Verified n-transform applied correctly
- Verified signature deobfuscation works

To view cipher logs:
```
adb logcat | grep -E "(Metrolist_Cipher|YTPlayerUtils|N-TRANSFORM|HARDCODED)"
```

## Related Issues
- Related to cipher/playback issues with recent YouTube changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced playback reliability with improved error handling and diagnostic logging for music stream processing.
  * Added automatic cache management for YouTube player data, optimizing app performance and reducing redundant downloads.
  * Better error detection and recovery when handling protected content and age-restricted tracks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->