### PR TITLE
fix(player): navigate to album on song title click regardless of play source

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
@@ -939,8 +939,11 @@ fun BottomSheetPlayer(
                                         indication = null,
                                         interactionSource = remember { MutableInteractionSource() },
                                         onClick = {
-                                            if (mediaMetadata.album != null) {
-                                                navController.navigate("album/${mediaMetadata.album.id}")
+                                            val albumId = mediaMetadata.album?.id
+                                                ?: currentSong?.album?.id
+                                                ?: currentSong?.song?.albumId
+                                            if (albumId != null) {
+                                                navController.navigate("album/$albumId")
                                                 state.collapseSoft()
                                             }
                                         },


### PR DESCRIPTION
## Summary
- Song title click in the player now navigates to the album even when the song was played from search, playlists, radio, or any non-album context
- Falls back to database album info (`currentSong.album` via `SongAlbumMap`, then `SongEntity.albumId`) when `mediaMetadata.album` is null

## Test plan
- [x] Play a song from search results, tap the song title in the player — should navigate to the album
- [x] Play a song from a playlist, tap the song title — should navigate to the album
- [x] Play a song from an album (existing behavior) — should still work as before
- [x] Play a song with no album association — title click should be a no-op (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved album navigation in the player to work more reliably by checking multiple sources for album information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->