### PR TITLE
feat: use low contrast on account settings popup

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Material3SettingsGroup.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Material3SettingsGroup.kt
@@ -42,7 +42,8 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun Material3SettingsGroup(
     title: String? = null,
-    items: List<Material3SettingsItem>
+    items: List<Material3SettingsItem>,
+    useLowContrast: Boolean = false
 ) {
     Column(
         modifier = Modifier
@@ -77,7 +78,11 @@ fun Material3SettingsGroup(
                         .animateContentSize(),
                     shape = shape,
                     colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+                        containerColor = if (!useLowContrast) {
+                            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+                        } else {
+                            MaterialTheme.colorScheme.surfaceContainerLow
+                        }
                     ),
                     elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
                 ) {

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AccountSettings.kt
@@ -291,7 +291,8 @@ fun AccountSettings(
                         }
                     }
                 )
-            )
+            ),
+            useLowContrast = true
         )
 
         Spacer(Modifier.height(8.dp))
@@ -360,7 +361,8 @@ fun AccountSettings(
                     },
                     enabled = isLoggedIn
                 )
-            )
+            ),
+            useLowContrast = true
         )
 
         Spacer(Modifier.height(12.dp))


### PR DESCRIPTION
## Problem
the slightly high contrast of the components the account settings dialog doesn't really look good with the bright background

## Solution
make it darker!!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added low-contrast rendering option for the Account Settings interface, improving visual clarity and accessibility for users who prefer reduced contrast displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->