### PR TITLE
fix: empty space at the add to playlist buttons location in lyrics mode

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
@@ -1141,7 +1141,7 @@ fun BottomSheetPlayer(
                             ) {
                                 Icon(
                                     painter = painterResource(R.drawable.add),
-                                    contentDescription = null,
+                                    contentDescription = stringResource(R.string.add_to_playlist),
                                     modifier = Modifier.size(24.dp),
                                 )
                             }
@@ -1287,7 +1287,7 @@ fun BottomSheetPlayer(
                         ) {
                             Icon(
                                 painter = painterResource(R.drawable.add),
-                                contentDescription = null,
+                                contentDescription = stringResource(R.string.add_to_playlist),
                                 tint = iconButtonColor,
                                 modifier = Modifier
                                     .align(Alignment.Center)


### PR DESCRIPTION
## Problem
In the lyrics mode the add to playlist button didn't appear, instead it showed a white space and if you clicked on it, it sometimes showed you the artist because the artists are moving invisible under these elements

## Cause
Didn't saw that when I tested it.

## Solution
Changed the add to playlist button spacer if showInLineLyrics is false to 0dp

## Testing
Tested with looking at the UI
Tested build

## Related PR's
- Related to #3315 , #3332