### PR TITLE
Fix for Artworks on Android Auto

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
@@ -765,12 +765,14 @@ constructor(
         ).build()
 
     private fun Song.toMediaItem(path: String, isPlayable: Boolean = true, isBrowsable: Boolean = false): MediaItem {
-        val artworkUri = song.thumbnailUrl?.let {
-            val snapshot = context.imageLoader.diskCache?.openSnapshot(it)
-            if (snapshot != null) {
-                snapshot.use { snapshot -> snapshot.data.toFile().toUri() }
-            } else {
-                it.toUri()
+        val artworkBytes = song.thumbnailUrl?.let { url ->
+            val request = coil3.request.ImageRequest.Builder(context)
+                .data(url)
+                .build()
+            context.imageLoader.enqueue(request)
+
+            context.imageLoader.diskCache?.openSnapshot(url)?.use { snapshot ->
+                snapshot.data.toFile().readBytes()
             }
         }
 
@@ -783,7 +785,7 @@ constructor(
                     .setTitle(song.title)
                     .setSubtitle(artists.joinToString { it.name })
                     .setArtist(artists.joinToString { it.name })
-                    .setArtworkUri(artworkUri)
+                    .setArtworkData(artworkBytes, MediaMetadata.PICTURE_TYPE_ILLUSTRATION)
                     .setIsPlayable(isPlayable)
                     .setIsBrowsable(isBrowsable)
                     .setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)


### PR DESCRIPTION
## Problem
On Android Auto, as of my understanding, artworkUris are cached automatically by the AA system and on a different way, therefore it should be useless to try to use cached images, so the cached system was not working for the same reason and the songs with artworkUri found in cache would just appear without artwork.

## Cause
I am not sure of the real cause of this problem, but by searching online it seems that AA does not have real permission to access the files obtained by the Uri on the device.

## Solution
- A simple solution would have been removing the case where it tries to use cached image on the phone and always use url.toUri, because it works even in offline mode as there is indeed automatic caching on AA, BUT if the songs are loaded while offline, AA would cache an empty artwork and would not refresh it unless the Uri of that song changed (making the caching useless).
- So the solution here just uses artworkData instead of artworkUri, with an automatic download and caching.

## Testing
- Built successfully, tested on my device and DHU.
- It works with cached images retreived by using the app on the phone.
- If the songs artworks are not downloaded yet, the user just need to exit and enter again to see them, because the download happens as soon the user enters the first time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated album artwork handling in media metadata for media playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->