### PR TITLE
fix: use startForegroundService for background-safe service startup

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -311,12 +311,11 @@ class MainActivity : ComponentActivity() {
         // Explicitly start the service so it becomes an "explicitly started" service.
         // Without this, the service only exists while a client is bound (BIND_AUTO_CREATE).
         // When onStop() releases the binding (e.g. screen off, app backgrounded), Media3's
-        // MediaNotificationManager tries to call startForegroundService() to keep the service
-        // alive — but this is blocked on Android 12+ when the app is in the background,
-        // causing ForegroundServiceStartNotAllowedException. Starting the service explicitly
-        // here ensures it persists independently of binding state, so Media3 never needs to
-        // re-start it from a background context.
-        startService(Intent(this, MusicService::class.java))
+        // MediaNotificationManager tries to keep the service alive, but this is blocked on
+        // Android 12+ when the app is in the background. Using startForegroundService() ensures
+        // the service persists independently of binding state on all Android versions, including
+        // Android 16+ where startService() from background contexts is not allowed.
+        ContextCompat.startForegroundService(this, Intent(this, MusicService::class.java))
         
         // Bind to service - if already bound, this is a no-op but ensures we stay connected
         if (!isServiceBound) {


### PR DESCRIPTION
## Problem
On Android 16+ (SDK 36), MusicService startup fails with `BackgroundServiceStartNotAllowedException` when the app is in background context. The crash occurs in `MainActivity.onStart()` which uses `startService()` to start the foreground service, violating Android 16+ background service restrictions.

## Cause
`startService()` is not allowed from background contexts on Android 16+. MusicService is designed as a foreground service (it calls `startForeground()` in `onCreate()`), but it was being started with the regular `startService()` method. The root cause is using the wrong API for starting a foreground service across all Android versions.

## Solution
- Replace `startService()` with `ContextCompat.startForegroundService()` in `MainActivity.kt:319`
- This is the architecturally correct method for starting foreground services on all Android versions
- No exception handling workarounds needed; this is the proper structural approach
- Updated comments to reflect Android 16+ compatibility

## Testing
- Verified no compilation errors in MainActivity
- Confirmed the fix is minimal (1 line changed + comment update)
- Verified compatibility with existing code (ContextCompat is already imported)
- Other receivers in the codebase (MusicAlarmReceiver, RecognitionLaunchActivity) already use `startForegroundService()`, confirming this is the established pattern

## Related Issues
- Closes #3439

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved music service initialization and stability through enhanced platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->