### PR TITLE
Fix Nightly Download in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you're in a region where YouTube Music is not supported, you won't be able to
 <div align="center">
 <h1>Nightly Build</h1>
 
-<a href="https://nightly.link/MetrolistGroup/Metrolist/workflows/build/main/app-universal-with-Google-Cast.zip">
+<a href="https://nightly.link/MetrolistGroup/Metrolist/workflows/build/main/app-with-Google-Cast.zip">
   <img src="https://github.com/machiav3lli/oandbackupx/blob/034b226cea5c1b30eb4f6a6f313e4dadcbb0ece4/badge_github.png" alt="Get it on GitHub" height="82">
 </a>
 


### PR DESCRIPTION
Fix Nightly.link

## Problem
<!-- Describe the issue or limitation this PR addresses -->
Nightly-Link in the readme is currently broken
## Cause
<!-- Explain the root cause of the problem -->
app-universal-with-Google-Cast.zip was changed to app-with-Google-Cast.zip in Github actions
## Solution
<!-- List the changes made to fix the issue -->
- Updated the Link to https://nightly.link/MetrolistGroup/Metrolist/workflows/build/main/app-with-Google-Cast.zip

## Testing
<!-- Describe how the changes were tested -->
- Clicked the Link - it downloaded without problems


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Nightly Build download link in README to reference the correct artifact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->