### PR TITLE
feat: add a addToPlaylist button between the share and like button

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
@@ -1139,7 +1139,7 @@ fun BottomSheetPlayer(
                                 ) {
                                     Icon(
                                         painter = painterResource(R.drawable.add),
-                                        contentDescription = null,
+                                        contentDescription = stringResource(R.string.add_to_playlist),
                                         modifier = Modifier.size(24.dp),
                                     )
                                 }
@@ -1288,7 +1288,7 @@ fun BottomSheetPlayer(
                             ) {
                                 Icon(
                                     painter = painterResource(R.drawable.add),
-                                    contentDescription = null,
+                                    contentDescription = stringResource(R.string.add_to_playlist),
                                     tint = iconButtonColor,
                                     modifier = Modifier
                                         .align(Alignment.Center)


### PR DESCRIPTION
## Problem
Until now it took very much clicks to add a song to a playlist in the main Player.

## Solution
Added a add to playlist button between the share and the like button in the main Player.

## Testing
Build tested
Adding to playlists tested multiple times.

## Screenshots

![Screenshot_2026-03-22-03-55-53-564_com.metrolist.music.debug.jpg](https://github.com/user-attachments/assets/b9ba8f09-38eb-4e58-894f-8ba964bfc69f)

![Screenshot_2026-03-22-03-55-56-942_com.metrolist.music.debug.jpg](https://github.com/user-attachments/assets/bf4accef-a239-4bf3-8411-57f50f5c2a0b)


## Related Issues
- Related to #1835 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Add to playlist" action to the music player, letting users add the currently playing track to a playlist directly from the player.
  * The control appears in both player layouts (new and legacy) and is conditionally shown or replaced by spacing depending on the inline lyrics setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->