### PR TITLE
feat: refine account settings ui

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AccountSettings.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -324,9 +325,19 @@ fun AccountSettings(
                             onCheckedChange = {
                                 YouTube.useLoginForBrowse = it
                                 onUseLoginForBrowseChange(it)
+                            },
+                            thumbContent = {
+                                Icon(
+                                    painter = painterResource(
+                                        id = if (useLoginForBrowse) R.drawable.check else R.drawable.close
+                                    ),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(SwitchDefaults.IconSize)
+                                )
                             }
                         )
                     },
+                    enabled = isLoggedIn
                 ),
                 Material3SettingsItem(
                     title = { Text(stringResource(R.string.yt_sync)) },
@@ -335,7 +346,16 @@ fun AccountSettings(
                         Switch(
                             enabled = isLoggedIn,
                             checked = ytmSync,
-                            onCheckedChange = onYtmSyncChange
+                            onCheckedChange = onYtmSyncChange,
+                            thumbContent = {
+                                Icon(
+                                    painter = painterResource(
+                                        id = if (ytmSync) R.drawable.check else R.drawable.close
+                                    ),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(SwitchDefaults.IconSize)
+                                )
+                            }
                         )
                     },
                     enabled = isLoggedIn


### PR DESCRIPTION
## Problem
the account settings ui is old and uses deprecated components guh

## Solution
redesign it!!
(this used to be another design but agamy rejected it)
(there is some deprecated components still used, although this may be temporary)
![IMG_20260315_191058](https://github.com/user-attachments/assets/b01ee54a-ae35-48ad-a8f5-076119cd8a96)


## Testing
using the `installFossDebug` task by using `../gradlew InstallFossDebug` and also testing the page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned Account Settings with Material You layout and improved spacing.
* **New Features**
  * Account entry now shows avatar/name and a logout action inline.
  * Token editor and login actions consolidated into cohesive settings items; multi-line token editing preserved.
  * "More content" and YouTube sync now use inline switches, enabled only when signed in.
* **Bug Fixes**
  * Kept logout confirmation flow intact for safer sign-out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->