### PR TITLE
fix(playback): stop service cleanly when foreground start is blocked …

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -3184,13 +3184,15 @@ class MusicService :
         super.onDestroy()
     }
 
-    override fun onBind(intent: Intent?) = if (startupAborted) super.onBind(intent) else super.onBind(intent) ?: binder
+    override fun onBind(intent: Intent?) = if (startupAborted) null else super.onBind(intent) ?: binder
 
     override fun onTaskRemoved(rootIntent: Intent?) {
         super.onTaskRemoved(rootIntent)
     }
 
-    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo) = mediaSession
+    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaLibrarySession? {
+        return if (startupAborted || !::mediaSession.isInitialized) null else mediaSession
+    }
 
     override fun onForegroundServiceStartNotAllowedException() {
         Timber.tag(TAG).w("Foreground service start not allowed via MediaSessionService callback, stopping service cleanly")


### PR DESCRIPTION
## Problem
On Android 12+, starting `MusicService` from the background (e.g., via an alarm, widget button press, or system auto-start) causes an `android.app.ForegroundServiceStartNotAllowedException` because `startForegroundService()` is not allowed when `mAllowStartForeground=false`. The service's `onCreate()` catch block caught the exception but continued executing, leaving the service in a partially-initialized state. This led to crashes, typically a `NullPointerException` or `IllegalStateException` shortly after when uninitialized `lateinit` fields (like `player`, `mediaSession`) were accessed.

## Cause
Media3's `MediaLibraryService` internally calls `startForegroundService()` through its `MediaNotificationManager` during the notification pipeline. On Android 12+, Android blocks this when the app is in the background and the service hasn't been started through a foreground-compatible path. The exception was caught but execution continued, leaving the service in a broken state with no foreground notification posted.
Additionally, `Media3`'s `MediaSessionService` has a `Listener` callback (`onForegroundServiceStartNotAllowedException()`) that was never registered, so Media3's internal fallback path also had no way to handle the blocked start.

## Solution
- Added `MediaSessionService.Listener` to the `MusicService` class declaration and registered the service as its own listener via `setListener(this@MusicService)` in `onCreate()`. This ensures that if Media3's notification pipeline ever tries to foreground the service later, the service receives the callback and can abort cleanly.
- Introduced a `startupAborted` flag that tracks when the service must stop due to foreground-service restrictions.
- In the `onCreate()` catch block, changed from just logging and continuing to calling `stopSelf()` and returning immediately. This prevents the partially-initialized state.
- Guarded `onStartCommand()` to return `START_NOT_STICKY` early when `startupAborted` is true.
- Guarded `onDestroy()` to call `super.onDestroy()` and return immediately when `startupAborted` is true, preventing `NullPointerException` from accessing uninitialized `lateinit` fields like `player` and `mediaSession`.
- Added an explicit `onForegroundServiceStartNotAllowedException()` override that mirrors the `onCreate()` abort logic, acting as a safety net for any code path in Media3 that triggers the callback.
- Guarded `onBind()` to handle the rare case where a bind arrives after the service was already aborted.

## Testing
- Tried to test with `adb shell am start-foreground-service -n com.metrolist.music.debug/com.metrolist.music.playback.MusicService`(triggering service start without any foreground path) seemed fine but I couldn't replicate the full bug.

## Related Issues
- Closes #3272 
- Related to #3272 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when the app cannot start a foreground music service on some devices/Android versions.
  * Service now registers a listener earlier and tracks an “startup aborted” state to short-circuit initialization, lifecycle callbacks, and binding when foreground starts are blocked.
  * Blocked-start scenarios now log a warning and stop the service cleanly, reducing crashes, hangs, and unexpected playback startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->