### PR TITLE
fix: adding songs not correctly and removing songs not correctly

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
@@ -119,24 +119,28 @@ fun AddToPlaylistDialog(
         mutableStateOf<Set<String>>(emptySet())
     }
 
-    LaunchedEffect(isVisible, playlists) {
+    LaunchedEffect(isVisible) {
         if (!isVisible) {
             songIds = null
             playlistsContainingSong = emptySet()
             return@LaunchedEffect
-            }
-               if (playlists.isNotEmpty() && songIds == null) {
+        }
+        if (playlists.isNotEmpty() && songIds == null) {
             withContext(Dispatchers.IO) {
                 val ids = onGetSong(playlists.first())
                 songIds = ids
-
-                playlistsContainingSong = playlists
-                    .filter { playlist ->
-                        database.playlistDuplicates(playlist.id, ids).isNotEmpty()
-                    }
-                    .map { it.id }
-                    .toSet()
             }
+        }
+    }
+    LaunchedEffect(songIds, playlists) {
+        val ids = songIds ?: return@LaunchedEffect
+        withContext(Dispatchers.IO) {
+            playlistsContainingSong = playlists
+                .filter { playlist ->
+                    database.playlistDuplicates(playlist.id, ids).isNotEmpty()
+                }
+                .map { it.id }
+                .toSet()
         }
     }
 


### PR DESCRIPTION
## Problem
Since the playlist highlighting feature was introduced, `AddToPlaylistDialog` would silently add songs to unintended playlists without user interaction. Specifically:

- Songs were added to playlists the user never selected
- After removing a song from a playlist, it would reappear (required removing twice)
- Songs were added to all previously used playlists on re-open

## Cause
The single LaunchedEffect(isVisible, playlists) caused onGetSong to be
called silently whenever the playlist list re-emitted (e.g. sort change),
resulting in songs being added to unintended playlists without user input.


## Solution
-Split the single `LaunchedEffect` into two with separate responsibilities:

- **`LaunchedEffect(isVisible)`** — runs only when the dialog opens or closes. Fetches song IDs once via `onGetSong`. Sort changes do not restart this effect.
- **`LaunchedEffect(songIds, playlists)`** — recalculates which playlists already contain the song for highlighting. Never calls `onGetSong`. Safe to re-run on sort changes.

## Testing
Tested with adding and removing songs from playlists and reopening the dialog multiple times.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved state management in the playlist dialog to optimize performance and enhance reliability when handling visibility and playlist changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->