### PR TITLE
Fix for GEMINI (not Google Assistant) voice play

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
@@ -542,8 +542,13 @@ constructor(
     ): ListenableFuture<MediaItemsWithStartPosition> =
         scope.future {
             val defaultResult = MediaItemsWithStartPosition(emptyList(), startIndex, startPositionMs)
-            val path = mediaItems.firstOrNull()?.mediaId?.split("/")
-                ?: return@future defaultResult
+            val voiceQuery = mediaItems.firstOrNull()?.requestMetadata?.searchQuery
+
+            val path = if (!voiceQuery.isNullOrBlank()) {
+                listOf(MusicService.SEARCH, voiceQuery, "")
+            } else {
+                mediaItems.firstOrNull()?.mediaId?.split("/")
+            } ?: return@future defaultResult
 
             when (path.firstOrNull()) {
                 MusicService.SONG -> {


### PR DESCRIPTION
## Problem
Gemini Assistant cannot play songs or playlists on Android Auto. When trying to do so, an "unxpected error" is returned instead.

## Cause
In OnSetMediaItems it is not checked if there is a searchQuery and therefore not used.

## Solution
Simply assigned MusicService.SEARCH and voiceQuery to the path if there is a searchQuery

## Testing
- Built successfully, tested on my device and DHU. Phrases like "Play *X*" or "Play my playlist named *Y*" works successfully.
- Should note that this fix just works for Gemini Assistant, the older one (Google Assistant) does not work.
- Another problem is the fact that somehow it does not like the app X (Old twitter) and so the pharases containing the letter "x" does not go through and i think it is a problem with gemini itself. A temporary fix is using an X app with another name (for example Twitter).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced voice search and search query handling in media playback to improve search operation reliability. Better recognition of search-related metadata and improved fallback logic ensure smoother media navigation and more stable playback control when using voice commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->