### PR TITLE
fix(Player): awkward padding on buttons when lyrics is hidden

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
@@ -5,7 +5,6 @@
 
 package com.metrolist.music.ui.player
 
-import android.annotation.SuppressLint
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context


### PR DESCRIPTION
## Problem
theres a giant padding in the middle of the buttons right next to the lyrics when you tap on the lyrics button..

![IMG_20260323_193844](https://github.com/user-attachments/assets/e6f3b17c-5a78-4855-9ab4-85ec86486f3a)

## Solution
fix it!!
![IMG_20260323_202123](https://github.com/user-attachments/assets/38575d4f-b59f-48c5-95dd-ac19369235ef)

@coderabbitai ignore