### PR TITLE
[replaced] fix(db): validate song existence before adding to playlist

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -1073,13 +1073,16 @@ interface DatabaseDao {
     fun addSongToPlaylist(playlist: Playlist, songIds: List<String>) {
         var position = playlist.songCount
         songIds.forEach { id ->
-            insert(
-                PlaylistSongMap(
-                    songId = id,
-                    playlistId = playlist.id,
-                    position = position++
+            val existingSong = getSongByIdBlocking(id)
+            if (existingSong != null) {
+                insert(
+                    PlaylistSongMap(
+                        songId = id,
+                        playlistId = playlist.id,
+                        position = position++
+                    )
                 )
-            )
+            }
         }
         updatePlaylistLastUpdated(playlist.id)
     }


### PR DESCRIPTION
## Problem
1. Adding a song to a playlist fails with FOREIGN KEY constraint failed error when the song doesn't exist in the local database
2. Deleted songs remain visible in the download list because the database is not updated when a download is removed

## Cause
1. The `addSongToPlaylist` function in DatabaseDao directly inserts a `PlaylistSongMap` without checking if the song exists in the database, causing a foreign key constraint violation
2. The DownloadManager listener doesn't handle `onDownloadRemoved` callback, so when a download is removed, the database is never updated to reflect that the song is no longer downloaded

## Solution
1. Modified `addSongToPlaylist` in DatabaseDao to check if the song exists before inserting the mapping using `getSongByIdBlocking(id)`
2. Added `onDownloadRemoved` callback to the DownloadManager listener in DownloadUtil that:
   - Removes the download from the in-memory downloads map
   - Updates the database to set `isDownloaded = false` and `dateDownload = null`

## Testing
Both fixes are defensive changes that prevent data inconsistency. The database now properly reflects the download state and playlist song mappings.

## Related Issues
- Closes #3418