### PR TITLE
fix: miniPlayer text and button colors for Gradiant, Blur and pure Black

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
@@ -288,9 +288,9 @@ private fun NewMiniPlayer(
         MiniPlayerBackgroundStyle.GRADIENT   -> MaterialTheme.colorScheme.surfaceContainer
         MiniPlayerBackgroundStyle.PURE_BLACK -> Color.Black
     }
-    val forceLightColors = miniPlayerBackground == MiniPlayerBackgroundStyle.PURE_BLACK ||
+    val forceLightColors = !useDarkTheme && (miniPlayerBackground == MiniPlayerBackgroundStyle.PURE_BLACK ||
             miniPlayerBackground == MiniPlayerBackgroundStyle.BLUR ||
-            miniPlayerBackground == MiniPlayerBackgroundStyle.GRADIENT
+            miniPlayerBackground == MiniPlayerBackgroundStyle.GRADIENT)
 
     val primaryColor = if (forceLightColors) Color.White else MaterialTheme.colorScheme.primary
     val outlineColor = if (forceLightColors) Color.White else MaterialTheme.colorScheme.outline


### PR DESCRIPTION
## Problem
The miniPlayer changed Text and button colors with the Materialyou colors, this caused a bad readability on Gradient, Blur and pure Black in light mode. Thanks for reporting @apollo79 on #3314

## Cause
Changed the colors with the changing Materialyou colors.

## Solution
Hardcoded them to light colors if lightMode is enabled.

## Testing
Tested by looking at the UI in light mode.
Build succesful

## Screenshots:
![Screenshot_2026-03-24-23-27-02-410_com.metrolist.music.debug.jpg](https://github.com/user-attachments/assets/5a358b64-6415-4aa9-bea7-7ac98e2119f5)

![Screenshot_2026-03-24-23-26-59-486_com.metrolist.music.debug.jpg](https://github.com/user-attachments/assets/77714db5-a15a-4806-bf51-3000ed75de70)

![Screenshot_2026-03-24-23-26-53-106_com.metrolist.music.debug.jpg](https://github.com/user-attachments/assets/b2ae0afa-2c66-47de-b790-39bf5109594f)


## Related Issues
- Related PR's #3314 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved mini player color handling to force high-contrast light colors on certain backgrounds, ensuring consistent readability.
  * Updated player action buttons to receive and use the mini player’s selected colors so tint, border, and background now match the player’s contrast rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->