### PR TITLE
fix: make switches follow m3e guidelines

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/RomanizationSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/RomanizationSettings.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -16,6 +17,7 @@ import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TriStateCheckbox
@@ -110,6 +112,15 @@ fun RomanizationSettings(
                         Switch(
                             checked = lyricsRomanizeAsMain,
                             onCheckedChange = onLyricsRomanizeAsMainChange,
+                            thumbContent = {
+                                Icon(
+                                    painter = painterResource(
+                                        id = if (lyricsRomanizeAsMain) R.drawable.check else R.drawable.close
+                                    ),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(SwitchDefaults.IconSize),
+                                )
+                            }
                         )
                     },
                     icon = painterResource(R.drawable.queue_music)
@@ -120,6 +131,15 @@ fun RomanizationSettings(
                         Switch(
                             checked = lyricsRomanizeCyrillicByLine,
                             onCheckedChange = onLyricsRomanizeCyrillicByLineChange,
+                            thumbContent = {
+                                Icon(
+                                    painter = painterResource(
+                                        id = if (lyricsRomanizeCyrillicByLine) R.drawable.check else R.drawable.close
+                                    ),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(SwitchDefaults.IconSize),
+                                )
+                            }
                         )
                     },
                     icon = painterResource(R.drawable.info)

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/DiscordSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/DiscordSettings.kt
@@ -40,6 +40,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -566,6 +567,15 @@ fun DiscordSettings(
                                 checked = discordRPC,
                                 onCheckedChange = onDiscordRPCChange,
                                 enabled = isLoggedIn,
+                                thumbContent = {
+                                    Icon(
+                                        painter = painterResource(
+                                            id = if (discordRPC) R.drawable.check else R.drawable.close
+                                        ),
+                                        contentDescription = null,
+                                        modifier = Modifier.size(SwitchDefaults.IconSize),
+                                    )
+                                }
                             )
                         },
                         enabled = isLoggedIn,
@@ -581,6 +591,15 @@ fun DiscordSettings(
                                 checked = useDetails,
                                 onCheckedChange = onUseDetailsChange,
                                 enabled = isLoggedIn && discordRPC,
+                                thumbContent = {
+                                    Icon(
+                                        painter = painterResource(
+                                            id = if (useDetails) R.drawable.check else R.drawable.close
+                                        ),
+                                        contentDescription = null,
+                                        modifier = Modifier.size(SwitchDefaults.IconSize),
+                                    )
+                                }
                             )
                         },
                         enabled = isLoggedIn && discordRPC,
@@ -598,6 +617,15 @@ fun DiscordSettings(
                                 checked = advancedMode,
                                 onCheckedChange = onAdvancedModeChange,
                                 enabled = isLoggedIn && discordRPC,
+                                thumbContent = {
+                                    Icon(
+                                        painter = painterResource(
+                                            id = if (advancedMode) R.drawable.check else R.drawable.close
+                                        ),
+                                        contentDescription = null,
+                                        modifier = Modifier.size(SwitchDefaults.IconSize),
+                                    )
+                                }
                             )
                         },
                         enabled = isLoggedIn && discordRPC,
@@ -694,6 +722,15 @@ fun DiscordSettings(
                                     Switch(
                                         checked = button1Visible,
                                         onCheckedChange = { button1Visible = it },
+                                        thumbContent = {
+                                            Icon(
+                                                painter = painterResource(
+                                                    id = if (button1Visible) R.drawable.check else R.drawable.close
+                                                ),
+                                                contentDescription = null,
+                                                modifier = Modifier.size(SwitchDefaults.IconSize),
+                                            )
+                                        }
                                     )
                                 },
                                 onClick = { showButton1TextDialog = true },
@@ -707,6 +744,15 @@ fun DiscordSettings(
                                     Switch(
                                         checked = button2Visible,
                                         onCheckedChange = { button2Visible = it },
+                                        thumbContent = {
+                                            Icon(
+                                                painter = painterResource(
+                                                    id = if (button2Visible) R.drawable.check else R.drawable.close
+                                                ),
+                                                contentDescription = null,
+                                                modifier = Modifier.size(SwitchDefaults.IconSize),
+                                            )
+                                        }
                                     )
                                 },
                                 onClick = { showButton2TextDialog = true },

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/LastFMSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/LastFMSettings.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -330,6 +331,15 @@ fun LastFMSettings(
                             checked = lastfmScrobbling,
                             onCheckedChange = onlastfmScrobblingChange,
                             enabled = isLoggedIn,
+                            thumbContent = {
+                                Icon(
+                                    painter = painterResource(
+                                        id = if (lastfmScrobbling) R.drawable.check else R.drawable.close
+                                    ),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(SwitchDefaults.IconSize),
+                                )
+                            }
                         )
                     },
                     enabled = isLoggedIn,
@@ -342,6 +352,15 @@ fun LastFMSettings(
                             checked = useNowPlaying,
                             onCheckedChange = onUseNowPlayingChange,
                             enabled = isLoggedIn && lastfmScrobbling,
+                            thumbContent = {
+                                Icon(
+                                    painter = painterResource(
+                                        id = if (useNowPlaying) R.drawable.check else R.drawable.close
+                                    ),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(SwitchDefaults.IconSize),
+                                )
+                            }
                         )
                     },
                     enabled = isLoggedIn && lastfmScrobbling,
@@ -355,6 +374,15 @@ fun LastFMSettings(
                             checked = useSendLikes,
                             onCheckedChange = onUseSendLikes,
                             enabled = isLoggedIn,
+                            thumbContent = {
+                                Icon(
+                                    painter = painterResource(
+                                        id = if (useSendLikes) R.drawable.check else R.drawable.close
+                                    ),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(SwitchDefaults.IconSize),
+                                )
+                            }
                         )
                     },
                     enabled = isLoggedIn,


### PR DESCRIPTION
## Problem
some switches in metrolist dont really follow the m3e guidelines, they dont have an icon in the thumb content
<img width="600" src="https://github.com/user-attachments/assets/157c8ef5-9e7e-4558-b1cc-096778d97fc4">

## Solution
fix it!!
<img width="600" src="https://github.com/user-attachments/assets/576c65a3-c06b-4498-8642-77e764449741">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced toggle switches across Romanization, Discord, and Last.fm settings with visual indicators: check marks for enabled toggles and close icons for disabled toggles, providing clearer state visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->