### PR TITLE
ref(ui): optimize speed dial grid for tablets and large screens

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
@@ -1425,9 +1425,14 @@ fun HomeScreen(
                                 }
 
                                 item(key = "speed_dial_list") {
-                                    val pagerState = rememberPagerState(pageCount = { (items.size + 8) / 9 })
+                                    val targetItemSize = 160.dp
                                     val availableWidth = maxWidth - 32.dp
-                                    val itemWidth = availableWidth / 3
+                                    val columns = (availableWidth / targetItemSize).toInt().coerceAtLeast(3)
+                                    val rows = if (columns >= 6) 1 else if (columns >= 4) 2 else 3
+                                    val itemsPerPage = columns * rows
+                                    val itemWidth = availableWidth / columns
+
+                                    val pagerState = rememberPagerState(pageCount = { (items.size + itemsPerPage - 1) / itemsPerPage })
 
                                     Column(
                                         modifier =
@@ -1442,18 +1447,18 @@ fun HomeScreen(
                                             modifier =
                                                 Modifier
                                                     .fillMaxWidth()
-                                                    .height(itemWidth * 3),
+                                                    .height(itemWidth * rows),
                                         ) { page ->
-                                            val pageStartIndex = page * 9
-                                            val pageItems = items.drop(pageStartIndex).take(9)
+                                            val pageStartIndex = page * itemsPerPage
+                                            val pageItems = items.drop(pageStartIndex).take(itemsPerPage)
 
                                             Column(modifier = Modifier.fillMaxSize()) {
-                                                for (row in 0 until 3) {
+                                                for (row in 0 until rows) {
                                                     Row(modifier = Modifier.fillMaxWidth()) {
-                                                        for (col in 0 until 3) {
-                                                            val itemIndex = row * 3 + col
+                                                        for (col in 0 until columns) {
+                                                            val itemIndex = row * columns + col
 
-                                                            val isRandomizeSlot = (page == 0 && itemIndex == 8)
+                                                            val isRandomizeSlot = (page == 0 && itemIndex == itemsPerPage - 1)
 
                                                             if (isRandomizeSlot) {
                                                                 Box(


### PR DESCRIPTION
## Problem
The speed dial grid was hardcoded to a 3×3 layout, causing items to render oversized on tablets and landscape orientations.

## Cause
Column and row counts were fixed values (`3`), with no awareness of available screen width.

## Solution
- Dynamic column calculation based on a 160dp target item size
- Row count adjusts to 1, 2, or 3 depending on how many columns fit
- Page size and the randomize slot index update accordingly

## Testing
Tested on a physical device in both portrait and landscape.

<img width="480" alt="Landscape" src="https://github.com/user-attachments/assets/a0f465cf-1683-480e-addb-435875a41995" />
<img width="270" alt="Portrait" src="https://github.com/user-attachments/assets/1524de60-6470-44a9-890f-5734e5100d16" />

## Related Issues
- Closes #3225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * SpeedDial layout now dynamically adapts to available screen width instead of using a fixed grid arrangement, providing improved responsiveness across different device sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->