### PR TITLE
(fix) DB Playlist date updated

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -1064,6 +1064,11 @@ interface DatabaseDao {
         songIds: List<String>,
     ): List<String>
 
+    @Query("UPDATE playlist SET lastUpdateTime = :now WHERE id = :playlistId")
+    fun updatePlaylistLastUpdated(
+        playlistId: String,
+        now: LocalDateTime = LocalDateTime.now(),
+    )
     @Transaction
     fun addSongToPlaylist(playlist: Playlist, songIds: List<String>) {
         var position = playlist.songCount
@@ -1076,6 +1081,7 @@ interface DatabaseDao {
                 )
             )
         }
+        updatePlaylistLastUpdated(playlist.id)
     }
 
     fun downloadedSongs(


### PR DESCRIPTION
## Problem
Until now we had the option to sort playlists by Date updated, not only in the library also in the addToPlaylistDialog. 

## Cause
That option didn't work, because the date was never written to the db, instead it used the hard coded default that was the same as Date added.

## Solution
Now calling updatePlaylistLastUpdated every time you add a song to the playlist, this function writes playlistId and LocalDateTime.now to the db. 

## Testing
Tested by adding different songs to different playlists and sort them by Date updated.

## Additional information
Sorry that I didn't created a Issue first, but it was only like 10 lines so I hope it's ok.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Playlists now automatically update their last-modified timestamp when songs are added, ensuring accurate information about playlist changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->