### PR TITLE
fix(playback): update database when download is removed

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/DownloadUtil.kt
@@ -192,6 +192,21 @@ constructor(
                             }
                         }
                     }
+
+                    override fun onDownloadRemoved(
+                        downloadManager: DownloadManager,
+                        download: Download,
+                    ) {
+                        downloads.update { map ->
+                            map.toMutableMap().apply {
+                                remove(download.request.id)
+                            }
+                        }
+
+                        scope.launch {
+                            database.updateDownloadedInfo(download.request.id, false, null)
+                        }
+                    }
                 }
             )
         }


### PR DESCRIPTION
## Problem
Deleted songs remain visible in the download list because the database is not updated when a download is removed.

## Cause
The DownloadManager listener doesn't handle the `onDownloadRemoved` callback, so when a download is explicitly removed, the database is never updated to reflect that the song is no longer downloaded.

## Solution
Added `onDownloadRemoved` callback to the DownloadManager listener in DownloadUtil that:
- Removes the download from the in-memory downloads map
- Updates the database to set `isDownloaded = false` and `dateDownload = null`

## Testing
The fix ensures the database properly reflects the download state when songs are removed from the download list.

## Related Issues
- Closes #3424

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download management by ensuring that when downloads are removed from the system, they are properly cleaned up from the app's internal tracking and database records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->