### PR TITLE
feat(lyrics): use binimum AM lyrics caching API to reduce load on lyricsplus APIs

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsPlusProvider.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsPlusProvider.kt
@@ -205,7 +205,8 @@ object LyricsPlusProvider : LyricsProvider {
         album: String?,
     ): BinimumLyricsFetchResult? {
         val normalizedId = id.trim()
-        val canUseIsrc = normalizedId.matches(ISRC_REGEX)
+        val normalizedIsrc = normalizedId.uppercase()
+        val canUseIsrc = normalizedIsrc.matches(ISRC_REGEX)
         val hasMetadata = title.isNotBlank() && artist.isNotBlank()
         // Search is valid when we have an ISRC, or when metadata (title + artist) is present.
         if (!canUseIsrc && !hasMetadata) return null
@@ -221,7 +222,7 @@ object LyricsPlusProvider : LyricsProvider {
 
         suspend fun requestByIsrc() = runCatching {
             client.get(BINIMUM_API_BASE_URL) {
-                parameter("isrc", normalizedId.uppercase())
+                parameter("isrc", normalizedIsrc)
             }
         }.getOrNull()
 


### PR DESCRIPTION
## Problem
<!-- Describe the issue or limitation this PR addresses  
DO NOT PR NEW FEATURES, WE'RE ON A FEATURE FREEZE!!! -->

Metrolist causes high load on our LyricsPlus APIs resulting in rate limiting.

## Cause
<!-- Explain the root cause of the problem -->

Metrolist users flooding our APIs.

## Solution
<!-- List the changes made to fix the issue -->

Prefer the lyrics cache hosted at lyrics-api.binimum.org to reduce load on LyricsPlus (and therefore resulting in less rate limiting from upstream providers).

## Testing
<!-- Describe how the changes were tested -->
Build succeeded, didn't test on a real device because changes are minor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Binimum as an additional lyrics source for broader coverage.
  * Detects and prefers word-synchronized lyrics when available.
  * Converts and normalizes incoming lyric formats for consistent display.

* **Improvements**
  * Smarter fallback logic to choose the best available lyrics between sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->