### PR TITLE
Fix #2447: Playtime in stats page not fully visible

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
@@ -1159,8 +1159,21 @@ fun LocalSongsGrid(
     fillMaxWidth: Boolean = false,
     modifier: Modifier = Modifier
 ) = GridItem(
-    title = title,
-    subtitle = subtitle,
+    title = { Text(title, style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+    subtitle = {
+        Text(
+            text = subtitle,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.secondary,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.basicMarquee(
+                iterations = 3,
+                initialDelayMillis = 1000,
+                velocity = 30.dp
+            )
+        )
+    },
     badges = badges,
     thumbnailContent = {
         LocalThumbnail(
@@ -1188,8 +1201,21 @@ fun LocalArtistsGrid(
     fillMaxWidth: Boolean = false,
     modifier: Modifier = Modifier
 ) = GridItem(
-    title = title,
-    subtitle = subtitle,
+    title = { Text(title, style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+    subtitle = {
+        Text(
+            text = subtitle,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.secondary,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.basicMarquee(
+                iterations = 3,
+                initialDelayMillis = 1000,
+                velocity = 30.dp
+            )
+        )
+    },
     badges = badges,
     thumbnailContent = {
         LocalThumbnail(
@@ -1217,8 +1243,21 @@ fun LocalAlbumsGrid(
     fillMaxWidth: Boolean = false,
     modifier: Modifier = Modifier
 ) = GridItem(
-    title = title,
-    subtitle = subtitle,
+    title = { Text(title, style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+    subtitle = {
+        Text(
+            text = subtitle,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.secondary,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.basicMarquee(
+                iterations = 3,
+                initialDelayMillis = 1000,
+                velocity = 30.dp
+            )
+        )
+    },
     badges = badges,
     thumbnailContent = {
         LocalThumbnail(


### PR DESCRIPTION
The playtime text could be cut off when it exceeded the available space, making it difficult to read the full value.

This was fixed by adjusting the text behavior so it scrolls and remains fully visible, ensuring a consistent display across the stats page.

## Problem
Playtime values in the stats page could be truncated when they were too long, preventing users from seeing the full listening time.

## Cause
The text component was limited to a single line with ellipsis overflow, causing longer values to be cut off instead of fully displayed.

## Solution
- Replaced ellipsis overflow with scrolling text using `basicMarquee`
- Added `basicMarquee` modifier to subtitle  `Text` components
- Configured marquee with 3 iterations, delay and controlled velocity
- Updated `LocalSongsGrid`,  `LocalArtistsGrid` and  `LocalAlbumsGrid` to support scrolling text

## Testing
- Built the app using ./gradlew :app:assembleFossDebug
- Reproduced the issue on the stats page
- Verified on emulator that long playtime values are now fully visible
- Confirmed scrolling behavior works as expected

## Related Issues
- Closes #2447
- Closes #1766 

https://github.com/user-attachments/assets/1889a700-31d6-417c-91c3-b8435bf99e93



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced grid item presentation across all music library views. Titles are now displayed bold and truncated to a single line for consistent spacing. Subtitles feature a dynamic scrolling marquee effect with secondary color styling to improve readability and visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->