### PR TITLE
fix(alarm): minor UI spacing and placement adjustments for alarm settings section to maintain consistency

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AlarmSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AlarmSettings.kt
@@ -266,16 +266,10 @@ fun AlarmSettingsSection(showTitle: Boolean = true) {
                     }
                 )
             }
+
+            addAll(systemItems)
         }
     )
-
-    if (systemItems.isNotEmpty()) {
-        Spacer(modifier = Modifier.height(16.dp))
-        Material3SettingsGroup(
-            title = stringResource(R.string.settings_section_system),
-            items = systemItems
-        )
-    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
@@ -668,7 +668,9 @@ fun PlayerSettings(
             }
         )
 
-        AlarmSettingsSection(showTitle = false)
+        Spacer(modifier = Modifier.height(16.dp))
+
+        AlarmSettingsSection()
 
         Spacer(modifier = Modifier.height(27.dp))
 


### PR DESCRIPTION
## Problem
Alarm settings UI sections were visually mixed and permission hints were shown in a separate unrelated-looking block.
_Originally posted by @johannesbrauer in https://github.com/MetrolistGroup/Metrolist/issues/3063#issuecomment-4092203649_

## Testing
Built and tested bebug app successfully with:
./gradlew --no-configuration-cache :app:assembleFossDebug
| Image 1 | Image 2 | Image 3 |
|---------|---------|---------|
| ![Image 1](https://github.com/user-attachments/assets/8f2d00ed-4f8c-43fa-88da-04a88671a9c7) | ![Image 2](https://github.com/user-attachments/assets/aa09ab20-1b27-45af-80e5-f149c05c9019) | ![Image 3](https://github.com/user-attachments/assets/9d9839a6-be1d-4669-8a97-f3f313004116) |
| Alarm section with permission requirement| Light mode after permission granted | Dark mode after permission granted |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized Alarm Settings layout by consolidating system items into the main settings group instead of a separate section.
  * Adjusted spacing and visibility of the Alarm Settings section header in Player Settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->