### PR TITLE
fix(Lyrics.kt): simplify if expression

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Lyrics.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Lyrics.kt
@@ -1620,7 +1620,7 @@ fun Lyrics(
                                                 scaleY = bounceScale
                                             },
                                 )
-                            } else if (isActiveLine && !lyricsGlowEffect) {
+                            } else if (!lyricsGlowEffect) {
                                 // Active line without glow effect - just bold text (and also an inactive line)
                                 Text(
                                     text = mainText,


### PR DESCRIPTION
## Problem
you dont need to repeat `Text` on multiple if statements when the only difference is 2 parameters guh

## Solution
make it once!!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated lyrics display styling logic to simplify rendering paths; improves maintainability while preserving the visual appearance and behavior of lyrics (no user-facing changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->