### PR TITLE
fix(lyrics): correct LyricsPlus duration unit and adaptive provider timeout

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsHelper.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsHelper.kt
@@ -19,6 +19,7 @@ import com.metrolist.music.utils.reportException
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
@@ -132,49 +133,58 @@ constructor(
         val result = withTimeoutOrNull(MAX_LYRICS_FETCH_MS) {
             val cleanedTitle = LyricsUtils.cleanTitleForSearch(mediaMetadata.title)
             val enabledProviders = lyricsProviders.filter { it.isEnabled(context) }
-            val startTime = System.currentTimeMillis()
 
-            for ((index, provider) in enabledProviders.withIndex()) {
-                val elapsed = System.currentTimeMillis() - startTime
-                val remaining = MAX_LYRICS_FETCH_MS - elapsed
-                if (remaining <= 0) break
+            val resultChannel = Channel<Pair<Int, LyricsWithProvider>>(capacity = enabledProviders.size)
 
-                // Give each provider an equal share of whatever time is left,
-                // but never more than a reasonable per-provider cap (10s)
-                val remainingProviders = enabledProviders.size - index
-                val perProviderTimeout = (remaining / remainingProviders).coerceAtMost(10000L)
+            val scope = CoroutineScope(SupervisorJob() + coroutineContext)
 
-                try {
-                    Timber.tag("LyricsHelper")
-                        .d("Trying ${provider.name} (timeout: ${perProviderTimeout}ms, remaining: ${remaining}ms)")
-                    val result = withTimeoutOrNull(perProviderTimeout) {
-                        provider.getLyrics(
-                            context,
-                            mediaMetadata.id,
-                            cleanedTitle,
-                            mediaMetadata.artists.joinToString { it.name },
-                            mediaMetadata.duration,
-                            mediaMetadata.album?.title,
-                        )
-                    }
-                    when {
-                        result?.isSuccess == true -> {
-                            Timber.tag("LyricsHelper").i("Got lyrics from ${provider.name}")
-                            val filteredLyrics = LyricsUtils.filterLyricsCreditLines(result.getOrNull()!!)
-                            return@withTimeoutOrNull LyricsWithProvider(filteredLyrics, provider.name)
+            val jobs = enabledProviders.mapIndexed { index, provider ->
+                scope.async {
+                    try {
+                        Timber.tag("LyricsHelper").d("Trying ${provider.name} concurrently (priority: $index)")
+                        val res = withTimeoutOrNull(MAX_LYRICS_FETCH_MS) {
+                            provider.getLyrics(
+                                context,
+                                mediaMetadata.id,
+                                cleanedTitle,
+                                mediaMetadata.artists.joinToString { it.name },
+                                mediaMetadata.duration,
+                                mediaMetadata.album?.title,
+                            )
                         }
-                        result == null -> Timber.tag("LyricsHelper").w("${provider.name} timed out after ${perProviderTimeout}ms")
-                        else -> Timber.tag("LyricsHelper").w("${provider.name} failed: ${result.exceptionOrNull()?.message}")
+                        if (res?.isSuccess == true) {
+                            val filtered = LyricsUtils.filterLyricsCreditLines(res.getOrNull()!!)
+                            Timber.tag("LyricsHelper").i("${provider.name} returned lyrics (priority: $index)")
+                            resultChannel.trySend(index to LyricsWithProvider(filtered, provider.name))
+                        } else {
+                            Timber.tag("LyricsHelper").w("${provider.name} failed or timed out")
+                        }
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        Timber.tag("LyricsHelper").w("${provider.name} threw: ${e.message}")
                     }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    Timber.tag("LyricsHelper").w("${provider.name} threw exception: ${e.message}")
                 }
             }
-            Timber.tag("LyricsHelper").w("All providers failed for ${mediaMetadata.title}")
-            LyricsWithProvider(LYRICS_NOT_FOUND, PROVIDER_NONE)
-}
+
+            scope.launch {
+                jobs.forEach { it.await() }
+                resultChannel.close()
+            }
+
+            var best: Pair<Int, LyricsWithProvider>? = null
+            while (true) {
+                val candidate = resultChannel.receiveCatching().getOrNull() ?: break
+                if (best == null || candidate.first.compareTo(best!!.first) < 0) {
+                    best = candidate
+                    if (best!!.first == 0) break
+                }
+            }
+
+            scope.cancel()
+            best?.second ?: LyricsWithProvider(LYRICS_NOT_FOUND, PROVIDER_NONE)
+        }
+
         return result ?: LyricsWithProvider(LYRICS_NOT_FOUND, PROVIDER_NONE)
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsHelper.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsHelper.kt
@@ -132,12 +132,21 @@ constructor(
         val result = withTimeoutOrNull(MAX_LYRICS_FETCH_MS) {
             val cleanedTitle = LyricsUtils.cleanTitleForSearch(mediaMetadata.title)
             val enabledProviders = lyricsProviders.filter { it.isEnabled(context) }
-            val perProviderTimeout = MAX_LYRICS_FETCH_MS / enabledProviders.size.coerceAtLeast(1)
+            val startTime = System.currentTimeMillis()
 
-            for (provider in enabledProviders) {
+            for ((index, provider) in enabledProviders.withIndex()) {
+                val elapsed = System.currentTimeMillis() - startTime
+                val remaining = MAX_LYRICS_FETCH_MS - elapsed
+                if (remaining <= 0) break
+
+                // Give each provider an equal share of whatever time is left,
+                // but never more than a reasonable per-provider cap (10s)
+                val remainingProviders = enabledProviders.size - index
+                val perProviderTimeout = (remaining / remainingProviders).coerceAtMost(10000L)
+
                 try {
                     Timber.tag("LyricsHelper")
-                        .d("Trying provider: ${provider.name} for $cleanedTitle (timeout: ${perProviderTimeout}ms)")
+                        .d("Trying ${provider.name} (timeout: ${perProviderTimeout}ms, remaining: ${remaining}ms)")
                     val result = withTimeoutOrNull(perProviderTimeout) {
                         provider.getLyrics(
                             context,
@@ -150,16 +159,12 @@ constructor(
                     }
                     when {
                         result?.isSuccess == true -> {
-                            Timber.tag("LyricsHelper").i("Successfully got lyrics from ${provider.name}")
+                            Timber.tag("LyricsHelper").i("Got lyrics from ${provider.name}")
                             val filteredLyrics = LyricsUtils.filterLyricsCreditLines(result.getOrNull()!!)
                             return@withTimeoutOrNull LyricsWithProvider(filteredLyrics, provider.name)
                         }
-                        result == null -> {
-                            Timber.tag("LyricsHelper").w("${provider.name} timed out after ${perProviderTimeout}ms")
-                        }
-                        else -> {
-                            Timber.tag("LyricsHelper").w("${provider.name} failed: ${result.exceptionOrNull()?.message}")
-                        }
+                        result == null -> Timber.tag("LyricsHelper").w("${provider.name} timed out after ${perProviderTimeout}ms")
+                        else -> Timber.tag("LyricsHelper").w("${provider.name} failed: ${result.exceptionOrNull()?.message}")
                     }
                 } catch (e: CancellationException) {
                     throw e
@@ -168,8 +173,8 @@ constructor(
                 }
             }
             Timber.tag("LyricsHelper").w("All providers failed for ${mediaMetadata.title}")
-            return@withTimeoutOrNull LyricsWithProvider(LYRICS_NOT_FOUND, PROVIDER_NONE)
-        }
+            LyricsWithProvider(LYRICS_NOT_FOUND, PROVIDER_NONE)
+}
         return result ?: LyricsWithProvider(LYRICS_NOT_FOUND, PROVIDER_NONE)
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsPlusProvider.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsPlusProvider.kt
@@ -176,6 +176,15 @@ object LyricsPlusProvider : LyricsProvider {
      */
     private fun convertToLrc(response: LyricsPlusResponse?): String? {
         val lyrics = response?.lyrics?.takeIf { it.isNotEmpty() } ?: return null
+
+        if (response.type.isNullOrEmpty() || response.type.equals("None", ignoreCase = true)) {
+            return lyrics
+                .joinToString("\n") { it.text }
+                .trimEnd()
+                .ifBlank { null }
+        }
+
+        
         val isWordSync = response.type.equals("Word", ignoreCase = true)
 
         // Agent mapping

--- a/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsPlusProvider.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsPlusProvider.kt
@@ -139,7 +139,6 @@ object LyricsPlusProvider : LyricsProvider {
             parameter("artist", artist)
             if (duration > 0) parameter("duration", duration)  // omit if invalid
             if (!album.isNullOrBlank()) parameter("album", album)
-            parameter("source", "apple,lyricsplus,qq,musixmatch,musixmatch-word")
         }
         if (response.status == HttpStatusCode.OK) response.body<LyricsPlusResponse>() else null
     }.getOrNull()

--- a/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsPlusProvider.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsPlusProvider.kt
@@ -137,7 +137,7 @@ object LyricsPlusProvider : LyricsProvider {
         val response = client.get("$url/v2/lyrics/get") {
             parameter("title", title)
             parameter("artist", artist)
-            if (duration > 0) parameter("duration", duration / 1000)  // omit if invalid
+            if (duration > 0) parameter("duration", duration)  // omit if invalid
             if (!album.isNullOrBlank()) parameter("album", album)
             parameter("source", "apple,lyricsplus,qq,musixmatch,musixmatch-word")
         }

--- a/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsPlusProvider.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsPlusProvider.kt
@@ -105,6 +105,18 @@ object LyricsPlusProvider : LyricsProvider {
         //"https://lyrics-plus-backend.vercel.app", //ibra's vercel (disabled due it's disabled)
     )
 
+    @Volatile
+    private var lastWorkingServer: String? = null
+
+    private fun getPrioritizedServers(): List<String> {
+        val last = lastWorkingServer
+        return if (last != null && last in baseUrls) {
+            listOf(last) + baseUrls.filter { it != last }
+        } else {
+            baseUrls
+        }
+    }
+
     private val client by lazy {
         HttpClient(CIO) {
             install(ContentNegotiation) {
@@ -154,10 +166,13 @@ object LyricsPlusProvider : LyricsProvider {
             return null
         }
 
-        for (baseUrl in baseUrls) {
+        for (baseUrl in getPrioritizedServers()) {
             try {
                 val result = fetchFromUrl(baseUrl, title, artist, duration, album)
-                if (result != null && !result.lyrics.isNullOrEmpty()) return result
+                if (result != null && !result.lyrics.isNullOrEmpty()) {
+                    lastWorkingServer = baseUrl
+                    return result
+                }
             } catch (e: Exception) {
                 Timber.tag("LyricsPlus").d(e, "Failed to fetch from $baseUrl")
             }


### PR DESCRIPTION
## Problem
LyricsPlus provider fetches incorrect/most popular song instead of the actual song being played, and lyrics fetching is unreliable due to poor timeout allocation.

## Cause
1. `duration` was divided by 1000 before being sent to the API (`duration / 1000`), turning a value like `206` seconds into `0`, making duration useless for song disambiguation.
2. Provider timeout was statically split equally among all enabled providers (`MAX_LYRICS_FETCH_MS / providerCount`), giving each only ~4.2s with 7 providers — not enough for LyricsPlus to try all its mirror URLs.

## Solution
- **Commit 1** `fix(lyricsPlus)`: Send duration in seconds directly instead of dividing by 1000
- **Commit 2** `feat`: Replace static per-provider timeout with adaptive allocation that distributes remaining budget among remaining providers, capped at 10s each

## Testing
- Verified LyricsPlus now fetches the correct song with proper duration value
- Confirmed providers no longer time out prematurely when earlier providers succeed quickly

## Related Issues
- Closes #
- Related to #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fetches lyrics from all enabled sources concurrently with a single global timeout for faster, more reliable results.
  * Prefers the last-successful server when available to improve success rate.
  * Sends track duration in raw units to match provider expectations.
  * Falls back to returning plain lyric text when provider metadata is missing, improving robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->