### PR TITLE
fix: scroll to current song when shuffle mode changes

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Queue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Queue.kt
@@ -737,7 +737,7 @@ fun Queue(
             }
         }
 
-        LaunchedEffect(mutableQueueWindows) {
+        LaunchedEffect(mutableQueueWindows, currentWindowIndex) {
             if (currentWindowIndex != -1) {
                 lazyListState.scrollToItem(currentWindowIndex)
             }


### PR DESCRIPTION
 ## Problem
 Shuffling quickly in the playlist doesn't place the current song on top of the list. When toggling shuffle mode rapidly, the playlist scrolls back and 
the current song is not visible.
 
 ## Cause
 The LaunchedEffect that handles list scrolling was only dependent on `mutableQueueWindows`, but not on `currentWindowIndex`. When shuffle mode changes,
 the current window index changes, but the effect wasn't triggering to scroll to the new position.
 
 ## Solution
 - Added `currentWindowIndex` as a dependency to the LaunchedEffect in Queue.kt that handles list scrolling
 
 ## Testing
 Tested by toggling shuffle on/off rapidly in the player queue - the current song now stays visible at the top of the list.
 
 ## Related Issues
 - Closes #3295
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Queue now automatically scrolls to display the currently playing track when playback changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->