### PR TITLE
feat: audio normalization loudness level selector

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -126,6 +126,18 @@ val ShuffleModeKey = booleanPreferencesKey("shuffleMode")
 val SkipSilenceKey = booleanPreferencesKey("skipSilence")
 val SkipSilenceInstantKey = booleanPreferencesKey("skipSilenceInstant")
 val AudioNormalizationKey = booleanPreferencesKey("audioNormalization")
+
+val LoudnessLevelKey = stringPreferencesKey("loudnessLevel")
+
+enum class LoudnessLevel(
+    val targetLufs: Float
+) {
+    AGGRESSIVE(-7f),
+    LOUD(-11f),
+    BALANCED(-14f),
+    QUIET(-19f),
+}
+
 val AutoLoadMoreKey = booleanPreferencesKey("autoLoadMore")
 val DisableLoadMoreWhenRepeatAllKey = booleanPreferencesKey("disableLoadMoreWhenRepeatAll")
 val AutoDownloadOnLikeKey = booleanPreferencesKey("autoDownloadOnLike")

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -181,7 +181,6 @@ import com.metrolist.music.playback.queues.Queue
 import com.metrolist.music.playback.queues.YouTubeQueue
 import com.metrolist.music.playback.queues.filterExplicit
 import com.metrolist.music.playback.queues.filterVideoSongs
-import com.metrolist.music.R
 import com.metrolist.music.constants.LoudnessLevel
 import com.metrolist.music.constants.LoudnessLevelKey
 import com.metrolist.music.utils.CoilBitmapLoader
@@ -229,9 +228,7 @@ import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
 import java.time.LocalDateTime
 import javax.inject.Inject
-import kotlin.coroutines.coroutineContext
 import kotlin.random.Random
-import kotlin.time.Duration.Companion.seconds
 
 private const val INSTANT_SILENCE_SKIP_STEP_MS = 15_000L
 private const val INSTANT_SILENCE_SKIP_SETTLE_MS = 350L
@@ -2133,18 +2130,22 @@ class MusicService :
         loudnessSetupJob?.cancel()
         loudnessSetupJob = null
 
-        if (loudnessEnhancer != null) {
-            releaseLoudnessEnhancer(clearNormalizationCache = clearNormalizationCache)
+        // Guard: only release/reset state if closing the currently active session
+        val isClosingCurrentSession =
+            isAudioEffectSessionOpened &&
+                    openedAudioEffectSessionId != C.AUDIO_SESSION_ID_UNSET &&
+                    sessionIdToClose == openedAudioEffectSessionId
+
+        if (isClosingCurrentSession) {
+            if (loudnessEnhancer != null) {
+                releaseLoudnessEnhancer(clearNormalizationCache = clearNormalizationCache)
+            }
+
+            isAudioEffectSessionOpened = false
+            openedAudioEffectSessionId = C.AUDIO_SESSION_ID_UNSET
         }
 
-        if (! isAudioEffectSessionOpened && (sessionIdToClose == C.AUDIO_SESSION_ID_UNSET || sessionIdToClose <= 0)) {
-            return
-        }
-
-        isAudioEffectSessionOpened = false
-        openedAudioEffectSessionId = C.AUDIO_SESSION_ID_UNSET
-        releaseLoudnessEnhancer(clearNormalizationCache = clearNormalizationCache)
-
+        // Broadcast close for the requested session (even if stale)
         if (sessionIdToClose != C.AUDIO_SESSION_ID_UNSET && sessionIdToClose > 0) {
             sendBroadcast(
                 Intent(AudioEffect.ACTION_CLOSE_AUDIO_EFFECT_CONTROL_SESSION).apply {

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -2044,7 +2044,7 @@ class MusicService :
         }
     }
 
-    private fun releaseLoudnessEnhancer() {
+    private fun releaseLoudnessEnhancer(clearNormalizationCache: Boolean = true) {
         try {
             loudnessEnhancer?.release()
             Timber.tag(TAG).d("LoudnessEnhancer released")
@@ -2052,8 +2052,10 @@ class MusicService :
             reportException(e)
             Timber.tag(TAG).e(e, "Error releasing LoudnessEnhancer: ${e.message}")
         } finally {
-            cachedNormalizationGainMb = null
-            cachedNormalizationEnabled = false
+            if (clearNormalizationCache) {
+                cachedNormalizationGainMb = null
+                cachedNormalizationEnabled = false
+            }
             loudnessEnhancer = null
         }
     }
@@ -2076,9 +2078,9 @@ class MusicService :
         }
 
         if (isAudioEffectSessionOpened && openedAudioEffectSessionId > 0) {
-            closeAudioEffectSession(openedAudioEffectSessionId)
+            closeAudioEffectSession(sessionIdOverride = openedAudioEffectSessionId, clearNormalizationCache = false)
         } else {
-            releaseLoudnessEnhancer()
+            releaseLoudnessEnhancer(clearNormalizationCache = false)
         }
 
         isAudioEffectSessionOpened = true
@@ -2103,7 +2105,7 @@ class MusicService :
         )
     }
 
