### PR TITLE
feat: add notification-based music recognition for quick tile

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -205,6 +205,14 @@
             android:exported="false"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
 
+        <activity
+            android:name=".recognition.RecognitionLaunchActivity"
+            android:excludeFromRecents="true"
+            android:exported="false"
+            android:launchMode="singleTask"
+            android:noHistory="true"
+            android:theme="@style/Theme.Metrolist.Transparent" />
+
         <service
             android:name=".playback.MusicService"
             android:exported="true"
@@ -320,6 +328,11 @@
 
         <service
             android:name=".widget.MusicRecognizerWidgetService"
+            android:exported="false"
+            android:foregroundServiceType="microphone" />
+
+        <service
+            android:name=".recognition.RecognitionForegroundService"
             android:exported="false"
             android:foregroundServiceType="microphone" />
 

--- a/app/src/main/kotlin/com/metrolist/music/quicksettings/MusicRecognizerTileService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/quicksettings/MusicRecognizerTileService.kt
@@ -6,8 +6,8 @@ import android.graphics.drawable.Icon
 import android.os.Build
 import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
-import com.metrolist.music.MainActivity
 import com.metrolist.music.R
+import com.metrolist.music.recognition.RecognitionLaunchActivity
 
 class MusicRecognizerTileService : TileService() {
     override fun onStartListening() {
@@ -21,16 +21,11 @@ class MusicRecognizerTileService : TileService() {
 
     override fun onClick() {
         super.onClick()
-
         val launchIntent =
-            Intent(this, MainActivity::class.java).apply {
-                action = MainActivity.ACTION_RECOGNITION
-                putExtra(MainActivity.EXTRA_AUTO_START_RECOGNITION, true)
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            Intent(this, RecognitionLaunchActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_NO_ANIMATION
             }
 
-        // startActivityAndCollapse(Intent) was deprecated in API 34 in favour of the
-        // PendingIntent overload, which collapses the Quick Settings panel reliably.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             val pendingIntent =
                 PendingIntent.getActivity(

--- a/app/src/main/kotlin/com/metrolist/music/recognition/RecognitionForegroundService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/recognition/RecognitionForegroundService.kt
@@ -1,0 +1,342 @@
+package com.metrolist.music.recognition
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.metrolist.music.MainActivity
+import com.metrolist.music.R
+import com.metrolist.shazamkit.models.RecognitionResult
+import com.metrolist.shazamkit.models.RecognitionStatus
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import java.net.HttpURLConnection
+import java.net.URL
+
+class RecognitionForegroundService : Service() {
+    private val serviceScope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob())
+    private var recognitionJob: Job? = null
+    private var statusJob: Job? = null
+    private var keepNotificationOnStop = false
+    private var terminalStateHandled = false
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (!startInForeground()) return START_NOT_STICKY
+        startRecognitionIfNeeded()
+        return START_NOT_STICKY
+    }
+
+    override fun onDestroy() {
+        recognitionJob?.cancel()
+        statusJob?.cancel()
+        serviceScope.cancel()
+        if (!keepNotificationOnStop) {
+            stopForeground(STOP_FOREGROUND_REMOVE)
+        }
+        super.onDestroy()
+    }
+
+    private fun startInForeground(): Boolean {
+        val notification =
+            buildNotification(
+                title = getString(R.string.recognize_music),
+                contentText = getString(R.string.recognition_notification_listening),
+                isTerminal = false,
+                contentIntent = null,
+                largeIcon = null,
+                actionIntent = null,
+                actionTitle = null,
+            )
+
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                startForeground(
+                    NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE,
+                )
+            } else {
+                startForeground(NOTIFICATION_ID, notification)
+            }
+            return true
+        } catch (foregroundTypeException: SecurityException) {
+            Log.w(TAG, "Unable to start microphone foreground service", foregroundTypeException)
+            stopSelf()
+            return false
+        }
+    }
+
+    private fun startRecognitionIfNeeded() {
+        if (recognitionJob?.isActive == true) return
+
+        keepNotificationOnStop = false
+        terminalStateHandled = false
+        MusicRecognitionService.reset()
+
+        statusJob?.cancel()
+        statusJob =
+            serviceScope.launch {
+                MusicRecognitionService.recognitionStatus.collect { status ->
+                    when (status) {
+                        is RecognitionStatus.Ready -> Unit
+                        else -> renderStatus(status)
+                    }
+                }
+            }
+
+        recognitionJob =
+            serviceScope.launch {
+                val result = MusicRecognitionService.recognize(this@RecognitionForegroundService)
+                if (result is RecognitionStatus.Error &&
+                    MusicRecognitionService.recognitionStatus.value !is RecognitionStatus.Error
+                ) {
+                    renderStatus(result)
+                }
+            }
+    }
+
+    private fun renderStatus(status: RecognitionStatus) {
+        when (status) {
+            is RecognitionStatus.Listening -> {
+                updateNotification(
+                    title = getString(R.string.recognize_music),
+                    contentText = getString(R.string.recognition_notification_listening),
+                    isTerminal = false,
+                    contentIntent = null,
+                    largeIcon = null,
+                    actionIntent = null,
+                    actionTitle = null,
+                )
+            }
+
+            is RecognitionStatus.Processing -> {
+                updateNotification(
+                    title = getString(R.string.recognize_music),
+                    contentText = getString(R.string.recognition_notification_processing),
+                    isTerminal = false,
+                    contentIntent = null,
+                    largeIcon = null,
+                    actionIntent = null,
+                    actionTitle = null,
+                )
+            }
+
+            is RecognitionStatus.Success -> {
+                handleSuccess(status.result)
+            }
+
+            is RecognitionStatus.NoMatch -> {
+                if (terminalStateHandled) return
+                terminalStateHandled = true
+                updateNotification(
+                    title = getString(R.string.recognize_music),
+                    contentText = getString(R.string.recognition_notification_no_match),
+                    isTerminal = true,
+                    contentIntent = null,
+                    largeIcon = null,
+                    actionIntent = null,
+                    actionTitle = null,
+                )
+                finishWithPersistentResult()
+            }
+
+            is RecognitionStatus.Error -> {
+                if (terminalStateHandled) return
+                terminalStateHandled = true
+                updateNotification(
+                    title = getString(R.string.recognize_music),
+                    contentText = getString(R.string.recognition_notification_failed),
+                    isTerminal = true,
+                    contentIntent = null,
+                    largeIcon = null,
+                    actionIntent = null,
+                    actionTitle = null,
+                )
+                finishWithPersistentResult()
+            }
+
+            is RecognitionStatus.Ready -> Unit
+        }
+    }
+
+    private fun updateNotification(
+        title: String,
+        contentText: String,
+        isTerminal: Boolean,
+        contentIntent: PendingIntent?,
+        largeIcon: Bitmap?,
+        actionIntent: PendingIntent?,
+        actionTitle: String?,
+    ) {
+        NotificationManagerCompat.from(this).notify(
+            NOTIFICATION_ID,
+            buildNotification(
+                title = title,
+                contentText = contentText,
+                isTerminal = isTerminal,
+                contentIntent = contentIntent,
+                largeIcon = largeIcon,
+                actionIntent = actionIntent,
+                actionTitle = actionTitle,
+            ),
+        )
+    }
+
+    private fun buildNotification(
+        title: String,
+        contentText: String,
+        isTerminal: Boolean,
+        contentIntent: PendingIntent?,
+        largeIcon: Bitmap?,
+        actionIntent: PendingIntent?,
+        actionTitle: String?,
+    ) =
+        NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_widget_mic)
+            .setContentTitle(title)
+            .setContentText(contentText)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setOnlyAlertOnce(true)
+            .setOngoing(!isTerminal)
+            .setAutoCancel(isTerminal)
+            .setContentIntent(contentIntent)
+            .setLargeIcon(largeIcon)
+            .apply {
+                if (actionIntent != null && actionTitle != null) {
+                    addAction(0, actionTitle, actionIntent)
+                }
+            }
+            .build()
+
+    private fun handleSuccess(result: RecognitionResult) {
+        if (terminalStateHandled) return
+        terminalStateHandled = true
+
+        val pendingIntent = createResultPendingIntent(result)
+        updateNotification(
+            title = result.title,
+            contentText = result.artist,
+            isTerminal = true,
+            contentIntent = pendingIntent,
+            largeIcon = null,
+            actionIntent = pendingIntent,
+            actionTitle = getString(R.string.listen_on_metrolist),
+        )
+
+        serviceScope.launch {
+            val coverUrl = result.coverArtHqUrl ?: result.coverArtUrl
+            val coverBitmap =
+                if (coverUrl == null) {
+                    null
+                } else {
+                    withTimeoutOrNull(1_500L) {
+                        loadBitmap(coverUrl)
+                    }
+                }
+
+            if (coverBitmap != null) {
+                updateNotification(
+                    title = result.title,
+                    contentText = result.artist,
+                    isTerminal = true,
+                    contentIntent = pendingIntent,
+                    largeIcon = coverBitmap,
+                    actionIntent = pendingIntent,
+                    actionTitle = getString(R.string.listen_on_metrolist),
+                )
+            }
+            finishWithPersistentResult()
+        }
+    }
+
+    private suspend fun loadBitmap(url: String): Bitmap? =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val connection = (URL(url).openConnection() as? HttpURLConnection)
+                    ?: return@runCatching null
+                try {
+                    connection.connectTimeout = BITMAP_CONNECT_TIMEOUT_MS
+                    connection.readTimeout = BITMAP_READ_TIMEOUT_MS
+                    connection.instanceFollowRedirects = true
+                    connection.doInput = true
+                    connection.connect()
+                    connection.inputStream.use(BitmapFactory::decodeStream)
+                } finally {
+                    connection.disconnect()
+                }
+            }.getOrNull()
+        }
+
+    private fun createResultPendingIntent(result: RecognitionResult): PendingIntent {
+        val launchIntent =
+            Intent(this, MainActivity::class.java).apply {
+                action = MainActivity.ACTION_RECOGNITION
+                putExtra(EXTRA_RECOGNITION_TRACK_ID, result.trackId)
+                putExtra(EXTRA_RECOGNITION_TITLE, result.title)
+                putExtra(EXTRA_RECOGNITION_ARTIST, result.artist)
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            }
+
+        return PendingIntent.getActivity(
+            this,
+            RESULT_PENDING_INTENT_REQUEST_CODE,
+            launchIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    private fun finishWithPersistentResult() {
+        keepNotificationOnStop = true
+        stopForeground(STOP_FOREGROUND_DETACH)
+        stopSelf()
+    }
+
+    private fun createNotificationChannel() {
+        val channel =
+            NotificationChannel(
+                CHANNEL_ID,
+                getString(R.string.recognition_notification_channel_name),
+                NotificationManager.IMPORTANCE_LOW,
+            ).apply {
+                description = getString(R.string.recognition_notification_channel_desc)
+                setShowBadge(false)
+            }
+
+        getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+    }
+
+    companion object {
+        const val EXTRA_RECOGNITION_TRACK_ID = "recognition_track_id"
+        const val EXTRA_RECOGNITION_TITLE = "recognition_title"
+        const val EXTRA_RECOGNITION_ARTIST = "recognition_artist"
+
+        private const val CHANNEL_ID = "recognition_channel"
+        private const val NOTIFICATION_ID = 9100
+        private const val RESULT_PENDING_INTENT_REQUEST_CODE = 9101
+        private const val TAG = "RecognitionFgService"
+        private const val BITMAP_CONNECT_TIMEOUT_MS = 1_200
+        private const val BITMAP_READ_TIMEOUT_MS = 1_200
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/recognition/RecognitionForegroundService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/recognition/RecognitionForegroundService.kt
@@ -39,7 +39,9 @@ class RecognitionForegroundService : Service() {
 
     override fun onCreate() {
         super.onCreate()
-        createNotificationChannel()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            createNotificationChannel()
+        }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -314,6 +316,8 @@ class RecognitionForegroundService : Service() {
     }
 
     private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+
         val channel =
             NotificationChannel(
                 CHANNEL_ID,

--- a/app/src/main/kotlin/com/metrolist/music/recognition/RecognitionForegroundService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/recognition/RecognitionForegroundService.kt
@@ -87,6 +87,17 @@ class RecognitionForegroundService : Service() {
             Log.w(TAG, "Unable to start microphone foreground service", foregroundTypeException)
             stopSelf()
             return false
+        } catch (runtimeException: RuntimeException) {
+            if (
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+                    runtimeException::class.java.name ==
+                    "android.app.ForegroundServiceStartNotAllowedException"
+            ) {
+                Log.w(TAG, "Unable to start microphone foreground service", runtimeException)
+                stopSelf()
+                return false
+            }
+            throw runtimeException
         }
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/recognition/RecognitionLaunchActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/recognition/RecognitionLaunchActivity.kt
@@ -1,0 +1,30 @@
+package com.metrolist.music.recognition
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+
+class RecognitionLaunchActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        startRecognitionService()
+        finish()
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        startRecognitionService()
+        finish()
+    }
+
+    private fun startRecognitionService() {
+        val serviceIntent = Intent(this, RecognitionForegroundService::class.java)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            startForegroundService(serviceIntent)
+        } else {
+            startService(serviceIntent)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/recognition/RecognitionLaunchActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/recognition/RecognitionLaunchActivity.kt
@@ -1,24 +1,52 @@
 package com.metrolist.music.recognition
 
+import android.Manifest
 import android.app.Activity
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
+import androidx.core.content.ContextCompat
+import com.metrolist.music.MainActivity
 
 class RecognitionLaunchActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        startRecognitionService()
-        finish()
+        handleRecognitionLaunch()
     }
 
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
-        startRecognitionService()
+        handleRecognitionLaunch()
+    }
+
+    private fun handleRecognitionLaunch() {
+        if (hasRecordPermission()) {
+            startRecognitionService()
+        } else {
+            openRecognitionPermissionFlow()
+        }
         finish()
     }
 
+    private fun hasRecordPermission(): Boolean {
+        return ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) ==
+            PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun openRecognitionPermissionFlow() {
+        val intent =
+            Intent(this, MainActivity::class.java).apply {
+                action = MainActivity.ACTION_RECOGNITION
+                putExtra(MainActivity.EXTRA_AUTO_START_RECOGNITION, true)
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            }
+        startActivity(intent)
+    }
+
     private fun startRecognitionService() {
+        if (!hasRecordPermission()) return
+
         val serviceIntent = Intent(this, RecognitionForegroundService::class.java)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/app/src/main/res/values-v31/styles.xml
+++ b/app/src/main/res/values-v31/styles.xml
@@ -2,4 +2,12 @@
 <resources>
     <!-- Widget Theme for Android 12+ with Dynamic Colors -->
     <style name="Theme.Widget.Metrolist" parent="@android:style/Theme.DeviceDefault.DayNight" />
+
+    <style name="Theme.Metrolist.Transparent" parent="@android:style/Theme.Translucent.NoTitleBar">
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowDisablePreview">true</item>
+        <item name="android:windowAnimationStyle">@null</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -728,6 +728,13 @@
     <string name="re_listen">Re-listen</string>
     <string name="play_on_app">Play on Metrolist</string>
     <string name="qs_tile_music_recognizer">Recognize Music</string>
+    <string name="recognition_notification_channel_name">Music Recognition</string>
+    <string name="recognition_notification_channel_desc">Shows a notification while identifying a song from Quick Settings</string>
+    <string name="recognition_notification_listening">Listening for music...</string>
+    <string name="recognition_notification_processing">Identifying...</string>
+    <string name="recognition_notification_no_match">No match found</string>
+    <string name="recognition_notification_failed">Recognition failed</string>
+    <string name="listen_on_metrolist">Listen on Metrolist</string>
 
     <!-- CSV Import Strings -->
     <string name="map_csv_columns">Map CSV Columns</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -16,4 +16,14 @@
     <style name="Theme.Widget.Metrolist" parent="@android:style/Theme.DeviceDefault.DayNight">
         <item name="android:colorBackground">#E6E1E5</item>
     </style>
+
+    <!-- Transparent theme for Music Recognizer Tile Service -->
+    <style name="Theme.Metrolist.Transparent" parent="@android:style/Theme.Translucent.NoTitleBar">
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowDisablePreview">true</item>
+        <item name="android:windowAnimationStyle">@null</item>
+    </style>
 </resources>


### PR DESCRIPTION
## Problem
The current Quick Settings Music Recognizer tile launches MainActivity with specific action flags to start music recognition. This approach is indirect, requires passing extras, and doesn't properly handle the recognition flow as a dedicated feature.

## Cause
The existing implementation couples music recognition to MainActivity by:
1. Using MainActivity.ACTION_RECOGNITION action and EXTRA_AUTO_START_RECOGNITION extra
2. Not having a dedicated activity/service for the recognition flow
3. Lacking proper notification support during recognition
4. Not handling the tile service launch in a clean, isolated way

## Solution
- Created a dedicated RecognitionLaunchActivity for launching music recognition
- Created RecognitionForegroundService to handle recognition with proper foreground service type (microphone)
- Added a transparent theme (Theme.Metrolist.Transparent) for the launch activity
- Added notification strings for recognition states (listening, processing, no match, failed) (well I might have used the existed ones...)
- Updated MusicRecognizerTileService to launch the new dedicated activity directly

## Testing
On Emulator and Samsung S25:
- Installed the Quick Settings tile
- Tapped the tile to trigger recognition
-  The activity launched correctly
- The foreground service ran with notification

## Screenshots 
![Screenshot_20260316_233338_One UI Home.png](https://github.com/user-attachments/assets/484d4786-3986-4904-ab92-c8ac0eb3dcac)



## Related Issues
- Closes #3197
- Related to #3197 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a foreground music-recognition service with microphone-aware notifications, actionable result intents, and persistent result handling.
  * Quick Settings tile now launches a lightweight recognition entry flow for faster access.

* **UI / Strings**
  * New transparent launch theme.
  * Added localized strings and notification text for recognition states (Listening, Processing, Success, No Match, Error) and channel metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->