### PR TITLE
fix(queue): prevent song restart when starting radio from queue menu

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/QueueMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/QueueMenu.kt
@@ -283,9 +283,16 @@ fun QueueMenu(
                         text = stringResource(R.string.start_radio),
                         onClick = {
                             onDismiss()
-                            playerConnection.playQueue(
-                                YouTubeQueue.radio(mediaMetadata)
-                            )
+                            val currentMediaId = playerConnection.player.currentMediaItemIndex.let {
+                                playerConnection.player.getMediaItemAt(it).mediaId
+                            }
+                            if (mediaMetadata.id == currentMediaId) {
+                                playerConnection.startRadioSeamlessly()
+                            } else {
+                                playerConnection.playQueue(
+                                    YouTubeQueue.radio(mediaMetadata)
+                                )
+                            }
                         }
                     ),
                     NewAction(


### PR DESCRIPTION
When tapping "Start radio" on the currently playing song in the queue 3-dot menu, use startRadioSeamlessly() (same as PlayerMenu) instead of playQueue() which replaces the entire queue and restarts the song.

Fixes #3153

## Problem
The currently playing song immediately stops and restarts from the beginning (0:00) while the new radio queue is generated.

## Cause
QueueMenu always called playerConnection.playQueue(YouTubeQueue.radio(mediaMetadata)), which replaces the entire queue and restarts playback, even when the selected song is already playing. PlayerMenu already handled this correctly by using startRadioSeamlessly(), but QueueMenu was missing that check.

## Solution
- Added a check to compare the selected song's ID against the currently playing media item.
- If they match, call startRadioSeamlessly() to build the radio queue without interrupting playback.
- If they don't match, fall back to the original playQueue() behavior.

## Testing
- Metrolist v13.3.0
- Android 16.0 emulator
- Tap "Start radio" on the currently playing song in the queue menu → song continues without restarting.
- Tap "Start radio" on a different song in the queue menu → behaves as before.

## Related Issues
- Closes #3153 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Radio functionality now intelligently starts with seamless playback when initiated from the currently playing track, while maintaining standard queue behavior for other selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->