### PR TITLE
RFC: Pinnable library categories

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -596,16 +596,6 @@ class MainActivity : ComponentActivity() {
                         }
                     }
 
-                val topLevelScreens =
-                    remember {
-                        listOf(
-                            Screens.Home.route,
-                            Screens.Library.route,
-                            Screens.ListenTogether.route,
-                            "settings",
-                        )
-                    }
-
                 val (query, onQueryChange) =
                     rememberSaveable(stateSaver = TextFieldValue.Saver) {
                         mutableStateOf(TextFieldValue())
@@ -785,8 +775,9 @@ class MainActivity : ComponentActivity() {
                     val isListenTogetherScreen =
                         currentRoute == Screens.ListenTogether.route ||
                             currentRoute == "listen_together_from_topbar"
-                    shouldShowTopBar = currentRoute in topLevelScreens &&
+                    shouldShowTopBar = navigationItemRoutes.contains(currentRoute) &&
                         currentRoute != "settings" &&
+                        currentRoute != "search_input" &&
                         !(isListenTogetherScreen && listenTogetherInTopBar)
                 }
 
@@ -867,7 +858,7 @@ class MainActivity : ComponentActivity() {
                                     TopAppBar(
                                         title = {
                                             Text(
-                                                text = currentTitleRes?.let { stringResource(it) } ?: "",
+                                                text = NavigationScreens.getNavbarItems().firstOrNull({ it.route == currentRoute })?.let { stringResource(it.titleId) } ?: currentTitleRes?.let { stringResource(it) } ?: "",
                                                 style = MaterialTheme.typography.titleLarge,
                                             )
                                         },

--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -634,6 +634,7 @@ class MainActivity : ComponentActivity() {
                     remember(currentRoute, navigationItemRoutes) {
                         currentRoute == null ||
                             navigationItemRoutes.contains(currentRoute) ||
+                            currentRoute!!.startsWith("library_") ||
                             currentRoute!!.startsWith("search/")
                     }
 

--- a/app/src/main/kotlin/com/metrolist/music/constants/NavigationScreens.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/NavigationScreens.kt
@@ -8,6 +8,7 @@ package com.metrolist.music.constants
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.metrolist.music.R
@@ -142,6 +143,11 @@ enum class NavigationScreens(
     @Composable
     fun position(): NavigationItemPosition {
         return rememberEnumPreference(this.key, this.default_position).value
+    }
+
+    @Composable
+    fun positionPreference(): MutableState<NavigationItemPosition> {
+        return rememberEnumPreference(this.key, this.default_position)
     }
 
     companion object {

--- a/app/src/main/kotlin/com/metrolist/music/constants/NavigationScreens.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/NavigationScreens.kt
@@ -54,7 +54,7 @@ enum class NavigationScreens(
         R.drawable.search,
         R.drawable.search,
         "search_input",
-        stringPreferencesKey("nav_home_position"),
+        stringPreferencesKey("nav_search_position"),
         NavigationItemType.OTHER,
         NavigationItemPosition.AUTOMATIC
     ),
@@ -125,7 +125,7 @@ enum class NavigationScreens(
         R.string.filter_playlists,
         R.drawable.playlist_play,
         R.drawable.playlist_play,
-        "library_PLAYLISTS",
+        "library_playlists",
         stringPreferencesKey("nav_library_playlists_position"),
         NavigationItemType.LIBRARY,
         NavigationItemPosition.HIDDEN

--- a/app/src/main/kotlin/com/metrolist/music/constants/NavigationScreens.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/NavigationScreens.kt
@@ -1,0 +1,216 @@
+
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.constants
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.metrolist.music.R
+import com.metrolist.music.utils.rememberEnumPreference
+import kotlin.enums.enumEntries
+
+// Max items pinned in navigation bar before items set to AUTOMATIC position are moved to the top bar
+const val MAX_ITEMS_IN_NAV_BAR = 5
+
+enum class NavigationItemPosition {
+    NAV_BAR,
+    TOP_BAR,
+    AUTOMATIC,
+    HIDDEN
+}
+
+enum class NavigationItemType {
+    CORE,
+    LIBRARY,
+    OTHER
+}
+
+enum class NavigationScreens(
+    @StringRes val titleId: Int,
+    @DrawableRes val iconIdInactive: Int,
+    @DrawableRes val iconIdActive: Int,
+    val route: String,
+    val key: Preferences.Key<String>,
+    val type: NavigationItemType,
+    val default_position: NavigationItemPosition
+) {
+    HOME(
+        R.string.home,
+        R.drawable.home_outlined,
+        R.drawable.home_filled,
+        "home",
+        stringPreferencesKey("nav_home_position"),
+        NavigationItemType.CORE,
+        NavigationItemPosition.NAV_BAR
+    ),
+    SEARCH(
+        R.string.search,
+        R.drawable.search,
+        R.drawable.search,
+        "search_input",
+        stringPreferencesKey("nav_home_position"),
+        NavigationItemType.OTHER,
+        NavigationItemPosition.AUTOMATIC
+    ),
+    HISTORY(
+        R.string.history,
+        R.drawable.history,
+        R.drawable.history,
+        "history",
+        stringPreferencesKey("nav_history_position"),
+        NavigationItemType.OTHER,
+        NavigationItemPosition.TOP_BAR
+    ),
+    STATS(
+        R.string.stats,
+        R.drawable.stats,
+        R.drawable.stats,
+        "stats",
+        stringPreferencesKey("nav_stats_position"),
+        NavigationItemType.OTHER,
+        NavigationItemPosition.TOP_BAR
+    ),
+    LISTEN_TOGETHER(
+        R.string.together,
+        R.drawable.group_outlined,
+        R.drawable.group_filled,
+        "listen_together",
+        stringPreferencesKey("nav_listen_together_position"),
+        NavigationItemType.OTHER,
+        NavigationItemPosition.TOP_BAR
+    ),
+    LIBRARY_SONGS(
+        R.string.filter_songs,
+        R.drawable.music_note,
+        R.drawable.music_note,
+        "library_songs",
+        stringPreferencesKey("nav_library_songs_position"),
+        NavigationItemType.LIBRARY,
+        NavigationItemPosition.HIDDEN
+    ),
+    LIBRARY_ARTISTS(
+        R.string.filter_artists,
+        R.drawable.person,
+        R.drawable.person,
+        "library_artists",
+        stringPreferencesKey("nav_library_artists_position"),
+        NavigationItemType.LIBRARY,
+        NavigationItemPosition.HIDDEN
+    ),
+    LIBRARY_ALBUMS(
+        R.string.filter_albums,
+        R.drawable.album,
+        R.drawable.album,
+        "library_albums",
+        stringPreferencesKey("nav_library_albums_position"),
+        NavigationItemType.LIBRARY,
+        NavigationItemPosition.HIDDEN
+    ),
+    LIBRARY_PODCASTS(
+        R.string.filter_podcasts,
+        R.drawable.radio,
+        R.drawable.radio,
+        "library_podcasts",
+        stringPreferencesKey("nav_library_podcasts_position"),
+        NavigationItemType.LIBRARY,
+        NavigationItemPosition.HIDDEN
+    ),
+    LIBRARY_PLAYLISTS(
+        R.string.filter_playlists,
+        R.drawable.playlist_play,
+        R.drawable.playlist_play,
+        "library_PLAYLISTS",
+        stringPreferencesKey("nav_library_playlists_position"),
+        NavigationItemType.LIBRARY,
+        NavigationItemPosition.HIDDEN
+    ),
+    LIBRARY(
+        R.string.filter_library,
+        R.drawable.library_music_outlined,
+        R.drawable.library_music_filled,
+        "library",
+        stringPreferencesKey("nav_library_position"),
+        NavigationItemType.CORE,
+        NavigationItemPosition.NAV_BAR
+    );
+
+    @Composable
+    fun position(): NavigationItemPosition {
+        return rememberEnumPreference(this.key, this.default_position).value
+    }
+
+    companion object {
+        @Composable
+        fun getNavbarItems(): List<NavigationScreens> {
+            // Get count of items manually pinned to the navigation bar
+            val manualCount = enumEntries<NavigationScreens>().count {
+                it.type == NavigationItemType.CORE || it.position() == NavigationItemPosition.NAV_BAR
+            }
+
+            // Calculate count of AUTOMATIC items that appear in the navigation bar
+            var autoCount = maxOf(0, MAX_ITEMS_IN_NAV_BAR - manualCount)
+
+            // Build list
+            val list = buildList {
+                for(item in NavigationScreens.entries) {
+                    // Show manually pinned items
+                    if(item.type == NavigationItemType.CORE || item.position() == NavigationItemPosition.NAV_BAR) {
+                        add(item)
+                    }
+
+                    // Show AUTOMATIC items up to MAX_ITEMS_IN_NAV_BAR
+                    if(item.position() == NavigationItemPosition.AUTOMATIC && autoCount > 0) {
+                        add(item)
+                        autoCount--
+                    }
+                }
+            }
+
+            return list
+        }
+
+        @Composable
+        fun getTopbarItems(includeHidden: Boolean = false): List<NavigationScreens> {
+            // Get count of items manually pinned to the navigation bar
+            val manualCount = enumEntries<NavigationScreens>().count {
+                it.position() == NavigationItemPosition.NAV_BAR
+            }
+
+            // Calculate count of AUTOMATIC items that appear in the navigation bar (they won't show in top bar)
+            var autoCount = maxOf(0, MAX_ITEMS_IN_NAV_BAR - manualCount)
+
+            // Build list
+            val list = buildList {
+                for(item in NavigationScreens.entries) {
+                    // Don't show library items in top bar
+                    if(item.type == NavigationItemType.LIBRARY) {
+                        break
+                    }
+
+                    // Show manually pinned items
+                    if(item.position() == NavigationItemPosition.TOP_BAR) {
+                        add(item)
+                    }
+
+                    // Show hidden items (if applicable)
+                    if(item.position() == NavigationItemPosition.HIDDEN && includeHidden) {
+                        add(item)
+                    }
+
+                    // Show AUTOMATIC items above MAX_ITEMS_IN_NAV_BAR
+                    if(item.position() == NavigationItemPosition.AUTOMATIC) {
+                        if(autoCount > 0)   autoCount--
+                        else                add(item)
+                    }
+                }
+            }
+
+            return list
+        }
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/NavigationBuilder.kt
@@ -24,13 +24,19 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.dialog
 import androidx.navigation.navArgument
 import com.metrolist.music.constants.DarkModeKey
+import com.metrolist.music.constants.NavigationScreens
 import com.metrolist.music.constants.PureBlackKey
 import com.metrolist.music.ui.screens.artist.ArtistAlbumsScreen
 import com.metrolist.music.ui.screens.artist.ArtistItemsScreen
 import com.metrolist.music.ui.screens.artist.ArtistScreen
 import com.metrolist.music.ui.screens.artist.ArtistSongsScreen
 import com.metrolist.music.ui.screens.equalizer.EqScreen
+import com.metrolist.music.ui.screens.library.LibraryAlbumsScreen
+import com.metrolist.music.ui.screens.library.LibraryArtistsScreen
+import com.metrolist.music.ui.screens.library.LibraryPlaylistsScreen
+import com.metrolist.music.ui.screens.library.LibraryPodcastsScreen
 import com.metrolist.music.ui.screens.library.LibraryScreen
+import com.metrolist.music.ui.screens.library.LibrarySongsScreen
 import com.metrolist.music.ui.screens.playlist.AutoPlaylistScreen
 import com.metrolist.music.ui.screens.playlist.CachePlaylistScreen
 import com.metrolist.music.ui.screens.playlist.LocalPlaylistScreen
@@ -93,6 +99,21 @@ fun NavGraphBuilder.navigationBuilder(
         )
     }
 
+    composable(NavigationScreens.LIBRARY_SONGS.route) {
+        LibrarySongsScreen(navController)
+    }
+    composable(NavigationScreens.LIBRARY_ARTISTS.route) {
+        LibraryArtistsScreen(navController)
+    }
+    composable(NavigationScreens.LIBRARY_ALBUMS.route) {
+        LibraryAlbumsScreen(navController)
+    }
+    composable(NavigationScreens.LIBRARY_PODCASTS.route) {
+        LibraryPodcastsScreen(navController)
+    }
+    composable(NavigationScreens.LIBRARY_PLAYLISTS.route) {
+        LibraryPlaylistsScreen(navController, {})
+    }
     composable(Screens.Library.route) {
         LibraryScreen(navController)
     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryAlbumsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryAlbumsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -61,6 +62,8 @@ import com.metrolist.music.constants.GridItemsSizeKey
 import com.metrolist.music.constants.GridThumbnailHeight
 import com.metrolist.music.constants.HideExplicitKey
 import com.metrolist.music.constants.LibraryViewType
+import com.metrolist.music.constants.NavigationItemPosition
+import com.metrolist.music.constants.NavigationScreens
 import com.metrolist.music.constants.YtmSyncKey
 import com.metrolist.music.ui.component.ChipsRow
 import com.metrolist.music.ui.component.EmptyPlaceholder
@@ -192,16 +195,39 @@ fun LibraryAlbumsScreen(
                 onClick = {
                     viewType = viewType.toggle()
                 },
-                modifier = Modifier.padding(start = 6.dp, end = 6.dp),
+                modifier = Modifier.padding(start = 8.dp).size(40.dp),
             ) {
                 Icon(
                     painter =
-                    painterResource(
-                        when (viewType) {
-                            LibraryViewType.LIST -> R.drawable.list
-                            LibraryViewType.GRID -> R.drawable.grid_view
-                        },
-                    ),
+                        painterResource(
+                            when (viewType) {
+                                LibraryViewType.LIST -> R.drawable.list
+                                LibraryViewType.GRID -> R.drawable.grid_view
+                            },
+                        ),
+                    contentDescription = null,
+                )
+            }
+
+            val (position, setPosition) = NavigationScreens.LIBRARY_ALBUMS.positionPreference()
+
+            IconButton(
+                onClick = {setPosition(
+                    if (position == NavigationItemPosition.HIDDEN)
+                        NavigationItemPosition.NAV_BAR
+                    else
+                        NavigationItemPosition.HIDDEN
+                )},
+                modifier = Modifier.padding(end = 8.dp).size(40.dp),
+            ) {
+                Icon(
+                    painter =
+                        painterResource(
+                            if (position == NavigationItemPosition.HIDDEN)
+                                R.drawable.pin_outlined
+                            else
+                                R.drawable.pin_filled,
+                        ),
                     contentDescription = null,
                 )
             }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryAlbumsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryAlbumsScreen.kt
@@ -78,7 +78,7 @@ import kotlinx.coroutines.withContext
 @Composable
 fun LibraryAlbumsScreen(
     navController: NavController,
-    onDeselect: () -> Unit,
+    onDeselect: (() -> Unit)? = null,
     viewModel: LibraryAlbumsViewModel = hiltViewModel(),
 ) {
     val menuState = LocalMenuState.current
@@ -102,17 +102,19 @@ fun LibraryAlbumsScreen(
 
     val filterContent = @Composable {
         Row {
-            Spacer(Modifier.width(12.dp))
-            FilterChip(
-                label = { Text(stringResource(R.string.albums)) },
-                selected = true,
-                colors = FilterChipDefaults.filterChipColors(containerColor = MaterialTheme.colorScheme.surface),
-                onClick = onDeselect,
-                shape = RoundedCornerShape(16.dp),
-                leadingIcon = {
-                    Icon(painter = painterResource(R.drawable.close), contentDescription = "")
-                },
-            )
+            if(onDeselect != null) {
+                Spacer(Modifier.width(12.dp))
+                FilterChip(
+                    label = { Text(stringResource(R.string.albums)) },
+                    selected = true,
+                    colors = FilterChipDefaults.filterChipColors(containerColor = MaterialTheme.colorScheme.surface),
+                    onClick = onDeselect,
+                    shape = RoundedCornerShape(16.dp),
+                    leadingIcon = {
+                        Icon(painter = painterResource(R.drawable.close), contentDescription = "")
+                    },
+                )
+            }
             ChipsRow(
                 chips =
                 listOf(

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryArtistsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryArtistsScreen.kt
@@ -76,7 +76,7 @@ import kotlinx.coroutines.withContext
 @Composable
 fun LibraryArtistsScreen(
     navController: NavController,
-    onDeselect: () -> Unit,
+    onDeselect: (() -> Unit)? = null,
     viewModel: LibraryArtistsViewModel = hiltViewModel(),
 ) {
     val menuState = LocalMenuState.current
@@ -95,17 +95,19 @@ fun LibraryArtistsScreen(
 
     val filterContent = @Composable {
         Row {
-            Spacer(Modifier.width(12.dp))
-            FilterChip(
-                label = { Text(stringResource(R.string.artists)) },
-                selected = true,
-                colors = FilterChipDefaults.filterChipColors(containerColor = MaterialTheme.colorScheme.surface),
-                onClick = onDeselect,
-                shape = RoundedCornerShape(16.dp),
-                leadingIcon = {
-                    Icon(painter = painterResource(R.drawable.close), contentDescription = "")
-                },
-            )
+            if(onDeselect != null) {
+                Spacer(Modifier.width(12.dp))
+                FilterChip(
+                    label = { Text(stringResource(R.string.artists)) },
+                    selected = true,
+                    colors = FilterChipDefaults.filterChipColors(containerColor = MaterialTheme.colorScheme.surface),
+                    onClick = onDeselect,
+                    shape = RoundedCornerShape(16.dp),
+                    leadingIcon = {
+                        Icon(painter = painterResource(R.drawable.close), contentDescription = "")
+                    },
+                )
+            }
             ChipsRow(
                 chips =
                 listOf(

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryArtistsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryArtistsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -59,6 +60,8 @@ import com.metrolist.music.constants.GridItemSize
 import com.metrolist.music.constants.GridItemsSizeKey
 import com.metrolist.music.constants.GridThumbnailHeight
 import com.metrolist.music.constants.LibraryViewType
+import com.metrolist.music.constants.NavigationItemPosition
+import com.metrolist.music.constants.NavigationScreens
 import com.metrolist.music.constants.YtmSyncKey
 import com.metrolist.music.ui.component.ChipsRow
 import com.metrolist.music.ui.component.EmptyPlaceholder
@@ -185,7 +188,7 @@ fun LibraryArtistsScreen(
                 onClick = {
                     viewType = viewType.toggle()
                 },
-                modifier = Modifier.padding(start = 6.dp, end = 6.dp),
+                modifier = Modifier.padding(start = 8.dp).size(40.dp),
             ) {
                 Icon(
                     painter =
@@ -195,6 +198,29 @@ fun LibraryArtistsScreen(
                             LibraryViewType.GRID -> R.drawable.grid_view
                         },
                     ),
+                    contentDescription = null,
+                )
+            }
+
+            val (position, setPosition) = NavigationScreens.LIBRARY_ARTISTS.positionPreference()
+
+            IconButton(
+                onClick = {setPosition(
+                    if (position == NavigationItemPosition.HIDDEN)
+                        NavigationItemPosition.NAV_BAR
+                    else
+                        NavigationItemPosition.HIDDEN
+                )},
+                modifier = Modifier.padding(end = 8.dp).size(40.dp),
+            ) {
+                Icon(
+                    painter =
+                        painterResource(
+                            if (position == NavigationItemPosition.HIDDEN)
+                                R.drawable.pin_outlined
+                            else
+                                R.drawable.pin_filled,
+                        ),
                     contentDescription = null,
                 )
             }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPlaylistsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPlaylistsScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
@@ -25,9 +26,11 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -46,16 +49,21 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
+import com.metrolist.innertube.YouTube
 import com.metrolist.innertube.utils.parseCookieString
 import com.metrolist.music.LocalPlayerAwareWindowInsets
 import com.metrolist.music.R
 import com.metrolist.music.constants.CONTENT_TYPE_HEADER
 import com.metrolist.music.constants.CONTENT_TYPE_PLAYLIST
+import com.metrolist.music.constants.ChipSortTypeKey
 import com.metrolist.music.constants.GridItemSize
 import com.metrolist.music.constants.GridItemsSizeKey
 import com.metrolist.music.constants.GridThumbnailHeight
 import com.metrolist.music.constants.InnerTubeCookieKey
+import com.metrolist.music.constants.LibraryFilter
 import com.metrolist.music.constants.LibraryViewType
+import com.metrolist.music.constants.NavigationItemPosition
+import com.metrolist.music.constants.NavigationScreens
 import com.metrolist.music.constants.PlaylistSortDescendingKey
 import com.metrolist.music.constants.PlaylistSortType
 import com.metrolist.music.constants.PlaylistSortTypeKey
@@ -251,16 +259,39 @@ fun LibraryPlaylistsScreen(
                 onClick = {
                     viewType = viewType.toggle()
                 },
-                modifier = Modifier.padding(start = 6.dp, end = 6.dp),
+                modifier = Modifier.padding(start = 8.dp).size(40.dp),
             ) {
                 Icon(
                     painter =
-                    painterResource(
-                        when (viewType) {
-                            LibraryViewType.LIST -> R.drawable.list
-                            LibraryViewType.GRID -> R.drawable.grid_view
-                        },
-                    ),
+                        painterResource(
+                            when (viewType) {
+                                LibraryViewType.LIST -> R.drawable.list
+                                LibraryViewType.GRID -> R.drawable.grid_view
+                            },
+                        ),
+                    contentDescription = null,
+                )
+            }
+
+            val (position, setPosition) = NavigationScreens.LIBRARY_PLAYLISTS.positionPreference()
+
+            IconButton(
+                onClick = {setPosition(
+                    if (position == NavigationItemPosition.HIDDEN)
+                        NavigationItemPosition.NAV_BAR
+                    else
+                        NavigationItemPosition.HIDDEN
+                    )},
+                modifier = Modifier.padding(end = 8.dp).size(40.dp),
+            ) {
+                Icon(
+                    painter =
+                        painterResource(
+                            if (position == NavigationItemPosition.HIDDEN)
+                                R.drawable.pin_outlined
+                            else
+                                R.drawable.pin_filled,
+                        ),
                     contentDescription = null,
                 )
             }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPodcastsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPodcastsScreen.kt
@@ -99,7 +99,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun LibraryPodcastsScreen(
     navController: NavController,
-    onDeselect: () -> Unit,
+    onDeselect: (() -> Unit)? = null,
     viewModel: LibraryPodcastsViewModel = hiltViewModel(),
 ) {
     val downloadedEpisodesStr = stringResource(R.string.downloaded_episodes)
@@ -178,24 +178,26 @@ fun LibraryPodcastsScreen(
         // Chip row header — same pattern as LibrarySongsScreen
         val chipsHeader = @Composable {
             Row {
-                Spacer(Modifier.width(12.dp))
-                FilterChip(
-                    label = { Text(stringResource(R.string.filter_podcasts)) },
-                    selected = true,
-                    colors =
-                        FilterChipDefaults.filterChipColors(
-                            containerColor = MaterialTheme.colorScheme.surface,
-                        ),
-                    onClick = onDeselect,
-                    shape = RoundedCornerShape(16.dp),
-                    border = null,
-                    leadingIcon = {
-                        Icon(
-                            painter = painterResource(R.drawable.close),
-                            contentDescription = null,
-                        )
-                    },
-                )
+                if(onDeselect != null) {
+                    Spacer(Modifier.width(12.dp))
+                    FilterChip(
+                        label = { Text(stringResource(R.string.filter_podcasts)) },
+                        selected = true,
+                        colors =
+                            FilterChipDefaults.filterChipColors(
+                                containerColor = MaterialTheme.colorScheme.surface,
+                            ),
+                        onClick = onDeselect,
+                        shape = RoundedCornerShape(16.dp),
+                        border = null,
+                        leadingIcon = {
+                            Icon(
+                                painter = painterResource(R.drawable.close),
+                                contentDescription = null,
+                            )
+                        },
+                    )
+                }
                 ChipsRow(
                     chips =
                         listOf(

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPodcastsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPodcastsScreen.kt
@@ -68,6 +68,8 @@ import com.metrolist.music.LocalSyncUtils
 import com.metrolist.music.R
 import com.metrolist.music.constants.CONTENT_TYPE_HEADER
 import com.metrolist.music.constants.CONTENT_TYPE_SONG
+import com.metrolist.music.constants.NavigationItemPosition
+import com.metrolist.music.constants.NavigationScreens
 import com.metrolist.music.constants.PodcastFilter
 import com.metrolist.music.constants.PodcastFilterKey
 import com.metrolist.music.constants.SongSortDescendingKey
@@ -223,6 +225,48 @@ fun LibraryPodcastsScreen(
                         chipsHeader()
                     }
 
+                    item(key = "sort_header", contentType = CONTENT_TYPE_HEADER) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.padding(start = 16.dp),
+                        ) {
+                            Spacer(Modifier.weight(1f))
+                            Text(
+                                text =
+                                    pluralStringResource(
+                                        R.plurals.n_podcast,
+                                        subscribedChannels.size,
+                                        subscribedChannels.size,
+                                    ),
+                                style = MaterialTheme.typography.titleSmall,
+                                color = MaterialTheme.colorScheme.secondary,
+                            )
+
+                            val (position, setPosition) = NavigationScreens.LIBRARY_PODCASTS.positionPreference()
+
+                            IconButton(
+                                onClick = {setPosition(
+                                    if (position == NavigationItemPosition.HIDDEN)
+                                        NavigationItemPosition.NAV_BAR
+                                    else
+                                        NavigationItemPosition.HIDDEN
+                                )},
+                                modifier = Modifier.padding(start = 8.dp, end = 8.dp).size(40.dp),
+                            ) {
+                                Icon(
+                                    painter =
+                                        painterResource(
+                                            if (position == NavigationItemPosition.HIDDEN)
+                                                R.drawable.pin_outlined
+                                            else
+                                                R.drawable.pin_filled,
+                                        ),
+                                    contentDescription = null,
+                                )
+                            }
+                        }
+                    }
+
                     // RDPN "New Episodes" auto-playlist card
                     item(key = "rdpn_playlist", contentType = CONTENT_TYPE_HEADER) {
                         AutoPlaylistCard(
@@ -285,14 +329,12 @@ fun LibraryPodcastsScreen(
                         chipsHeader()
                     }
 
-                    item(key = "channels_count", contentType = CONTENT_TYPE_HEADER) {
+                    item(key = "sort_header", contentType = CONTENT_TYPE_HEADER) {
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
-                            modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 16.dp, vertical = 4.dp),
+                            modifier = Modifier.padding(start = 16.dp),
                         ) {
+                            Spacer(Modifier.weight(1f))
                             Text(
                                 text =
                                     pluralStringResource(
@@ -303,6 +345,29 @@ fun LibraryPodcastsScreen(
                                 style = MaterialTheme.typography.titleSmall,
                                 color = MaterialTheme.colorScheme.secondary,
                             )
+
+                            val (position, setPosition) = NavigationScreens.LIBRARY_PODCASTS.positionPreference()
+
+                            IconButton(
+                                onClick = {setPosition(
+                                    if (position == NavigationItemPosition.HIDDEN)
+                                        NavigationItemPosition.NAV_BAR
+                                    else
+                                        NavigationItemPosition.HIDDEN
+                                )},
+                                modifier = Modifier.padding(start = 8.dp, end = 8.dp).size(40.dp),
+                            ) {
+                                Icon(
+                                    painter =
+                                        painterResource(
+                                            if (position == NavigationItemPosition.HIDDEN)
+                                                R.drawable.pin_outlined
+                                            else
+                                                R.drawable.pin_filled,
+                                        ),
+                                    contentDescription = null,
+                                )
+                            }
                         }
                     }
 
@@ -356,7 +421,7 @@ fun LibraryPodcastsScreen(
                     item(key = "sort_header", contentType = CONTENT_TYPE_HEADER) {
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.padding(horizontal = 16.dp),
+                            modifier = Modifier.padding(start = 16.dp),
                         ) {
                             SortHeader(
                                 sortType = sortType,
@@ -383,6 +448,29 @@ fun LibraryPodcastsScreen(
                                 style = MaterialTheme.typography.titleSmall,
                                 color = MaterialTheme.colorScheme.secondary,
                             )
+
+                            val (position, setPosition) = NavigationScreens.LIBRARY_PODCASTS.positionPreference()
+
+                            IconButton(
+                                onClick = {setPosition(
+                                    if (position == NavigationItemPosition.HIDDEN)
+                                        NavigationItemPosition.NAV_BAR
+                                    else
+                                        NavigationItemPosition.HIDDEN
+                                )},
+                                modifier = Modifier.padding(start = 8.dp, end = 8.dp).size(40.dp),
+                            ) {
+                                Icon(
+                                    painter =
+                                        painterResource(
+                                            if (position == NavigationItemPosition.HIDDEN)
+                                                R.drawable.pin_outlined
+                                            else
+                                                R.drawable.pin_filled,
+                                        ),
+                                    contentDescription = null,
+                                )
+                            }
                         }
                     }
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -65,6 +66,8 @@ import com.metrolist.music.R
 import com.metrolist.music.constants.CONTENT_TYPE_HEADER
 import com.metrolist.music.constants.CONTENT_TYPE_SONG
 import com.metrolist.music.constants.HideExplicitKey
+import com.metrolist.music.constants.NavigationItemPosition
+import com.metrolist.music.constants.NavigationScreens
 import com.metrolist.music.constants.SongFilter
 import com.metrolist.music.constants.SongFilterKey
 import com.metrolist.music.constants.SongSortDescendingKey
@@ -365,7 +368,7 @@ fun LibrarySongsScreen(
             ) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.padding(horizontal = 16.dp),
+                    modifier = Modifier.padding(start = 16.dp),
                 ) {
                     SortHeader(
                         sortType = sortType,
@@ -394,6 +397,29 @@ fun LibrarySongsScreen(
                         style = MaterialTheme.typography.titleSmall,
                         color = MaterialTheme.colorScheme.secondary,
                     )
+
+                    val (position, setPosition) = NavigationScreens.LIBRARY_SONGS.positionPreference()
+
+                    IconButton(
+                        onClick = {setPosition(
+                            if (position == NavigationItemPosition.HIDDEN)
+                                NavigationItemPosition.NAV_BAR
+                            else
+                                NavigationItemPosition.HIDDEN
+                        )},
+                        modifier = Modifier.padding(start = 8.dp, end = 8.dp).size(40.dp),
+                    ) {
+                        Icon(
+                            painter =
+                                painterResource(
+                                    if (position == NavigationItemPosition.HIDDEN)
+                                        R.drawable.pin_outlined
+                                    else
+                                        R.drawable.pin_filled,
+                                ),
+                            contentDescription = null,
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
@@ -92,7 +92,7 @@ import kotlinx.coroutines.withContext
 @Composable
 fun LibrarySongsScreen(
     navController: NavController,
-    onDeselect: () -> Unit,
+    onDeselect: (() -> Unit)? = null,
     viewModel: LibrarySongsViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
@@ -326,20 +326,22 @@ fun LibrarySongsScreen(
                 contentType = CONTENT_TYPE_HEADER,
             ) {
                 Row {
-                    Spacer(Modifier.width(12.dp))
-                    FilterChip(
-                        label = { Text(stringResource(R.string.songs)) },
-                        selected = true,
-                        colors = FilterChipDefaults.filterChipColors(containerColor = MaterialTheme.colorScheme.surface),
-                        onClick = onDeselect,
-                        shape = RoundedCornerShape(16.dp),
-                        leadingIcon = {
-                            Icon(
-                                painter = painterResource(R.drawable.close),
-                                contentDescription = "",
-                            )
-                        },
-                    )
+                    if(onDeselect != null) {
+                        Spacer(Modifier.width(12.dp))
+                        FilterChip(
+                            label = { Text(stringResource(R.string.songs)) },
+                            selected = true,
+                            colors = FilterChipDefaults.filterChipColors(containerColor = MaterialTheme.colorScheme.surface),
+                            onClick = onDeselect,
+                            shape = RoundedCornerShape(16.dp),
+                            leadingIcon = {
+                                Icon(
+                                    painter = painterResource(R.drawable.close),
+                                    contentDescription = "",
+                                )
+                            },
+                        )
+                    }
                     ChipsRow(
                         chips =
                             listOf(

--- a/app/src/main/res/drawable/pin_filled.xml
+++ b/app/src/main/res/drawable/pin_filled.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="m640,480 l80,80v80L520,640v240l-40,40 -40,-40v-240L240,640v-80l80,-80v-280h-40v-80h400v80h-40v280Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/app/src/main/res/drawable/pin_outlined.xml
+++ b/app/src/main/res/drawable/pin_outlined.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="m640,480 l80,80v80L520,640v240l-40,40 -40,-40v-240L240,640v-80l80,-80v-280h-40v-80h400v80h-40v280ZM354,560h252l-46,-46v-314L400,200v314l-46,46ZM480,560Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -794,6 +794,10 @@
         <item quantity="one">%d channel</item>
         <item quantity="other">%d channels</item>
     </plurals>
+    <plurals name="n_podcast">
+        <item quantity="one">%d podcast</item>
+        <item quantity="other">%d podcasts</item>
+    </plurals>
 
     <!-- Restore confirmation dialog -->
     <string name="restore_confirm_title">Restore backup?</string>


### PR DESCRIPTION
### Important

This PR depends on #3279

This branch only contains the cherry-picked commits implementing pinnable library categories upon that base.

**Please ignore the tabbed interface on some of the screenshots, this is from another PR !**

---

This PR adds the ability to easily pin specific library categories to the main navigation bar, allowing users to pin specific categories for quick access.

No category is pinned by default, and a user may pin a category using the "pin" button next to the view button at the top of the page.

When more than two categories are pinned to the navigation bar, the search button will move to the top bar by default, helping to keep a reasonable number of items in the navigation bar (M3E's recommendation being 3-5 max).

All of this is built upon and configurable using the NavigationScreens implemented in #3279

| Overview | Comments |
| :---: | :---: |
| <img width="50%" src="https://github.com/user-attachments/assets/fca355f3-a267-48b1-9181-de235636dc27"/><br/>The pin button is visible in the top-right of the page | <img width="50%" src="https://github.com/user-attachments/assets/17f13e06-51f8-4e70-8846-f0d04f86a752"/><br/>Once pinned, a quick access button is added to the navigation bar |
| <img width="50%" src="https://github.com/user-attachments/assets/d46827b7-2df8-4639-9640-daa7840aac17"/><br/>Navigating to a library page through the navigation bar looks as you'd expect, with navigation items specific to the library page (here tabs from #3274, by default it'd just affect the back filter chip though) | <img width="50%" src="https://github.com/user-attachments/assets/5cf8c5c9-3454-4a9d-9961-d24b39605adf"/><br/>All library categories can be pinned, eg. podcasts. (You can see I added a podcast count while I was at it btw) |

### Implementation

Building upon #3279, a NavigationScreens item was created for each independent library page, and routes to each independent page were added to the NavigationBuilder.

These items are all positioned as HIDDEN by default, meaning they won't show up in the top bar or navigation bar (but still in the library ofc), and have their type set to LIBRARY, meaning they shouldn't ever show up in the top bar, and indicating to any relevant future works that they shouldn't be listed as being able to be pinned there in user-facing configuration pages.

The pin icon simply toggles the position of the desired item between NAV_BAR and HIDDEN, and the search icon will automatically move to the top bar if more than two categories are pinned (in addition to the home and library pages) as its position is set to AUTOMATIC.

---

I'm marking this as not a draft even if #3279 still is as I feel pretty confident about this PR, which should work smoothly once the underlying works introduced in #3279 get ironed out.

Currently known issues: after going to online search from a navbar tab, tapping on said tab will bring you back to the search page. Going back from the search page will land you on the desired page. This probably has to do with the navigation stacking management, which I'm not accustomed to.

Any comments and reviews appreciated !

Cheers,
Lurux.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable navigation bar: users can now pin/unpin library sections (Songs, Artists, Albums, Podcasts, Playlists) to appear in the bottom navigation bar.
  * Added pin icons to library screen headers for easy toggling of navigation visibility.

* **UI Improvements**
  * Improved navigation bar visibility logic with preference-based item placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->