### PR TITLE
fix(ui): hide lyrics provider banner for manually edited lyrics

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/ExperimentalLyrics.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/ExperimentalLyrics.kt
@@ -311,7 +311,7 @@ fun ExperimentalLyrics(
     var isSelectionModeActive by rememberSaveable { mutableStateOf(false) }
     val selectedIndices = remember { mutableStateListOf<Int>() }
     var showMaxSelectionToast by remember { mutableStateOf(false) }
-    val isLyricsProviderShown = lyricsEntity != null && lyricsEntity.provider != "Unknown" && !isSelectionModeActive
+    val isLyricsProviderShown = lyricsEntity != null && lyricsEntity.provider != "Unknown" && lyricsEntity.provider != "Manual" && !isSelectionModeActive
     var isAutoScrollEnabled by rememberSaveable { mutableStateOf(true) }
 
     BackHandler(enabled = isSelectionModeActive) {

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/OriginalLyrics.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/OriginalLyrics.kt
@@ -482,7 +482,7 @@ fun OriginalLyrics(
     val selectedIndices = remember { mutableStateListOf<Int>() }
     var showMaxSelectionToast by remember { mutableStateOf(false) } // State for showing max selection toast
 
-    val isLyricsProviderShown = lyricsEntity?.provider != null && lyricsEntity?.provider != "Unknown" && !isSelectionModeActive
+    val isLyricsProviderShown = lyricsEntity?.provider != null && lyricsEntity?.provider != "Unknown" && lyricsEntity?.provider != "Manual" && !isSelectionModeActive
 
     val lazyListState = rememberLazyListState()
 


### PR DESCRIPTION
## Problem
When users manually edit lyrics, the lyrics provider banner (e.g., "Lyrics from Kugou") continues to display even though the lyrics are no longer sourced from that service.

## Cause
The code checked if the provider was "Unknown" to hide the banner, but manually edited lyrics are saved with provider "Manual", which was not being filtered out.

## Solution
- Updated `isLyricsProviderShown` in OriginalLyrics.kt to exclude "Manual" provider
- Updated `isLyricsProviderShown` in ExperimentalLyrics.kt to exclude "Manual" provider
- This ensures the provider banner is hidden when lyrics are manually edited by the user

## Testing
Verified the changes compile correctly. The logic now properly hides the provider banner when lyrics have been manually edited (provider = "Manual").

## Related Issues
- Closes #3426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the display logic for the "Lyrics from provider" attribution label. The label now correctly hides when lyrics are sourced from a manual entry, while maintaining proper display for other provider sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->