### PR TITLE
fix(playback): fallback to related endpoint for empty radio queues

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/queues/YouTubeQueue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/queues/YouTubeQueue.kt
@@ -45,7 +45,7 @@ class YouTubeQueue(
                     var items = nextResult.items
                     val relEndpoint = nextResult.relatedEndpoint
                     
-                    if (isRadioRequest && nextResult.continuation == null && items.size <= 1) {
+                    if (isRadioRequest && continuation == null && items.size <= 1) {
                         if (endpoint.playlistId?.startsWith("RDAMVM") == true) {
                             throw EmptyRadioQueueException()
                         } else if (relEndpoint != null) {


### PR DESCRIPTION
- Add robust fallback logic in `YouTubeQueue.getInitialStatus`.
- If a radio queue request (`RDAMVM` or standard `videoId`) returns an empty queue (1 item only), automatically fetch the `relatedEndpoint`.
- This mimics the official YouTube Music behavior for environments or ISPs where the queue API returns empty results.

## Problem
Users report that when playing any single isolated song—whether from the online search results, Quick Picks/Recommendations on the home screen, or other single-song interactions outside of standard playlists—playback stops immediately after the chosen song finishes. No "Up Next" queue is generated, constantly interrupting the user's listening experience. This issue is especially prevalent when the app language is set to certain non-English locales (e.g., Indonesian), where the `RDAMVM` radio endpoint consistently returns empty results.

## Cause
A recent update aggressively forced `YouTubeQueue` to request the `RDAMVM` (Automix/Radio) playlist endpoint to fix song uniqueness issues. However, YouTube's backend API frequently throttles or fails to generate this specific radio mix under certain conditions:
- **Certain locales**: The `RDAMVM` endpoint returns empty results for some app language settings (e.g., Indonesian), while it works for others (e.g., English).
- **Unauthenticated client requests**: The API returns a "success" response containing only the playing song and strips the rest of the queue.
- **Android version**: The bug is reproducible on Android 15 but not on Android 12 (tested with limited devices), suggesting that changes in newer Android network stacks or privacy policies may also affect how YouTube's API responds to radio requests.

Since the API does not throw an error in any of these cases, the previous fallback mechanism silently failed to trigger, leaving the queue perpetually empty for affected users.


## Solution
**Bug Fixes**
* **Empty radio queue initialization** — Replicated the official YouTube Music API behavior by aggressively fetching the `relatedEndpoint` (Up Next panel) if the primary `RDAMVM` or standard `videoId` request fails or returns an empty radio mix (queue size <= 1). The `relatedEndpoint` works reliably regardless of the conditions that cause `RDAMVM` to fail, ensuring that single-song plays (from Online Search or Quick Picks) always generate continuous playback queues.
* **Scoped fallback to radio requests only** — Added an `isRadioRequest` guard so that legitimate one-track playlists/albums are not incorrectly populated with Up Next recommendations.
* **Dedicated exception handling** — Introduced `EmptyRadioQueueException` so that network timeouts or parse errors are not confused with intentional empty-queue signals, allowing `RDAMVM` requests to be properly retried on transient failures.

## Screenshots
| Before (Empty Queue) | After (Queue Populated) |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/c0f6a2e5-5824-47d3-88bd-801afc52ee86" width="300"> | <img src="https://github.com/user-attachments/assets/3a0ee0ab-f11e-4481-bd19-5db5c5c927ce" width="300"> |

## Files Changed
| File | Change |
| :--- | :--- |
| `YouTubeQueue.kt` | Added `isRadioRequest` guard and `EmptyRadioQueueException` to scope the fallback strictly to radio requests. Implemented `relatedEndpoint` data extraction as a final fallback for `getInitialStatus()` queue generation |


## Testing
* Built and tested on a physical device (**POCO X6 Pro & POCO F7**).
* Replicated the empty queue issue by playing single songs from various entry points (Online Search, Quick Picks).
* Verified the fix works with a non-English app language (Indonesian) where the queue was previously empty — queue now populates correctly.
* Confirmed the bug only reproduces on Android 15; Android 12 returns a full radio queue without the fix.
* Verified that the initial request catches the empty 1-item queue gracefully.
* Verified that the fallback correctly fetches the "Up Next" `relatedEndpoint`.
* Verified that isolated single-song plays now successfully queue 20+ songs correctly and resume seamless radio autoplay globally.


## Related Issues
- Closes #3268
- Closes #1796
- Closes #686


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of YouTube “radio” requests when initial results are empty or very small—playback now automatically falls back to related-song suggestions and retries with the original video to maintain continuous playback and avoid dead queues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->