### PR TITLE
fix: play-next not working and ghost adds

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
@@ -840,15 +840,7 @@ fun SongMenu(
                                                     ps.map.songId,
                                                     ps.map.playlistId
                                                 ) {
-                                                    capturedSetVideoId ?: run {
-                                                        var setVideoId: String? = null
-                                                        for (attempt in 0 until 10) {
-                                                            setVideoId = database.getSetVideoId(ps.map.songId)?.setVideoId
-                                                            if (setVideoId != null) break
-                                                            delay(3_000L)
-                                                        }
-                                                        setVideoId
-                                                    }
+                                                    capturedSetVideoId
                                                 }
                                             }
                                             onDismiss()


### PR DESCRIPTION
## Problem
same Problem like in my last PR: #3340 , Uhhh I'm so tired of making fixes for this. 
And instead my logic got behind the play next button, so play next also didn't work anymore.

## Cause
There were big merge conflicts at my last PR, I'm 100% sure that my fix worked, and still works. But GitHub (or me) must have resolved the merge conflicts wrong, maybe I overlooked something. But anyways my remove logic was bound to the Play next button instead of the remove Button.

## Solution
I moved my remove button logic again to the remove button (it was already there before I resolved the merge conflicts) and restored the play next logic.

## Testing
I've now tested that many times, but every time it gets merged something doesn't work again, so it would be nice if someone besides me could test it too.

## Related Issues
- should close #3397 
- Related to #3340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * "Play next" now consistently dismisses the menu and starts playing the selected song immediately.

* **Improvements**
  * Removing a song now reliably updates the local playlist and always schedules remote removal.
  * Remote removal scheduling no longer polls for missing data — it is scheduled immediately using available information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->