-    private fun closeAudioEffectSession(sessionIdOverride: Int? = null) {
+    private fun closeAudioEffectSession(sessionIdOverride: Int? = null, clearNormalizationCache: Boolean = true) {
         val sessionIdToClose = sessionIdOverride ?: openedAudioEffectSessionId
 
         if (! isAudioEffectSessionOpened && (sessionIdToClose == C.AUDIO_SESSION_ID_UNSET || sessionIdToClose <= 0)) {
@@ -2112,7 +2114,7 @@ class MusicService :
 
         isAudioEffectSessionOpened = false
         openedAudioEffectSessionId = C.AUDIO_SESSION_ID_UNSET
-        releaseLoudnessEnhancer()
+        releaseLoudnessEnhancer(clearNormalizationCache = clearNormalizationCache)
 
         if (sessionIdToClose != C.AUDIO_SESSION_ID_UNSET && sessionIdToClose > 0) {
             sendBroadcast(

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -2133,6 +2133,10 @@ class MusicService :
         loudnessSetupJob?.cancel()
         loudnessSetupJob = null
 
+        if (loudnessEnhancer != null) {
+            releaseLoudnessEnhancer(clearNormalizationCache = clearNormalizationCache)
+        }
+
         if (! isAudioEffectSessionOpened && (sessionIdToClose == C.AUDIO_SESSION_ID_UNSET || sessionIdToClose <= 0)) {
             return
         }
@@ -4094,6 +4098,8 @@ class MusicService :
             timber.log.Timber.e(e, "Failed to swap player in MediaSession")
         }
 
+        val previousAudioSessionId = fadingPlayer?.audioSessionId ?: C.AUDIO_SESSION_ID_UNSET
+
         openAudioEffectSession()
 
         crossfadeJob =
@@ -4132,13 +4138,14 @@ class MusicService :
                 try {
                     fadingPlayer?.volume = 0f
                     player.volume = startVolume
-                    cleanupCrossfade()
                 } catch (e: Exception) {
                 }
+
+                cleanupCrossfade(fadingPlayerSessionId = previousAudioSessionId)
             }
     }
 
-    private fun cleanupCrossfade() {
+    private fun cleanupCrossfade(fadingPlayerSessionId: Int = C.AUDIO_SESSION_ID_UNSET) {
         fadingPlayer?.stop()
         fadingPlayer?.clearMediaItems()
         fadingPlayer?.release()
@@ -4146,6 +4153,10 @@ class MusicService :
         isCrossfading = false
         applyEffectiveVolume()
         sleepTimer.notifySongTransition()
+
+        if (fadingPlayerSessionId != C.AUDIO_SESSION_ID_UNSET && fadingPlayerSessionId > 0) {
+            closeAudioEffectSession(sessionIdOverride = fadingPlayerSessionId, clearNormalizationCache = true)
+        }
     }
 
     companion object {

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -388,7 +388,7 @@ class MusicService :
     private var normalizationEnabledCached: Boolean = false
 
     @Volatile
-    private var loudnessLevelCached: LoudnessLevel = LoudnessLevel.AGGRESSIVE
+    private var loudnessLevelCached: LoudnessLevel = LoudnessLevel.BALANCED
 
     private var cachedNormalizationGainMb: Int? = null
     private var cachedNormalizationEnabled: Boolean = false
@@ -801,7 +801,7 @@ class MusicService :
                 .map { it[AudioNormalizationKey] ?: true }
                 .distinctUntilChanged(),
             dataStore.data
-                .map { prefs -> prefs[LoudnessLevelKey].toEnum(LoudnessLevel.AGGRESSIVE) }
+                .map { prefs -> prefs[LoudnessLevelKey].toEnum(LoudnessLevel.BALANCED) }
                 .distinctUntilChanged(),
         ) { format, normalizeAudio, loudnessLevel ->
             Triple(format, normalizeAudio, loudnessLevel)
@@ -1914,7 +1914,7 @@ class MusicService :
 
     private fun seedLoudnessCacheFromPrefs() {
         normalizationEnabledCached = dataStore.get(AudioNormalizationKey, true)
-        loudnessLevelCached = dataStore[LoudnessLevelKey].toEnum(LoudnessLevel.AGGRESSIVE)
+        loudnessLevelCached = dataStore[LoudnessLevelKey].toEnum(LoudnessLevel.BALANCED)
 
         Timber.tag(TAG).d(
             "Seeded loudness cache: normalization=$normalizationEnabledCached, level=$loudnessLevelCached"
@@ -1993,7 +1993,7 @@ class MusicService :
                         .tag(TAG)
                         .d("Format loudnessDb: ${format?.loudnessDb}, perceptualLoudnessDb: ${format?.perceptualLoudnessDb}")
 
-                    // Use loudnessDb if available, otherwise fall back to perceptualLoudnessDb
+                    // Use perceptualLoudnessDb if available, otherwise fall back to loudnessDb + offset
                     val measuredLufs: Double? = format?.perceptualLoudnessDb ?: format?.loudnessDb?.let { it + LoudnessLevel.AGGRESSIVE.targetLufs }
 
                     withContext(Dispatchers.Main) {

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -181,6 +181,9 @@ import com.metrolist.music.playback.queues.Queue
 import com.metrolist.music.playback.queues.YouTubeQueue
 import com.metrolist.music.playback.queues.filterExplicit
 import com.metrolist.music.playback.queues.filterVideoSongs
+import com.metrolist.music.R
+import com.metrolist.music.constants.LoudnessLevel
+import com.metrolist.music.constants.LoudnessLevelKey
 import com.metrolist.music.utils.CoilBitmapLoader
 import com.metrolist.music.utils.DiscordRPC
 import com.metrolist.music.utils.NetworkConnectivityObserver
@@ -229,6 +232,8 @@ import kotlin.time.Duration.Companion.seconds
 
 private const val INSTANT_SILENCE_SKIP_STEP_MS = 15_000L
 private const val INSTANT_SILENCE_SKIP_SETTLE_MS = 350L
+
+private const val API_DEFAULT_TARGET_LUFS = -7.0
 
 @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
 @androidx.annotation.OptIn(UnstableApi::class)
@@ -785,9 +790,12 @@ class MusicService :
             dataStore.data
                 .map { it[AudioNormalizationKey] ?: true }
                 .distinctUntilChanged(),
-        ) { format, normalizeAudio ->
-            format to normalizeAudio
-        }.collectLatest(scope) { (format, normalizeAudio) -> setupLoudnessEnhancer() }
+            dataStore.data
+                .map { prefs -> prefs[LoudnessLevelKey].toEnum(LoudnessLevel.AGGRESSIVE) }
+                .distinctUntilChanged(),
+        ) { format, normalizeAudio, loudnessLevel ->
+            Triple(format, normalizeAudio, loudnessLevel)
+        }.collectLatest(scope) { (format, normalizeAudio, loudnessLevel) -> setupLoudnessEnhancer() }
 
         combine(
             dataStore.data.map { it[AudioOffload] ?: false },
@@ -1930,22 +1938,32 @@ class MusicService :
                             database.format(currentMediaId).first()
                         }
 
+                    val loudnessLevel = withContext(Dispatchers.IO) {
+                        dataStore.data
+                            .map { prefs -> prefs[LoudnessLevelKey].toEnum(LoudnessLevel.AGGRESSIVE) }
+                            .first()
+                    }
+
+                    val targetLufs = loudnessLevel.targetLufs
+
                     Timber.tag(TAG).d("Audio normalization enabled: $normalizeAudio")
                     Timber
                         .tag(TAG)
                         .d("Format loudnessDb: ${format?.loudnessDb}, perceptualLoudnessDb: ${format?.perceptualLoudnessDb}")
 
                     // Use loudnessDb if available, otherwise fall back to perceptualLoudnessDb
-                    val loudness = format?.loudnessDb ?: format?.perceptualLoudnessDb
+                    val measuredLufs: Double? = format?.perceptualLoudnessDb ?: format?.loudnessDb?.let { it + API_DEFAULT_TARGET_LUFS }
 
                     withContext(Dispatchers.Main) {
-                        if (loudness != null) {
-                            val loudnessDb = loudness.toFloat()
-                            val targetGain = (-loudnessDb * 100).toInt()
+                        if (measuredLufs != null) {
+                            val loudnessDb = measuredLufs.let { it - targetLufs }
+                            val targetGain = (-loudnessDb * 100.0).toInt()
                             val clampedGain = targetGain.coerceIn(MIN_GAIN_MB, MAX_GAIN_MB)
 
-                            Timber
-                                .tag(TAG)
+                            Timber.tag(TAG)
+                                .d("Normalization Target LUFS: $targetLufs, Measured LUFS: $measuredLufs, Calculated gain: $targetGain mB, Clamped gain: $clampedGain mB")
+
+                            Timber.tag(TAG)
                                 .d("Calculated raw normalization gain: $targetGain mB (from loudness: $loudnessDb)")
 
                             try {

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -385,6 +385,15 @@ class MusicService :
     private var isAudioEffectSessionOpened = false
     private var loudnessEnhancer: LoudnessEnhancer? = null
 
+    @Volatile
+    private var normalizationEnabledCached: Boolean = true
+
+    @Volatile
+    private var loudnessLevelCached: LoudnessLevel = LoudnessLevel.AGGRESSIVE
+
+    private var cachedNormalizationGainMb: Int? = null
+    private var cachedNormalizationEnabled: Boolean = false
+
     private var discordRpc: DiscordRPC? = null
     private var lastPlaybackSpeed = 1.0f
     private var discordUpdateJob: kotlinx.coroutines.Job? = null
@@ -795,7 +804,11 @@ class MusicService :
                 .distinctUntilChanged(),
         ) { format, normalizeAudio, loudnessLevel ->
             Triple(format, normalizeAudio, loudnessLevel)
-        }.collectLatest(scope) { (format, normalizeAudio, loudnessLevel) -> setupLoudnessEnhancer() }
+        }.collectLatest(scope) { (format, normalizeAudio, loudnessLevel) ->
+            normalizationEnabledCached = normalizeAudio
+            loudnessLevelCached = loudnessLevel
+            setupLoudnessEnhancer()
+        }
 
         combine(
             dataStore.data.map { it[AudioOffload] ?: false },
@@ -1898,6 +1911,38 @@ class MusicService :
         startRadioSeamlessly()
     }
 
+    private fun applyCachedLoudnessEnhancerNow() {
+        val enhancer = loudnessEnhancer ?: return
+
+        try {
+            val gain = cachedNormalizationGainMb
+
+            if (cachedNormalizationEnabled && gain != null) {
+                enhancer.setTargetGain(gain)
+                enhancer.enabled = true
+            } else {
+                enhancer.enabled = false
+            }
+        } catch (e: Exception) {
+            reportException(e)
+            releaseLoudnessEnhancer()
+        }
+    }
+
+    private fun createLoudnessEnhancerForSessionId(audioSessionId: Int): Boolean {
+        try {
+            loudnessEnhancer = LoudnessEnhancer(audioSessionId)
+            Timber.tag(TAG).d("LoudnessEnhancer created for sessionId=$audioSessionId")
+
+            return true
+        } catch (e: Exception) {
+            reportException(e)
+            loudnessEnhancer = null
+
+            return false
+        }
+    }
+
     private fun setupLoudnessEnhancer() {
         val audioSessionId = player.audioSessionId
 
@@ -1910,12 +1955,7 @@ class MusicService :
 
         // Create or recreate enhancer if needed
         if (loudnessEnhancer == null) {
-            try {
-                loudnessEnhancer = LoudnessEnhancer(audioSessionId)
-                Timber.tag(TAG).d("LoudnessEnhancer created for sessionId=$audioSessionId")
-            } catch (e: Exception) {
-                reportException(e)
-                loudnessEnhancer = null
+            if (! createLoudnessEnhancerForSessionId(audioSessionId)) {
                 return
             }
         }
@@ -1927,10 +1967,7 @@ class MusicService :
                         player.currentMediaItem?.mediaId
                     }
 
-                val normalizeAudio =
-                    withContext(Dispatchers.IO) {
-                        dataStore.data.map { it[AudioNormalizationKey] ?: true }.first()
-                    }
+                val normalizeAudio = normalizationEnabledCached
 
                 if (normalizeAudio && currentMediaId != null) {
                     val format =
@@ -1938,12 +1975,7 @@ class MusicService :
                             database.format(currentMediaId).first()
                         }
 
-                    val loudnessLevel = withContext(Dispatchers.IO) {
-                        dataStore.data
-                            .map { prefs -> prefs[LoudnessLevelKey].toEnum(LoudnessLevel.AGGRESSIVE) }
-                            .first()
-                    }
-
+                    val loudnessLevel = loudnessLevelCached
                     val targetLufs = loudnessLevel.targetLufs
 
                     Timber.tag(TAG).d("Audio normalization enabled: $normalizeAudio")
@@ -1967,6 +1999,9 @@ class MusicService :
                                 .d("Calculated raw normalization gain: $targetGain mB (from loudness: $loudnessDb)")
 
                             try {
+                                cachedNormalizationGainMb = clampedGain
+                                cachedNormalizationEnabled = true
+
                                 loudnessEnhancer?.setTargetGain(clampedGain)
                                 loudnessEnhancer?.enabled = true
                                 Timber.tag(TAG).i("LoudnessEnhancer gain applied: $clampedGain mB")
@@ -1976,6 +2011,8 @@ class MusicService :
                                 releaseLoudnessEnhancer()
                             }
                         } else {
+                            cachedNormalizationGainMb = null
+                            cachedNormalizationEnabled = false
                             loudnessEnhancer?.enabled = false
                             Timber
                                 .tag(TAG)
@@ -1984,6 +2021,8 @@ class MusicService :
                     }
                 } else {
                     withContext(Dispatchers.Main) {
+                        cachedNormalizationGainMb = null
+                        cachedNormalizationEnabled = false
                         loudnessEnhancer?.enabled = false
                         Timber.tag(TAG).d("setupLoudnessEnhancer: normalization disabled or mediaId unavailable")
                     }
@@ -2003,6 +2042,8 @@ class MusicService :
             reportException(e)
             Timber.tag(TAG).e(e, "Error releasing LoudnessEnhancer: ${e.message}")
         } finally {
+            cachedNormalizationGainMb = null
+            cachedNormalizationEnabled = false
             loudnessEnhancer = null
         }
     }
@@ -2010,7 +2051,18 @@ class MusicService :
     private fun openAudioEffectSession() {
         if (isAudioEffectSessionOpened) return
         isAudioEffectSessionOpened = true
-        setupLoudnessEnhancer()
+
+        val audioSessionId = player.audioSessionId
+        if (audioSessionId != C.AUDIO_SESSION_ID_UNSET && audioSessionId > 0 && loudnessEnhancer == null) {
+            createLoudnessEnhancerForSessionId(audioSessionId)
+        }
+
+        applyCachedLoudnessEnhancerNow()
+
+        if (!cachedNormalizationEnabled || cachedNormalizationGainMb == null) {
+            setupLoudnessEnhancer()
+        }
+
         sendBroadcast(
             Intent(AudioEffect.ACTION_OPEN_AUDIO_EFFECT_CONTROL_SESSION).apply {
                 putExtra(AudioEffect.EXTRA_AUDIO_SESSION, player.audioSessionId)
@@ -2259,7 +2311,7 @@ class MusicService :
         }
 
         if (playWhenReady) {
-            setupLoudnessEnhancer()
+            applyCachedLoudnessEnhancerNow()
         }
     }
 
@@ -2280,7 +2332,7 @@ class MusicService :
                 if (focusGranted) {
                     openAudioEffectSession()
                 }
-            } else {
+            } else if (player.playbackState == Player.STATE_IDLE) {
                 closeAudioEffectSession()
             }
         }

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -233,8 +233,6 @@ import kotlin.time.Duration.Companion.seconds
 private const val INSTANT_SILENCE_SKIP_STEP_MS = 15_000L
 private const val INSTANT_SILENCE_SKIP_SETTLE_MS = 350L
 
-private const val API_DEFAULT_TARGET_LUFS = -7.0
-
 @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
 @androidx.annotation.OptIn(UnstableApi::class)
 @AndroidEntryPoint
@@ -383,10 +381,11 @@ class MusicService :
     private val instantSilenceSkipEnabled = MutableStateFlow(false)
 
     private var isAudioEffectSessionOpened = false
+    private var openedAudioEffectSessionId: Int = C.AUDIO_SESSION_ID_UNSET
     private var loudnessEnhancer: LoudnessEnhancer? = null
 
     @Volatile
-    private var normalizationEnabledCached: Boolean = true
+    private var normalizationEnabledCached: Boolean = false
 
     @Volatile
     private var loudnessLevelCached: LoudnessLevel = LoudnessLevel.AGGRESSIVE
@@ -497,6 +496,8 @@ class MusicService :
 
         // 3. Connect the processor to the service
         // handled in createExoPlayer
+
+        seedLoudnessCacheFromPrefs()
 
         if (!ensureStartedAsForegroundOrStop()) {
             return
@@ -1911,6 +1912,15 @@ class MusicService :
         startRadioSeamlessly()
     }
 
+    private fun seedLoudnessCacheFromPrefs() {
+        normalizationEnabledCached = dataStore.get(AudioNormalizationKey, true)
+        loudnessLevelCached = dataStore[LoudnessLevelKey].toEnum(LoudnessLevel.AGGRESSIVE)
+
+        Timber.tag(TAG).d(
+            "Seeded loudness cache: normalization=$normalizationEnabledCached, level=$loudnessLevelCached"
+        )
+    }
+
     private fun applyCachedLoudnessEnhancerNow() {
         val enhancer = loudnessEnhancer ?: return
 
@@ -1984,7 +1994,7 @@ class MusicService :
                         .d("Format loudnessDb: ${format?.loudnessDb}, perceptualLoudnessDb: ${format?.perceptualLoudnessDb}")
 
                     // Use loudnessDb if available, otherwise fall back to perceptualLoudnessDb
-                    val measuredLufs: Double? = format?.perceptualLoudnessDb ?: format?.loudnessDb?.let { it + API_DEFAULT_TARGET_LUFS }
+                    val measuredLufs: Double? = format?.perceptualLoudnessDb ?: format?.loudnessDb?.let { it + LoudnessLevel.AGGRESSIVE.targetLufs }
 
                     withContext(Dispatchers.Main) {
                         if (measuredLufs != null) {
@@ -2049,11 +2059,32 @@ class MusicService :
     }
 
     private fun openAudioEffectSession() {
-        if (isAudioEffectSessionOpened) return
-        isAudioEffectSessionOpened = true
-
         val audioSessionId = player.audioSessionId
-        if (audioSessionId != C.AUDIO_SESSION_ID_UNSET && audioSessionId > 0 && loudnessEnhancer == null) {
+        if (audioSessionId == C.AUDIO_SESSION_ID_UNSET || audioSessionId <= 0) {
+            Timber.tag(TAG).w("openAudioEffectSession: invalid audioSessionId=$audioSessionId")
+            return
+        }
+
+        if (isAudioEffectSessionOpened && openedAudioEffectSessionId == audioSessionId) {
+            applyCachedLoudnessEnhancerNow()
+
+            if (!cachedNormalizationEnabled || cachedNormalizationGainMb == null) {
+                setupLoudnessEnhancer()
+            }
+
+            return
+        }
+
+        if (isAudioEffectSessionOpened && openedAudioEffectSessionId > 0) {
+            closeAudioEffectSession(openedAudioEffectSessionId)
+        } else {
+            releaseLoudnessEnhancer()
+        }
+
+        isAudioEffectSessionOpened = true
+        openedAudioEffectSessionId = audioSessionId
+
+        if (loudnessEnhancer == null) {
             createLoudnessEnhancerForSessionId(audioSessionId)
         }
 
@@ -2065,23 +2096,32 @@ class MusicService :
 
         sendBroadcast(
             Intent(AudioEffect.ACTION_OPEN_AUDIO_EFFECT_CONTROL_SESSION).apply {
-                putExtra(AudioEffect.EXTRA_AUDIO_SESSION, player.audioSessionId)
+                putExtra(AudioEffect.EXTRA_AUDIO_SESSION, audioSessionId)
                 putExtra(AudioEffect.EXTRA_PACKAGE_NAME, packageName)
                 putExtra(AudioEffect.EXTRA_CONTENT_TYPE, AudioEffect.CONTENT_TYPE_MUSIC)
             },
         )
     }
 
-    private fun closeAudioEffectSession() {
-        if (!isAudioEffectSessionOpened) return
+    private fun closeAudioEffectSession(sessionIdOverride: Int? = null) {
+        val sessionIdToClose = sessionIdOverride ?: openedAudioEffectSessionId
+
+        if (! isAudioEffectSessionOpened && (sessionIdToClose == C.AUDIO_SESSION_ID_UNSET || sessionIdToClose <= 0)) {
+            return
+        }
+
         isAudioEffectSessionOpened = false
+        openedAudioEffectSessionId = C.AUDIO_SESSION_ID_UNSET
         releaseLoudnessEnhancer()
-        sendBroadcast(
-            Intent(AudioEffect.ACTION_CLOSE_AUDIO_EFFECT_CONTROL_SESSION).apply {
-                putExtra(AudioEffect.EXTRA_AUDIO_SESSION, player.audioSessionId)
-                putExtra(AudioEffect.EXTRA_PACKAGE_NAME, packageName)
-            },
-        )
+
+        if (sessionIdToClose != C.AUDIO_SESSION_ID_UNSET && sessionIdToClose > 0) {
+            sendBroadcast(
+                Intent(AudioEffect.ACTION_CLOSE_AUDIO_EFFECT_CONTROL_SESSION).apply {
+                    putExtra(AudioEffect.EXTRA_AUDIO_SESSION, sessionIdToClose)
+                    putExtra(AudioEffect.EXTRA_PACKAGE_NAME, packageName)
+                },
+            )
+        }
     }
 
     private var previousMediaItemIndex = C.INDEX_UNSET
@@ -3553,7 +3593,7 @@ class MusicService :
         discordRpc = null
         connectivityObserver.unregister()
         abandonAudioFocus()
-        releaseLoudnessEnhancer()
+        closeAudioEffectSession()
         mediaLibrarySessionCallback.release()
         mediaSession.release()
         player.removeListener(this)
@@ -4026,6 +4066,8 @@ class MusicService :
         } catch (e: Exception) {
             timber.log.Timber.e(e, "Failed to swap player in MediaSession")
         }
+
+        openAudioEffectSession()
 
         crossfadeJob =
             scope.launch {

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -196,6 +196,9 @@ import com.metrolist.music.utils.reportException
 import com.metrolist.music.widget.MetrolistWidgetManager
 import com.metrolist.music.widget.MusicWidgetReceiver
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CancellationException
+import kotlin.coroutines.coroutineContext
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -383,6 +386,9 @@ class MusicService :
     private var isAudioEffectSessionOpened = false
     private var openedAudioEffectSessionId: Int = C.AUDIO_SESSION_ID_UNSET
     private var loudnessEnhancer: LoudnessEnhancer? = null
+
+    private var loudnessSetupJob: Job? = null
+    private var loudnessSetupGeneration: Long = 0L
 
     @Volatile
     private var normalizationEnabledCached: Boolean = false
@@ -1964,13 +1970,14 @@ class MusicService :
         }
 
         // Create or recreate enhancer if needed
-        if (loudnessEnhancer == null) {
-            if (! createLoudnessEnhancerForSessionId(audioSessionId)) {
-                return
-            }
+        if (loudnessEnhancer == null && !createLoudnessEnhancerForSessionId(audioSessionId)) {
+            return
         }
 
-        scope.launch {
+        val requestGeneration = ++loudnessSetupGeneration
+        loudnessSetupJob?.cancel()
+
+        loudnessSetupJob = scope.launch {
             try {
                 val currentMediaId =
                     withContext(Dispatchers.Main) {
@@ -1985,8 +1992,7 @@ class MusicService :
                             database.format(currentMediaId).first()
                         }
 
-                    val loudnessLevel = loudnessLevelCached
-                    val targetLufs = loudnessLevel.targetLufs
+                    val targetLufs = loudnessLevelCached.targetLufs
 
                     Timber.tag(TAG).d("Audio normalization enabled: $normalizeAudio")
                     Timber
@@ -1994,9 +2000,13 @@ class MusicService :
                         .d("Format loudnessDb: ${format?.loudnessDb}, perceptualLoudnessDb: ${format?.perceptualLoudnessDb}")
 
                     // Use perceptualLoudnessDb if available, otherwise fall back to loudnessDb + offset
-                    val measuredLufs: Double? = format?.perceptualLoudnessDb ?: format?.loudnessDb?.let { it + LoudnessLevel.AGGRESSIVE.targetLufs }
+                    val measuredLufs: Double? = format?.perceptualLoudnessDb
+                        ?: format?.loudnessDb?.let { it + LoudnessLevel.AGGRESSIVE.targetLufs }
 
                     withContext(Dispatchers.Main) {
+                        if (!isActive || requestGeneration != loudnessSetupGeneration) return@withContext
+                        if (player.audioSessionId != audioSessionId || player.currentMediaItem?.mediaId != currentMediaId) return@withContext
+
                         if (measuredLufs != null) {
                             val loudnessDb = measuredLufs.let { it - targetLufs }
                             val targetGain = (-loudnessDb * 100.0).toInt()
@@ -2031,12 +2041,16 @@ class MusicService :
                     }
                 } else {
                     withContext(Dispatchers.Main) {
+                        if (!isActive || requestGeneration != loudnessSetupGeneration) return@withContext
                         cachedNormalizationGainMb = null
                         cachedNormalizationEnabled = false
                         loudnessEnhancer?.enabled = false
                         Timber.tag(TAG).d("setupLoudnessEnhancer: normalization disabled or mediaId unavailable")
                     }
                 }
+            } catch (e: CancellationException) {
+                Timber.tag(TAG).d("setupLoudnessEnhancer: job cancelled, likely due to new setup request or session change")
+                throw e
             } catch (e: Exception) {
                 reportException(e)
                 releaseLoudnessEnhancer()
@@ -2067,7 +2081,10 @@ class MusicService :
             return
         }
 
-        if (isAudioEffectSessionOpened && openedAudioEffectSessionId == audioSessionId) {
+        if (isAudioEffectSessionOpened &&
+            openedAudioEffectSessionId == audioSessionId &&
+            loudnessEnhancer != null
+        ) {
             applyCachedLoudnessEnhancerNow()
 
             if (!cachedNormalizationEnabled || cachedNormalizationGainMb == null) {
@@ -2083,12 +2100,17 @@ class MusicService :
             releaseLoudnessEnhancer(clearNormalizationCache = false)
         }
 
+        val enhancerReady = loudnessEnhancer != null || createLoudnessEnhancerForSessionId(audioSessionId)
+
+        if (!enhancerReady) {
+            isAudioEffectSessionOpened = false
+            openedAudioEffectSessionId = C.AUDIO_SESSION_ID_UNSET
+            Timber.tag(TAG).w("openAudioEffectSession: failed to create LoudnessEnhancer for sessionId=$audioSessionId, audio effects will be unavailable")
+            return
+        }
+
         isAudioEffectSessionOpened = true
         openedAudioEffectSessionId = audioSessionId
-
-        if (loudnessEnhancer == null) {
-            createLoudnessEnhancerForSessionId(audioSessionId)
-        }
 
         applyCachedLoudnessEnhancerNow()
 
@@ -2107,6 +2129,10 @@ class MusicService :
 
     private fun closeAudioEffectSession(sessionIdOverride: Int? = null, clearNormalizationCache: Boolean = true) {
         val sessionIdToClose = sessionIdOverride ?: openedAudioEffectSessionId
+
+        loudnessSetupGeneration++
+        loudnessSetupJob?.cancel()
+        loudnessSetupJob = null
 
         if (! isAudioEffectSessionOpened && (sessionIdToClose == C.AUDIO_SESSION_ID_UNSET || sessionIdToClose <= 0)) {
             return

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -2007,36 +2007,35 @@ class MusicService :
                         if (!isActive || requestGeneration != loudnessSetupGeneration) return@withContext
                         if (player.audioSessionId != audioSessionId || player.currentMediaItem?.mediaId != currentMediaId) return@withContext
 
-                        if (measuredLufs != null) {
-                            val loudnessDb = measuredLufs.let { it - targetLufs }
-                            val targetGain = (-loudnessDb * 100.0).toInt()
-                            val clampedGain = targetGain.coerceIn(MIN_GAIN_MB, MAX_GAIN_MB)
+                        when {
+                            measuredLufs != null -> {
+                                val loudnessDb = measuredLufs - targetLufs
+                                val targetGain = (-loudnessDb * 100.0).toInt()
+                                val clampedGain = targetGain.coerceIn(MIN_GAIN_MB, MAX_GAIN_MB)
 
-                            Timber.tag(TAG)
-                                .d("Normalization Target LUFS: $targetLufs, Measured LUFS: $measuredLufs, Calculated gain: $targetGain mB, Clamped gain: $clampedGain mB")
+                                Timber.tag(TAG)
+                                    .d("Normalization Target LUFS: $targetLufs, Measured LUFS: $measuredLufs, Calculated gain: $targetGain mB, Clamped gain: $clampedGain mB")
 
-                            Timber.tag(TAG)
-                                .d("Calculated raw normalization gain: $targetGain mB (from loudness: $loudnessDb)")
+                                Timber.tag(TAG)
+                                    .d("Calculated raw normalization gain: $targetGain mB (from loudness: $loudnessDb)")
 
-                            try {
                                 cachedNormalizationGainMb = clampedGain
                                 cachedNormalizationEnabled = true
-
                                 loudnessEnhancer?.setTargetGain(clampedGain)
                                 loudnessEnhancer?.enabled = true
-                                Timber.tag(TAG).i("LoudnessEnhancer gain applied: $clampedGain mB")
-                            } catch (e: Exception) {
-                                Timber.tag(TAG).e(e, "Failed to apply loudness enhancement")
-                                reportException(e)
-                                releaseLoudnessEnhancer()
                             }
-                        } else {
-                            cachedNormalizationGainMb = null
-                            cachedNormalizationEnabled = false
-                            loudnessEnhancer?.enabled = false
-                            Timber
-                                .tag(TAG)
-                                .w("Normalization enabled but no loudness data available - no normalization applied")
+
+                            format == null -> {
+                                // Row not available yet for new track: keep carry-over gain to avoid a jump.
+                                Timber.tag(TAG).d("Loudness row not ready yet; keeping cached normalization state")
+                            }
+
+                            else -> {
+                                cachedNormalizationGainMb = null
+                                cachedNormalizationEnabled = false
+                                loudnessEnhancer?.enabled = false
+                                Timber.tag(TAG).w("No loudness data available for track - normalization disabled")
+                            }
                         }
                     }
                 } else {

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
@@ -128,7 +128,7 @@ fun PlayerSettings(
 
     val (loudnessLevel, onLoudnessLevelChange) = rememberEnumPreference(
         LoudnessLevelKey,
-        defaultValue = LoudnessLevel.AGGRESSIVE,
+        defaultValue = LoudnessLevel.BALANCED,
     )
 
     val (audioOffload, onAudioOffloadChange) = rememberPreference(

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
@@ -87,6 +87,7 @@ import com.metrolist.music.ui.component.decodeDayTimes
 import com.metrolist.music.ui.component.encodeDayTimes
 import com.metrolist.music.constants.SleepTimerFadeOutKey
 import com.metrolist.music.constants.SleepTimerStopAfterCurrentSongKey
+import com.metrolist.music.ui.utils.getLoudnessLevelLabel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -251,14 +252,7 @@ fun PlayerSettings(
             title = stringResource(R.string.loudness_level),
             current = loudnessLevel,
             values = LoudnessLevel.values().toList(),
-            valueText = {
-                when (it) {
-                    LoudnessLevel.AGGRESSIVE -> stringResource(R.string.loudness_level_aggressive)
-                    LoudnessLevel.LOUD -> stringResource(R.string.loudness_level_loud)
-                    LoudnessLevel.BALANCED -> stringResource(R.string.loudness_level_balanced)
-                    LoudnessLevel.QUIET -> stringResource(R.string.loudness_level_quiet)
-                }
-            }
+            valueText = { getLoudnessLevelLabel(it) }
         )
     }
 
@@ -474,14 +468,7 @@ fun PlayerSettings(
                         icon = painterResource(R.drawable.volume_up),
                         title = { Text(stringResource(R.string.loudness_level)) },
                         description = {
-                            Text(
-                                when (loudnessLevel) {
-                                    LoudnessLevel.AGGRESSIVE -> stringResource(R.string.loudness_level_aggressive)
-                                    LoudnessLevel.LOUD -> stringResource(R.string.loudness_level_loud)
-                                    LoudnessLevel.BALANCED -> stringResource(R.string.loudness_level_balanced)
-                                    LoudnessLevel.QUIET -> stringResource(R.string.loudness_level_quiet)
-                                }
-                            )
+                            Text(getLoudnessLevelLabel(loudnessLevel))
                         },
                         onClick = { showLoudnessLevelDialog = true }
                     ))

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
@@ -6,7 +6,6 @@
 package com.metrolist.music.ui.screens.settings
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.height
@@ -53,6 +52,8 @@ import com.metrolist.music.constants.DisableLoadMoreWhenRepeatAllKey
 import com.metrolist.music.constants.EnableGoogleCastKey
 import com.metrolist.music.constants.HistoryDuration
 import com.metrolist.music.constants.KeepScreenOn
+import com.metrolist.music.constants.LoudnessLevel
+import com.metrolist.music.constants.LoudnessLevelKey
 import com.metrolist.music.constants.PauseOnMute
 import com.metrolist.music.constants.PersistentQueueKey
 import com.metrolist.music.constants.PersistentShuffleAcrossQueuesKey
@@ -123,6 +124,11 @@ fun PlayerSettings(
     val (audioNormalization, onAudioNormalizationChange) = rememberPreference(
         AudioNormalizationKey,
         defaultValue = true
+    )
+
+    val (loudnessLevel, onLoudnessLevelChange) = rememberEnumPreference(
+        LoudnessLevelKey,
+        defaultValue = LoudnessLevel.AGGRESSIVE,
     )
 
     val (audioOffload, onAudioOffloadChange) = rememberPreference(
@@ -210,6 +216,10 @@ fun PlayerSettings(
         mutableStateOf(false)
     }
 
+    var showLoudnessLevelDialog by remember {
+        mutableStateOf(false)
+    }
+
     if (showAudioQualityDialog) {
         EnumDialog(
             onDismiss = { showAudioQualityDialog = false },
@@ -226,6 +236,27 @@ fun PlayerSettings(
                     AudioQuality.HIGH -> stringResource(R.string.audio_quality_high)
                     AudioQuality.LOW -> stringResource(R.string.audio_quality_low)
                     AudioQuality.VERY_HIGH -> stringResource(R.string.audio_quality_very_high)
+                }
+            }
+        )
+    }
+
+    if (showLoudnessLevelDialog) {
+        EnumDialog(
+            onDismiss = { showLoudnessLevelDialog = false },
+            onSelect = {
+                onLoudnessLevelChange(it)
+                showLoudnessLevelDialog = false
+            },
+            title = stringResource(R.string.loudness_level),
+            current = loudnessLevel,
+            values = LoudnessLevel.values().toList(),
+            valueText = {
+                when (it) {
+                    LoudnessLevel.AGGRESSIVE -> stringResource(R.string.loudness_level_aggressive)
+                    LoudnessLevel.LOUD -> stringResource(R.string.loudness_level_loud)
+                    LoudnessLevel.BALANCED -> stringResource(R.string.loudness_level_balanced)
+                    LoudnessLevel.QUIET -> stringResource(R.string.loudness_level_quiet)
                 }
             }
         )
@@ -438,6 +469,23 @@ fun PlayerSettings(
                     },
                     onClick = { onAudioNormalizationChange(!audioNormalization) }
                 ))
+                if (audioNormalization) {
+                    add(Material3SettingsItem(
+                        icon = painterResource(R.drawable.volume_up),
+                        title = { Text(stringResource(R.string.loudness_level)) },
+                        description = {
+                            Text(
+                                when (loudnessLevel) {
+                                    LoudnessLevel.AGGRESSIVE -> stringResource(R.string.loudness_level_aggressive)
+                                    LoudnessLevel.LOUD -> stringResource(R.string.loudness_level_loud)
+                                    LoudnessLevel.BALANCED -> stringResource(R.string.loudness_level_balanced)
+                                    LoudnessLevel.QUIET -> stringResource(R.string.loudness_level_quiet)
+                                }
+                            )
+                        },
+                        onClick = { showLoudnessLevelDialog = true }
+                    ))
+                }
                 add(Material3SettingsItem(
                     icon = painterResource(R.drawable.graphic_eq),
                     title = { Text(stringResource(R.string.audio_offload)) },

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
@@ -43,12 +43,15 @@ import com.metrolist.innertube.models.MediaInfo
 import com.metrolist.music.LocalDatabase
 import com.metrolist.music.LocalPlayerConnection
 import com.metrolist.music.R
+import com.metrolist.music.constants.LoudnessLevel
+import com.metrolist.music.constants.LoudnessLevelKey
 import com.metrolist.music.db.entities.FormatEntity
 import com.metrolist.music.db.entities.Song
 import com.metrolist.music.ui.component.Material3SettingsGroup
 import com.metrolist.music.ui.component.Material3SettingsItem
 import com.metrolist.music.ui.component.shimmer.ShimmerHost
 import com.metrolist.music.ui.component.shimmer.TextPlaceholder
+import com.metrolist.music.utils.rememberEnumPreference
 
 @Composable
 fun ShowMediaInfo(videoId: String) {
@@ -67,6 +70,13 @@ fun ShowMediaInfo(videoId: String) {
 
     val playerConnection = LocalPlayerConnection.current
     val context = LocalContext.current
+
+    val loudnessLevel by rememberEnumPreference(
+        LoudnessLevelKey,
+        defaultValue = LoudnessLevel.AGGRESSIVE
+    )
+
+    val targetLufs: Float = loudnessLevel.targetLufs
 
     LaunchedEffect(Unit, videoId) {
         info = YouTube.getMediaInfo(videoId).getOrNull()
@@ -119,6 +129,7 @@ fun ShowMediaInfo(videoId: String) {
                         R.drawable.gradient,
                         R.drawable.contrast,
                         R.drawable.volume_up,
+                        R.drawable.volume_up,
                         R.drawable.volume_mute,
                         R.drawable.content_copy
                     )
@@ -133,7 +144,13 @@ fun ShowMediaInfo(videoId: String) {
                             stringResource(R.string.codecs) to currentFormat?.codecs,
                             stringResource(R.string.bitrate) to currentFormat?.bitrate?.let { "${it / 1000} Kbps" },
                             stringResource(R.string.sample_rate) to currentFormat?.sampleRate?.let { "$it Hz" },
-                            stringResource(R.string.loudness) to currentFormat?.loudnessDb?.let { "$it dB" },
+                            stringResource(R.string.loudness) to currentFormat?.perceptualLoudnessDb?.let { "${it - targetLufs} dB" },
+                            stringResource(R.string.loudness_level) to when (loudnessLevel) {
+                                LoudnessLevel.AGGRESSIVE -> stringResource(R.string.loudness_level_aggressive)
+                                LoudnessLevel.LOUD -> stringResource(R.string.loudness_level_loud)
+                                LoudnessLevel.BALANCED -> stringResource(R.string.loudness_level_balanced)
+                                LoudnessLevel.QUIET -> stringResource(R.string.loudness_level_quiet)
+                            },
                             stringResource(R.string.volume) to if (playerConnection != null) "${(playerConnection.player.volume * 100).toInt()}%" else null,
                             stringResource(R.string.file_size) to
                                     currentFormat?.contentLength?.let {

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
@@ -134,6 +134,8 @@ fun ShowMediaInfo(videoId: String) {
                         R.drawable.content_copy
                     )
 
+                    val measuredLufs: Double? = currentFormat?.perceptualLoudnessDb ?: currentFormat?.loudnessDb?.let { it + LoudnessLevel.AGGRESSIVE.targetLufs }
+
                     val extendedList = if (currentFormat != null) {
                         listOf(
                             stringResource(R.string.views) to info?.viewCount?.let(::numberFormatter).orEmpty(),
@@ -144,7 +146,7 @@ fun ShowMediaInfo(videoId: String) {
                             stringResource(R.string.codecs) to currentFormat?.codecs,
                             stringResource(R.string.bitrate) to currentFormat?.bitrate?.let { "${it / 1000} Kbps" },
                             stringResource(R.string.sample_rate) to currentFormat?.sampleRate?.let { "$it Hz" },
-                            stringResource(R.string.loudness) to currentFormat?.perceptualLoudnessDb?.let { "${it - targetLufs} dB" },
+                            stringResource(R.string.loudness) to measuredLufs?.let { "${it - targetLufs} dB" },
                             stringResource(R.string.loudness_level) to when (loudnessLevel) {
                                 LoudnessLevel.AGGRESSIVE -> stringResource(R.string.loudness_level_aggressive)
                                 LoudnessLevel.LOUD -> stringResource(R.string.loudness_level_loud)

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
@@ -52,6 +52,17 @@ import com.metrolist.music.ui.component.Material3SettingsItem
 import com.metrolist.music.ui.component.shimmer.ShimmerHost
 import com.metrolist.music.ui.component.shimmer.TextPlaceholder
 import com.metrolist.music.utils.rememberEnumPreference
+import androidx.compose.ui.platform.LocalLocale
+
+@Composable
+fun getLoudnessLevelLabel(loudnessLevel: LoudnessLevel): String {
+    return when (loudnessLevel) {
+        LoudnessLevel.AGGRESSIVE -> stringResource(R.string.loudness_level_aggressive)
+        LoudnessLevel.LOUD -> stringResource(R.string.loudness_level_loud)
+        LoudnessLevel.BALANCED -> stringResource(R.string.loudness_level_balanced)
+        LoudnessLevel.QUIET -> stringResource(R.string.loudness_level_quiet)
+    }
+}
 
 @Composable
 fun ShowMediaInfo(videoId: String) {
@@ -146,13 +157,10 @@ fun ShowMediaInfo(videoId: String) {
                             stringResource(R.string.codecs) to currentFormat?.codecs,
                             stringResource(R.string.bitrate) to currentFormat?.bitrate?.let { "${it / 1000} Kbps" },
                             stringResource(R.string.sample_rate) to currentFormat?.sampleRate?.let { "$it Hz" },
-                            stringResource(R.string.loudness) to measuredLufs?.let { "${(it - targetLufs).toFloat()}dB" },
-                            stringResource(R.string.loudness_level) to when (loudnessLevel) {
-                                LoudnessLevel.AGGRESSIVE -> stringResource(R.string.loudness_level_aggressive)
-                                LoudnessLevel.LOUD -> stringResource(R.string.loudness_level_loud)
-                                LoudnessLevel.BALANCED -> stringResource(R.string.loudness_level_balanced)
-                                LoudnessLevel.QUIET -> stringResource(R.string.loudness_level_quiet)
+                            stringResource(R.string.loudness) to measuredLufs?.let {
+                                String.format(LocalLocale.current.platformLocale, "%.2f dB", it - targetLufs)
                             },
+                            stringResource(R.string.loudness_level) to getLoudnessLevelLabel(loudnessLevel),
                             stringResource(R.string.volume) to if (playerConnection != null) "${(playerConnection.player.volume * 100).toInt()}%" else null,
                             stringResource(R.string.file_size) to
                                     currentFormat?.contentLength?.let {

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
@@ -73,7 +73,7 @@ fun ShowMediaInfo(videoId: String) {
 
     val loudnessLevel by rememberEnumPreference(
         LoudnessLevelKey,
-        defaultValue = LoudnessLevel.AGGRESSIVE
+        defaultValue = LoudnessLevel.BALANCED
     )
 
     val targetLufs: Float = loudnessLevel.targetLufs
@@ -146,7 +146,7 @@ fun ShowMediaInfo(videoId: String) {
                             stringResource(R.string.codecs) to currentFormat?.codecs,
                             stringResource(R.string.bitrate) to currentFormat?.bitrate?.let { "${it / 1000} Kbps" },
                             stringResource(R.string.sample_rate) to currentFormat?.sampleRate?.let { "$it Hz" },
-                            stringResource(R.string.loudness) to measuredLufs?.let { "${it - targetLufs} dB" },
+                            stringResource(R.string.loudness) to measuredLufs?.let { "${(it - targetLufs).toFloat()}dB" },
                             stringResource(R.string.loudness_level) to when (loudnessLevel) {
                                 LoudnessLevel.AGGRESSIVE -> stringResource(R.string.loudness_level_aggressive)
                                 LoudnessLevel.LOUD -> stringResource(R.string.loudness_level_loud)

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -946,4 +946,11 @@
     <string name="switch_to_list_view">Switch to list view</string>
     <string name="switch_to_grid_view">Switch to grid view</string>
     <string name="more_options">More options</string>
+
+    <!-- Loudness Level -->
+    <string name="loudness_level">Loudness level</string>
+    <string name="loudness_level_aggressive">Aggressive (-7dB)</string>
+    <string name="loudness_level_loud">Loud (-11dB)</string>
+    <string name="loudness_level_balanced">Balanced (-14dB)</string>
+    <string name="loudness_level_quiet">Quiet (-19dB)</string>
 </resources>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -949,8 +949,8 @@
 
     <!-- Loudness Level -->
     <string name="loudness_level">Loudness level</string>
-    <string name="loudness_level_aggressive">Aggressive (-7dB)</string>
-    <string name="loudness_level_loud">Loud (-11dB)</string>
-    <string name="loudness_level_balanced">Balanced (-14dB)</string>
-    <string name="loudness_level_quiet">Quiet (-19dB)</string>
+    <string name="loudness_level_aggressive">Aggressive (-7 dB)</string>
+    <string name="loudness_level_loud">Loud (-11 dB)</string>
+    <string name="loudness_level_balanced">Balanced (-14 dB)</string>
+    <string name="loudness_level_quiet">Quiet (-19 dB)</string>
 </resources>


### PR DESCRIPTION
## Problem
Audio normalization feature only sets the normalization of audio tracks to the default target loudness of -7dB. Audios having a different value compared to the default target loudness are either boosted or reduced in volume to match it. Most noticeable issue Audio normalization has is the very audible aggressive compression it applies when the audio stream exceeds the dB limit due to the boost of volume.

## Cause
Issues arise when the `loudness` value is negative. A negative value causes a boost, which in turn, may cause the system to compress the audio when it exceeds the dB limit. The purpose of the `loudness` value is to provide the difference between the perceived loudness and the target loudness of the media. The values of which are given by the API response. This single reference of truth causes the audio issues (lower audio quality, aggressive compression) that we hear with Audio normalization enabled for the tracks with negative value for `loudness`.

## Solution
- **Loudness level** - when Audio normalization is enabled, another option pops up called **Loudness level** under it. This allows control for the target level that a media's perceived loudness will be compensated for. Options include: Aggressive (-7dB), Loud (-11dB), Balanced (-14dB), Quiet (-19dB). Balanced is set as default.
- **Song Details** - The value of **Loudness** is now defined as _Audio Perceived Loudness - Selected Loudness Level._ The selected value of the **Loudness level** setting is shown after **Loudness**.
- **Normalization Caching** - Applied in-code to reduce the sudden short jump of volume during pause/play and song change.

_**Note:** **Balanced** is set as the default **Loudness Level** for consistency with major streaming services' default normalization level target._ 

## Testing
- Built and tested on physical device.
- Selecting options **Loud**, **Balanced**, **Quiet**, has shown improvement in audio quality and reduction in compression artifacts. Some compression artifacts or reduction in audio quality may still be heard when using the **Loud** option.
- Enabling **Audio normalization** applies the selected **Loudness level**
- Disabling **Audio normalization** disables the normalization completely. **Loudness** computation will still be _Audio Perceived Loudness - Selected Loudness Level._ Loudness level will still show in **Song Details**.
- Loudness corrections are applied per-song depending on their API-return values.
- Loudness correction behavior is consistent through pause/play and song change.
- Aggressive compression and loss of audio quality will still occur if loud options (Aggressive and Loud) are selected. This is a safety built into the system itself to prevent damage to audio devices.

## Screenshots
<img width="200" alt="RUID8c64e0100464438d86342389f3b7a22b" src="https://github.com/user-attachments/assets/dc048a87-eed1-4903-99a1-075a3cb01494" />
<img width="200" alt="RUID70a067bf53b54b4b8502ae61907edc32" src="https://github.com/user-attachments/assets/36b8c47e-e48f-45e0-a542-3cf835dbe547" />
<img width="200" alt="RUIDfcd6e34e555d4502900fe0b255767c9c" src="https://github.com/user-attachments/assets/bcbbfd12-b55f-466c-bfd4-df2d25159480" />
<img width="200"  alt="RUID02d513205ea747f3963acc5cdc3848d3" src="https://github.com/user-attachments/assets/1820720e-96a7-4af0-9e4c-19727263d55d" />

## Related Issues
<!-- List any related issues or PRs -->
- Closes #
- Related to #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Loudness Level preference with four presets (Aggressive, Loud, Balanced, Quiet; default Balanced).
  * Loudness level selectable in Player Settings via a dialog (visible when audio normalization is enabled).
  * Loudness level and computed loudness delta shown in media details with new localized labels and icons.

* **Bug Fixes / Stability**
  * Audio normalization now applies immediately, respects chosen level, and persists correctly across playback, session changes, crossfades, and shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->