### PR TITLE
[wontfix] feat: remove low quality audio option

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -111,7 +111,6 @@ val AudioQualityKey = stringPreferencesKey("audioQuality")
 enum class AudioQuality {
     AUTO,
     HIGH,
-    LOW,
 }
 
 val AudioOffload = booleanPreferencesKey("enableOffload")

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
@@ -213,7 +213,6 @@ fun PlayerSettings(
                 when (it) {
                     AudioQuality.AUTO -> stringResource(R.string.audio_quality_auto)
                     AudioQuality.HIGH -> stringResource(R.string.audio_quality_high)
-                    AudioQuality.LOW -> stringResource(R.string.audio_quality_low)
                 }
             }
         )
@@ -270,7 +269,6 @@ fun PlayerSettings(
                             when (audioQuality) {
                                 AudioQuality.AUTO -> stringResource(R.string.audio_quality_auto)
                                 AudioQuality.HIGH -> stringResource(R.string.audio_quality_high)
-                                AudioQuality.LOW -> stringResource(R.string.audio_quality_low)
                             }
                         )
                     },

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -428,7 +428,6 @@ object YTPlayerUtils {
                 it.bitrate * when (audioQuality) {
                     AudioQuality.AUTO -> if (connectivityManager.isActiveNetworkMetered) -1 else 1
                     AudioQuality.HIGH -> 1
-                    AudioQuality.LOW -> -1
                 } + (if (it.mimeType.startsWith("audio/webm")) 10240 else 0) // prefer opus stream
             }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -282,7 +282,6 @@
     <string name="audio_quality">Audio quality</string>
     <string name="audio_quality_auto">Auto</string>
     <string name="audio_quality_high">High</string>
-    <string name="audio_quality_low">Low</string>
     <string name="queue">Queue</string>
     <string name="persistent_queue">Persistent queue</string>
     <string name="persistent_queue_desc">Restore your last queue when the app starts</string>


### PR DESCRIPTION
## Problem
The audio quality setting included a "Low" option, which is a commercial tactic used by streaming services to allow non-paying users to have a basic listening experience. As an open-source non-commercial application, this option has no legitimate use case.

## Cause
The AudioQuality enum originally included LOW as one of the available options, inherited from commercial streaming service patterns.

## Solution
- Removed the LOW audio quality option from the AudioQuality enum
- Updated the format selection logic in YTPlayerUtils to remove LOW case
- Removed LOW from the UI settings in PlayerSettings
- Removed corresponding string resource

## Testing
Build completed successfully.

## Related Issues
- Related to #3351

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the LOW audio quality option from playback settings. Users now have access to AUTO and HIGH quality options only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->