### PR TITLE
fix: support playback of user-uploaded YouTube Music tracks

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/models/MediaMetadata.kt
+++ b/app/src/main/kotlin/com/metrolist/music/models/MediaMetadata.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Immutable
 import com.metrolist.innertube.models.EpisodeItem
 import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.models.WatchEndpoint.WatchEndpointMusicSupportedConfigs.WatchEndpointMusicConfig.Companion.MUSIC_VIDEO_TYPE_ATV
+import com.metrolist.innertube.models.WatchEndpoint.WatchEndpointMusicSupportedConfigs.WatchEndpointMusicConfig.Companion.MUSIC_VIDEO_TYPE_OMV
 import com.metrolist.innertube.models.WatchEndpoint.WatchEndpointMusicSupportedConfigs.WatchEndpointMusicConfig.Companion.MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
 import com.metrolist.music.db.entities.Song
 import com.metrolist.music.db.entities.SongEntity
@@ -99,7 +100,7 @@ fun Song.toMediaMetadata() =
         explicit = song.explicit,
         musicVideoType = when {
             song.isUploaded -> MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
-            song.isVideo -> "MUSIC_VIDEO_TYPE_OMV"
+            song.isVideo -> MUSIC_VIDEO_TYPE_OMV
             else -> null
         },
         suggestedBy = null,

--- a/app/src/main/kotlin/com/metrolist/music/models/MediaMetadata.kt
+++ b/app/src/main/kotlin/com/metrolist/music/models/MediaMetadata.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Immutable
 import com.metrolist.innertube.models.EpisodeItem
 import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.models.WatchEndpoint.WatchEndpointMusicSupportedConfigs.WatchEndpointMusicConfig.Companion.MUSIC_VIDEO_TYPE_ATV
+import com.metrolist.innertube.models.WatchEndpoint.WatchEndpointMusicSupportedConfigs.WatchEndpointMusicConfig.Companion.MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
 import com.metrolist.music.db.entities.Song
 import com.metrolist.music.db.entities.SongEntity
 import com.metrolist.music.ui.utils.resize
@@ -37,6 +38,7 @@ data class MediaMetadata(
 ) : Serializable {
     val isVideoSong: Boolean
         get() = musicVideoType != null && musicVideoType != MUSIC_VIDEO_TYPE_ATV
+                && musicVideoType != MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
 
     data class Artist(
         val id: String?,
@@ -64,6 +66,7 @@ data class MediaMetadata(
             libraryRemoveToken = libraryRemoveToken,
             isVideo = isVideoSong,
             isEpisode = isEpisode,
+            isUploaded = musicVideoType == MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK,
             uploadEntityId = uploadEntityId
         )
 }
@@ -94,10 +97,14 @@ fun Song.toMediaMetadata() =
             )
         },
         explicit = song.explicit,
-        // Use a non-ATV type if isVideo is true to indicate it's a video song
-        musicVideoType = if (song.isVideo) "MUSIC_VIDEO_TYPE_OMV" else null,
+        musicVideoType = when {
+            song.isUploaded -> MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
+            song.isVideo -> "MUSIC_VIDEO_TYPE_OMV"
+            else -> null
+        },
         suggestedBy = null,
         isEpisode = song.isEpisode,
+        uploadEntityId = song.uploadEntityId,
     )
 
 fun SongItem.toMediaMetadata() =

--- a/app/src/main/kotlin/com/metrolist/music/models/MediaMetadata.kt
+++ b/app/src/main/kotlin/com/metrolist/music/models/MediaMetadata.kt
@@ -51,6 +51,10 @@ data class MediaMetadata(
         val title: String,
     ) : Serializable
 
+    /**
+     * Converts this [MediaMetadata] to a [SongEntity] suitable for Room database persistence.
+     * Maps [musicVideoType] to the [SongEntity.isUploaded] and [SongEntity.isVideo] flags.
+     */
     fun toSongEntity() =
         SongEntity(
             id = id,
@@ -72,6 +76,11 @@ data class MediaMetadata(
         )
 }
 
+/**
+ * Converts a database [Song] (entity + joined artists/album) into a [MediaMetadata] instance.
+ * Reconstructs the [MediaMetadata.musicVideoType] from the persisted boolean flags so that
+ * downstream consumers (e.g. the player) can distinguish uploaded, video, and audio-only tracks.
+ */
 fun Song.toMediaMetadata() =
     MediaMetadata(
         id = song.id,
@@ -108,6 +117,10 @@ fun Song.toMediaMetadata() =
         uploadEntityId = song.uploadEntityId,
     )
 
+/**
+ * Converts an InnerTube [SongItem] into a [MediaMetadata] instance for use in the UI and player.
+ * Thumbnails are resized to 544x544 for consistency.
+ */
 fun SongItem.toMediaMetadata() =
     MediaMetadata(
         id = id,
@@ -138,6 +151,10 @@ fun SongItem.toMediaMetadata() =
         uploadEntityId = uploadEntityId
     )
 
+/**
+ * Converts an InnerTube [EpisodeItem] into a [MediaMetadata] instance.
+ * The episode's podcast is mapped to [MediaMetadata.Album] and [MediaMetadata.isEpisode] is set.
+ */
 fun EpisodeItem.toMediaMetadata() =
     MediaMetadata(
         id = id,

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -3091,9 +3091,6 @@ class MusicService :
 
                 val streamUrl = nonNullPlayback.streamUrl
 
-                songUrlCache[mediaId] =
-                    streamUrl to System.currentTimeMillis() + (nonNullPlayback.streamExpiresInSeconds * 1000L)
-
                 // For privately-owned tracks, mark the URL so the interceptor attaches auth cookies
                 val finalUrl = if (nonNullPlayback.isPrivatelyOwned) {
                     val sep = if ("?" in streamUrl) "&" else "?"
@@ -3101,6 +3098,9 @@ class MusicService :
                 } else {
                     streamUrl
                 }
+
+                songUrlCache[mediaId] =
+                    finalUrl to System.currentTimeMillis() + (nonNullPlayback.streamExpiresInSeconds * 1000L)
 
                 return@Factory dataSpec.withUri(finalUrl.toUri()).subrange(dataSpec.uriPositionOffset, CHUNK_LENGTH)
             }

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -80,7 +80,6 @@ import com.google.common.util.concurrent.MoreExecutors
 import com.metrolist.innertube.YouTube
 import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.models.WatchEndpoint
-import com.metrolist.innertube.models.WatchEndpoint.WatchEndpointMusicSupportedConfigs.WatchEndpointMusicConfig.Companion.MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
 import com.metrolist.lastfm.LastFM
 import com.metrolist.music.MainActivity
 import com.metrolist.music.R
@@ -3013,10 +3012,7 @@ class MusicService :
             }
 
             Timber.tag("MusicService").i("FETCHING STREAM: $mediaId | quality=$audioQuality")
-            val dbSong = database.getSongByIdBlocking(mediaId)
-            val queueItemMusicVideoType = player.findNextMediaItemById(mediaId)?.metadata?.musicVideoType
-            val isUploaded = dbSong?.song?.isUploaded == true
-                || queueItemMusicVideoType == MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
+            val isUploaded = database.getSongByIdBlocking(mediaId)?.song?.isUploaded == true
             val playbackData =
                 runBlocking(Dispatchers.IO) {
                     YTPlayerUtils.playerResponseForPlayback(

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -2867,7 +2867,27 @@ class MusicService :
                                                 .header("Proxy-Authorization", auth)
                                                 .build()
                                         } ?: response.request
-                                    }.build(),
+                                    }
+                                    .addInterceptor { chain ->
+                                        var request = chain.request()
+                                        Timber.tag("MusicService").d("OkHttp interceptor: ${request.url.toString().take(80)}")
+                                        // Add auth cookie for privately-owned/uploaded track streams
+                                        if (request.url.queryParameter("_metrolist_private") != null) {
+                                            Timber.tag("MusicService").d("Private stream detected, attaching cookie")
+                                            // Strip the marker param and add auth cookie
+                                            val cleanUrl = request.url.newBuilder()
+                                                .removeAllQueryParameters("_metrolist_private")
+                                                .build()
+                                            val builder = request.newBuilder().url(cleanUrl)
+                                            YouTube.cookie?.let { cookie ->
+                                                builder.header("Cookie", cookie)
+                                                Timber.tag("MusicService").d("Cookie attached (length=${cookie.length})")
+                                            } ?: Timber.tag("MusicService").w("No cookie available!")
+                                            request = builder.build()
+                                        }
+                                        chain.proceed(request)
+                                    }
+                                    .build(),
                             ),
                         ),
                     ),
@@ -2996,10 +3016,12 @@ class MusicService :
             }
 
             Timber.tag("MusicService").i("FETCHING STREAM: $mediaId | quality=$audioQuality")
+            val isUploaded = database.getSongByIdBlocking(mediaId)?.song?.isUploaded == true
             val playbackData =
                 runBlocking(Dispatchers.IO) {
                     YTPlayerUtils.playerResponseForPlayback(
                         mediaId,
+                        isUploadedHint = isUploaded,
                         audioQuality = audioQuality,
                         connectivityManager = connectivityManager,
                     )
@@ -3078,7 +3100,16 @@ class MusicService :
 
                 songUrlCache[mediaId] =
                     streamUrl to System.currentTimeMillis() + (nonNullPlayback.streamExpiresInSeconds * 1000L)
-                return@Factory dataSpec.withUri(streamUrl.toUri()).subrange(dataSpec.uriPositionOffset, CHUNK_LENGTH)
+
+                // For privately-owned tracks, mark the URL so the interceptor attaches auth cookies
+                val finalUrl = if (nonNullPlayback.isPrivatelyOwned) {
+                    val sep = if ("?" in streamUrl) "&" else "?"
+                    "${streamUrl}${sep}_metrolist_private=1"
+                } else {
+                    streamUrl
+                }
+
+                return@Factory dataSpec.withUri(finalUrl.toUri()).subrange(dataSpec.uriPositionOffset, CHUNK_LENGTH)
             }
         }
     }

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -80,6 +80,7 @@ import com.google.common.util.concurrent.MoreExecutors
 import com.metrolist.innertube.YouTube
 import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.models.WatchEndpoint
+import com.metrolist.innertube.models.WatchEndpoint.WatchEndpointMusicSupportedConfigs.WatchEndpointMusicConfig.Companion.MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
 import com.metrolist.lastfm.LastFM
 import com.metrolist.music.MainActivity
 import com.metrolist.music.R
@@ -2876,7 +2877,7 @@ class MusicService :
                                                 .build()
                                             val builder = request.newBuilder().url(cleanUrl)
                                             val host = cleanUrl.host
-                                            if (host.endsWith(".youtube.com") || host.endsWith(".googlevideo.com")) {
+                                            if (host == "youtube.com" || host.endsWith(".youtube.com") || host.endsWith(".googlevideo.com")) {
                                                 YouTube.cookie?.let { builder.header("Cookie", it) }
                                             }
                                             request = builder.build()
@@ -3012,7 +3013,10 @@ class MusicService :
             }
 
             Timber.tag("MusicService").i("FETCHING STREAM: $mediaId | quality=$audioQuality")
-            val isUploaded = database.getSongByIdBlocking(mediaId)?.song?.isUploaded == true
+            val dbSong = database.getSongByIdBlocking(mediaId)
+            val queueItemMusicVideoType = player.findNextMediaItemById(mediaId)?.metadata?.musicVideoType
+            val isUploaded = dbSong?.song?.isUploaded == true
+                || queueItemMusicVideoType == MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
             val playbackData =
                 runBlocking(Dispatchers.IO) {
                     YTPlayerUtils.playerResponseForPlayback(

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -2875,7 +2875,10 @@ class MusicService :
                                                 .removeAllQueryParameters(PRIVATE_STREAM_MARKER)
                                                 .build()
                                             val builder = request.newBuilder().url(cleanUrl)
-                                            YouTube.cookie?.let { builder.header("Cookie", it) }
+                                            val host = cleanUrl.host
+                                            if (host.endsWith(".youtube.com") || host.endsWith(".googlevideo.com")) {
+                                                YouTube.cookie?.let { builder.header("Cookie", it) }
+                                            }
                                             request = builder.build()
                                         }
                                         chain.proceed(request)

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -2870,19 +2870,12 @@ class MusicService :
                                     }
                                     .addInterceptor { chain ->
                                         var request = chain.request()
-                                        Timber.tag("MusicService").d("OkHttp interceptor: ${request.url.toString().take(80)}")
-                                        // Add auth cookie for privately-owned/uploaded track streams
-                                        if (request.url.queryParameter("_metrolist_private") != null) {
-                                            Timber.tag("MusicService").d("Private stream detected, attaching cookie")
-                                            // Strip the marker param and add auth cookie
+                                        if (request.url.queryParameter(PRIVATE_STREAM_MARKER) != null) {
                                             val cleanUrl = request.url.newBuilder()
-                                                .removeAllQueryParameters("_metrolist_private")
+                                                .removeAllQueryParameters(PRIVATE_STREAM_MARKER)
                                                 .build()
                                             val builder = request.newBuilder().url(cleanUrl)
-                                            YouTube.cookie?.let { cookie ->
-                                                builder.header("Cookie", cookie)
-                                                Timber.tag("MusicService").d("Cookie attached (length=${cookie.length})")
-                                            } ?: Timber.tag("MusicService").w("No cookie available!")
+                                            YouTube.cookie?.let { builder.header("Cookie", it) }
                                             request = builder.build()
                                         }
                                         chain.proceed(request)
@@ -3104,7 +3097,7 @@ class MusicService :
                 // For privately-owned tracks, mark the URL so the interceptor attaches auth cookies
                 val finalUrl = if (nonNullPlayback.isPrivatelyOwned) {
                     val sep = if ("?" in streamUrl) "&" else "?"
-                    "${streamUrl}${sep}_metrolist_private=1"
+                    "${streamUrl}${sep}${PRIVATE_STREAM_MARKER}=1"
                 } else {
                     streamUrl
                 }
@@ -3764,6 +3757,7 @@ class MusicService :
         private const val MIN_GAIN_MB = -1500 // Minimum gain in millibels (-15 dB)
 
         private const val TAG = "MusicService"
+        private const val PRIVATE_STREAM_MARKER = "_metrolist_private"
 
         @Volatile
         var isRunning = false

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -92,7 +92,7 @@ object YTPlayerUtils {
         Timber.tag(TAG).d("audioQuality: $audioQuality")
 
         // Check if this is an uploaded/privately owned track
-        val isUploadedTrack = isUploadedHint || playlistId?.contains(UPLOADED_TRACKS_PLAYLIST_PREFIX) == true
+        val isUploadedTrack = isUploadedHint || playlistId?.startsWith(UPLOADED_TRACKS_PLAYLIST_PREFIX) == true
         Timber.tag(TAG).d("Content type detection (preliminary):")
         Timber.tag(TAG).d("  isUploadedTrack (from playlistId): $isUploadedTrack")
 

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -196,12 +196,14 @@ object YTPlayerUtils {
             mainPlayerResponse.videoDetails?.musicVideoType == MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
 
         // For private tracks with a successful WEB_CREATOR response: try its streams first (index -1)
-        // For private tracks without a working response: use TVHTML5 (index 1)
+        // For private tracks where WEB_REMIX already returned OK streams: try those first (index -1)
+        // For private tracks where the main client failed: skip to TVHTML5 (index 1)
         // For age-restricted: skip main client, start with fallbacks
         // For normal content: standard order
         val startIndex = when {
             isPrivateTrack && usedAgeRestrictedClient != null -> -1  // WEB_CREATOR succeeded, try its streams
-            isPrivateTrack -> 1  // TVHTML5
+            isPrivateTrack && mainPlayerResponse.playabilityStatus.status == "OK" -> -1  // WEB_REMIX works for this upload
+            isPrivateTrack -> 1  // TVHTML5 (main client could not serve this upload)
             isAgeRestricted -> 0
             else -> -1
         }
@@ -564,6 +566,7 @@ object YTPlayerUtils {
      */
     private fun getSignatureTimestampOrNull(videoId: String): SignatureTimestampResult {
         Timber.tag(logTag).d("Getting signature timestamp for videoId: $videoId")
+        com.metrolist.innertube.NewPipeUtils  // Ensure NewPipe downloader is initialized before use
         val result = NewPipeExtractor.getSignatureTimestamp(videoId)
         return result.fold(
             onSuccess = { timestamp ->

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -307,8 +307,9 @@ object YTPlayerUtils {
                         // Use CipherDeobfuscator for n-transform, fall back to NewPipe
                         streamUrl = CipherDeobfuscator.transformNParamInUrl(streamUrl)
 
-                        if (originalUrl == streamUrl) {
-                            // CipherDeobfuscator didn't change the URL, try NewPipe's throttling deobfuscation
+                        if (originalUrl == streamUrl && skipNewPipe) {
+                            // CipherDeobfuscator failed and NewPipe wasn't used for stream resolution
+                            // (private/uploaded tracks) — try NewPipe's throttling deobfuscation as fallback
                             Timber.tag(TAG).d("  CipherDeobfuscator failed, trying NewPipe throttling deobfuscation...")
                             try {
                                 // Ensure NewPipe Downloader is initialized

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -172,12 +172,13 @@ object YTPlayerUtils {
         var streamUrl: String? = null
         var streamExpiresInSeconds: Int? = null
         var streamPlayerResponse: PlayerResponse? = null
-        // Tracks the last successful private-track candidate so the loop can keep iterating
-        // without losing a good result if a later client fails.
+        // Tracks the best private-track candidate (first authenticated client wins).
+        // Set inferredAsPrivate when a 403 on validation reveals an undeclared private track.
         var privateCandidateStreamUrl: String? = null
         var privateCandidateFormat: PlayerResponse.StreamingData.Format? = null
         var privateCandidateExpiry: Int? = null
         var privateCandidateResponse: PlayerResponse? = null
+        var inferredAsPrivate = false
         val retryMainPlayerResponse: PlayerResponse? = if (usedAgeRestrictedClient != null) mainPlayerResponse else null
 
         // Check current status
@@ -385,24 +386,38 @@ object YTPlayerUtils {
 
                 if (isPrivate) {
                     // Private tracks can't be validated via HEAD request (cookie-based auth).
-                    // Save this client as the best candidate so far and keep iterating — a later
-                    // client may be better suited. The loop commits at isLastClient, or the
-                    // candidate is restored below if the loop exhausts without breaking.
-                    Timber.tag(logTag).d("Skipping validation for privately owned track, recording candidate and continuing: ${currentClient.clientName}")
+                    // Keep the first (highest-priority, usually WEB_REMIX) candidate — its
+                    // authenticated stream URL is more likely to work than later unauthenticated ones.
+                    if (privateCandidateStreamUrl == null) {
+                        Timber.tag(logTag).d("Skipping validation for privately owned track, recording first candidate: ${currentClient.clientName}")
+                        privateCandidateStreamUrl = streamUrl
+                        privateCandidateFormat = format
+                        privateCandidateExpiry = streamExpiresInSeconds
+                        privateCandidateResponse = streamPlayerResponse
+                    } else {
+                        Timber.tag(logTag).d("Already have private candidate, skipping: ${currentClient.clientName}")
+                    }
+                    continue
+                }
+
+                val httpStatus = validateStatus(streamUrl)
+                if (httpStatus != null && httpStatus in 200..299) {
+                    // working stream found
+                    Timber.tag(logTag).d("Stream validated successfully with client: ${currentClient.clientName}")
+                    Timber.tag(TAG).i("Playback: client=${currentClient.clientName}, videoId=$videoId")
+                    break
+                } else if (httpStatus == 403 && isLoggedIn && privateCandidateStreamUrl == null) {
+                    // 403 with no prior private candidate — this stream likely requires cookie auth
+                    // even though the API didn't flag it as PRIVATELY_OWNED. Treat as private.
+                    Timber.tag(logTag).d("403 on validation, inferring private track, recording candidate: ${currentClient.clientName}")
+                    inferredAsPrivate = true
                     privateCandidateStreamUrl = streamUrl
                     privateCandidateFormat = format
                     privateCandidateExpiry = streamExpiresInSeconds
                     privateCandidateResponse = streamPlayerResponse
                     continue
-                }
-
-                if (validateStatus(streamUrl)) {
-                    // working stream found
-                    Timber.tag(logTag).d("Stream validated successfully with client: ${currentClient.clientName}")
-                    Timber.tag(TAG).i("Playback: client=${currentClient.clientName}, videoId=$videoId")
-                    break
                 } else {
-                    Timber.tag(logTag).d("Stream validation failed for client: ${currentClient.clientName}")
+                    Timber.tag(logTag).d("Stream validation failed ($httpStatus) for client: ${currentClient.clientName}")
                 }
             } else {
                 Timber.tag(logTag).d("Player response status not OK: ${streamPlayerResponse?.playabilityStatus?.status}, reason: ${streamPlayerResponse?.playabilityStatus?.reason}")
@@ -466,7 +481,7 @@ object YTPlayerUtils {
             format,
             streamUrl,
             streamExpiresInSeconds,
-            isPrivatelyOwned = isPrivateTrack ||
+            isPrivatelyOwned = isPrivateTrack || inferredAsPrivate ||
                 streamPlayerResponse?.videoDetails?.musicVideoType == MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK,
         )
     }.onFailure { e ->
@@ -527,8 +542,9 @@ object YTPlayerUtils {
      * Checks if the stream url returns a successful status.
      * If this returns true the url is likely to work.
      * If this returns false the url might cause an error during playback.
+     * Returns the HTTP status code, or null on network error.
      */
-    private fun validateStatus(url: String, includeAuth: Boolean = false): Boolean {
+    private fun validateStatus(url: String, includeAuth: Boolean = false): Int? {
         Timber.tag(logTag).d("Validating stream URL status")
         try {
             val requestBuilder = okhttp3.Request.Builder()
@@ -543,13 +559,13 @@ object YTPlayerUtils {
 
             httpClient.newCall(requestBuilder.build()).execute().use { response ->
                 Timber.tag(logTag).d("Stream URL validation result: ${if (response.isSuccessful) "Success" else "Failed"} (${response.code})")
-                return response.isSuccessful
+                return response.code
             }
         } catch (e: Exception) {
             Timber.tag(logTag).e(e, "Stream URL validation failed with exception")
             reportException(e)
         }
-        return false
+        return null
     }
     /**
      * Result of attempting to obtain a signature timestamp from NewPipe.

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -167,6 +167,12 @@ object YTPlayerUtils {
         var streamUrl: String? = null
         var streamExpiresInSeconds: Int? = null
         var streamPlayerResponse: PlayerResponse? = null
+        // Tracks the last successful private-track candidate so the loop can keep iterating
+        // without losing a good result if a later client fails.
+        var privateCandidateStreamUrl: String? = null
+        var privateCandidateFormat: PlayerResponse.StreamingData.Format? = null
+        var privateCandidateExpiry: Int? = null
+        var privateCandidateResponse: PlayerResponse? = null
         val retryMainPlayerResponse: PlayerResponse? = if (usedAgeRestrictedClient != null) mainPlayerResponse else null
 
         // Check current status
@@ -362,22 +368,30 @@ object YTPlayerUtils {
                 // Skip validation for private tracks (cookie-based auth, not URL-verifiable)
                 // or for the last fallback client
                 val isPrivate = isPrivateTrack || isPrivatelyOwnedTrack
+                val isLastClient = clientIndex == STREAM_FALLBACK_CLIENTS.size - 1
 
-                if (clientIndex == STREAM_FALLBACK_CLIENTS.size - 1 || isPrivate) {
-                    if (isPrivate) {
-                        Timber.tag(logTag).d("Skipping validation for privately owned track: ${currentClient.clientName}")
-                    } else {
-                        Timber.tag(logTag).d("Using last fallback client without validation: ${STREAM_FALLBACK_CLIENTS[clientIndex].clientName}")
-                    }
-                    Timber.tag(TAG)
-                        .i("Playback: client=${currentClient.clientName}, videoId=$videoId, private=$isPrivate")
+                if (isLastClient) {
+                    Timber.tag(logTag).d("Using last fallback client without validation: ${currentClient.clientName}")
+                    Timber.tag(TAG).i("Playback: client=${currentClient.clientName}, videoId=$videoId, private=$isPrivate")
                     break
+                }
+
+                if (isPrivate) {
+                    // Private tracks can't be validated via HEAD request (cookie-based auth).
+                    // Save this client as the best candidate so far and keep iterating — a later
+                    // client may be better suited. The loop commits at isLastClient, or the
+                    // candidate is restored below if the loop exhausts without breaking.
+                    Timber.tag(logTag).d("Skipping validation for privately owned track, recording candidate and continuing: ${currentClient.clientName}")
+                    privateCandidateStreamUrl = streamUrl
+                    privateCandidateFormat = format
+                    privateCandidateExpiry = streamExpiresInSeconds
+                    privateCandidateResponse = streamPlayerResponse
+                    continue
                 }
 
                 if (validateStatus(streamUrl)) {
                     // working stream found
                     Timber.tag(logTag).d("Stream validated successfully with client: ${currentClient.clientName}")
-                    // Log for release builds
                     Timber.tag(TAG).i("Playback: client=${currentClient.clientName}, videoId=$videoId")
                     break
                 } else {
@@ -386,6 +400,16 @@ object YTPlayerUtils {
             } else {
                 Timber.tag(logTag).d("Player response status not OK: ${streamPlayerResponse?.playabilityStatus?.status}, reason: ${streamPlayerResponse?.playabilityStatus?.reason}")
             }
+        }
+
+        // If the loop exhausted without committing (streamUrl null) but accumulated a valid
+        // private-track candidate, restore it rather than throwing.
+        if (streamUrl == null && privateCandidateStreamUrl != null) {
+            Timber.tag(logTag).d("Loop exhausted; restoring best private-track candidate (${privateCandidateResponse?.videoDetails?.videoId})")
+            streamUrl = privateCandidateStreamUrl
+            format = privateCandidateFormat
+            streamExpiresInSeconds = privateCandidateExpiry
+            streamPlayerResponse = privateCandidateResponse
         }
 
         if (streamPlayerResponse == null) {

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -40,6 +40,9 @@ import timber.log.Timber
 object YTPlayerUtils {
     private const val logTag = "YTPlayerUtils"
     private const val TAG = "YTPlayerUtils"
+    private const val UPLOADED_TRACKS_PLAYLIST_PREFIX = "MLPT"
+
+    private val WEB_CLIENTS = listOf("WEB", "WEB_REMIX", "WEB_CREATOR", "TVHTML5")
 
     private val httpClient = OkHttpClient.Builder()
         .proxy(YouTube.proxy)
@@ -89,7 +92,7 @@ object YTPlayerUtils {
         Timber.tag(TAG).d("audioQuality: $audioQuality")
 
         // Check if this is an uploaded/privately owned track
-        val isUploadedTrack = isUploadedHint || playlistId == "MLPT" || playlistId?.contains("MLPT") == true
+        val isUploadedTrack = isUploadedHint || playlistId?.contains(UPLOADED_TRACKS_PLAYLIST_PREFIX) == true
         Timber.tag(TAG).d("Content type detection (preliminary):")
         Timber.tag(TAG).d("  isUploadedTrack (from playlistId): $isUploadedTrack")
 
@@ -120,12 +123,12 @@ object YTPlayerUtils {
         var mainPlayerResponse = YouTube.player(videoId, playlistId, MAIN_CLIENT, signatureTimestamp.timestamp, poToken?.playerRequestPoToken).getOrThrow()
 
         // Debug uploaded track response
-        if (isUploadedTrack || playlistId?.contains("MLPT") == true) {
-            println("[PLAYBACK_DEBUG] Main player response status: ${mainPlayerResponse.playabilityStatus.status}")
-            println("[PLAYBACK_DEBUG] Playability reason: ${mainPlayerResponse.playabilityStatus.reason}")
-            println("[PLAYBACK_DEBUG] Video details: title=${mainPlayerResponse.videoDetails?.title}, videoId=${mainPlayerResponse.videoDetails?.videoId}")
-            println("[PLAYBACK_DEBUG] Streaming data null? ${mainPlayerResponse.streamingData == null}")
-            println("[PLAYBACK_DEBUG] Adaptive formats count: ${mainPlayerResponse.streamingData?.adaptiveFormats?.size ?: 0}")
+        if (isUploadedTrack) {
+            Timber.tag(TAG).d("Uploaded track player response status: ${mainPlayerResponse.playabilityStatus.status}")
+            Timber.tag(TAG).d("Uploaded track playability reason: ${mainPlayerResponse.playabilityStatus.reason}")
+            Timber.tag(TAG).d("Uploaded track details: title=${mainPlayerResponse.videoDetails?.title}, videoId=${mainPlayerResponse.videoDetails?.videoId}")
+            Timber.tag(TAG).d("Uploaded track streaming data null? ${mainPlayerResponse.streamingData == null}")
+            Timber.tag(TAG).d("Uploaded track adaptive formats: ${mainPlayerResponse.streamingData?.adaptiveFormats?.size ?: 0}")
         }
 
         var usedAgeRestrictedClient: YouTubeClient? = null
@@ -285,13 +288,13 @@ object YTPlayerUtils {
 
                 // Apply n-transform and PoToken for web clients AND for private tracks
                 val needsNTransform = currentClient.useWebPoTokens ||
-                    currentClient.clientName in listOf("WEB", "WEB_REMIX", "WEB_CREATOR", "TVHTML5") ||
+                    currentClient.clientName in WEB_CLIENTS ||
                     isPrivatelyOwnedTrack
 
                 Timber.tag(TAG).d("N-transform decision:")
                 Timber.tag(TAG).d("  needsNTransform: $needsNTransform")
                 Timber.tag(TAG).d("  Reason: useWebPoTokens=${currentClient.useWebPoTokens}, " +
-                    "clientInList=${currentClient.clientName in listOf("WEB", "WEB_REMIX", "WEB_CREATOR", "TVHTML5")}, " +
+                    "clientInList=${currentClient.clientName in WEB_CLIENTS}, " +
                     "isPrivatelyOwnedTrack=$isPrivatelyOwnedTrack")
 
                 if (needsNTransform) {
@@ -361,7 +364,7 @@ object YTPlayerUtils {
                     /** skip [validateStatus] for last client or private tracks */
                     if (isPrivatelyOwned) {
                         Timber.tag(logTag).d("Skipping validation for privately owned track: ${currentClient.clientName}")
-                        println("[PLAYBACK_DEBUG] Using stream without validation for PRIVATELY_OWNED_TRACK")
+                        Timber.tag(TAG).d("Using stream without validation for privately owned track")
                     } else {
                         Timber.tag(logTag).d("Using last fallback client without validation: ${STREAM_FALLBACK_CLIENTS[clientIndex].clientName}")
                     }
@@ -387,7 +390,7 @@ object YTPlayerUtils {
         if (streamPlayerResponse == null) {
             Timber.tag(logTag).e("Bad stream player response - all clients failed")
             if (isUploadedTrack) {
-                println("[PLAYBACK_DEBUG] FAILURE: All clients failed for uploaded track videoId=$videoId")
+                Timber.tag(TAG).e("All clients failed for uploaded track videoId=$videoId")
             }
             throw Exception("Bad stream player response")
         }
@@ -396,7 +399,7 @@ object YTPlayerUtils {
             val errorReason = streamPlayerResponse.playabilityStatus.reason
             Timber.tag(logTag).e("Playability status not OK: $errorReason")
             if (isUploadedTrack) {
-                println("[PLAYBACK_DEBUG] FAILURE: Playability not OK for uploaded track - status=${streamPlayerResponse.playabilityStatus.status}, reason=$errorReason")
+                Timber.tag(TAG).e("Playability not OK for uploaded track: status=${streamPlayerResponse.playabilityStatus.status}, reason=$errorReason")
             }
             throw PlaybackException(
                 errorReason,
@@ -422,7 +425,7 @@ object YTPlayerUtils {
 
         Timber.tag(logTag).d("Successfully obtained playback data with format: ${format.mimeType}, bitrate: ${format.bitrate}")
         if (isUploadedTrack) {
-            println("[PLAYBACK_DEBUG] SUCCESS: Got playback data for uploaded track - format=${format.mimeType}, streamUrl=${streamUrl.take(100)}...")
+            Timber.tag(TAG).d("Got playback data for uploaded track: format=${format.mimeType}")
         }
         PlaybackData(
             audioConfig,
@@ -435,7 +438,7 @@ object YTPlayerUtils {
                 streamPlayerResponse?.videoDetails?.musicVideoType == MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK,
         )
     }.onFailure { e ->
-        println("[PLAYBACK_DEBUG] EXCEPTION during playback for videoId=$videoId: ${e::class.simpleName}: ${e.message}")
+        Timber.tag(TAG).e(e, "Playback exception for videoId=$videoId")
         e.printStackTrace()
     }
     /**
@@ -496,7 +499,7 @@ object YTPlayerUtils {
             // Add authentication cookie for privately owned tracks
             YouTube.cookie?.let { cookie ->
                 requestBuilder.addHeader("Cookie", cookie)
-                println("[PLAYBACK_DEBUG] Added cookie to validation request")
+                Timber.tag(TAG).d("Added cookie to validation request")
             }
 
             val response = httpClient.newCall(requestBuilder.build()).execute()

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -489,17 +489,17 @@ object YTPlayerUtils {
      * If this returns true the url is likely to work.
      * If this returns false the url might cause an error during playback.
      */
-    private fun validateStatus(url: String): Boolean {
+    private fun validateStatus(url: String, includeAuth: Boolean = false): Boolean {
         Timber.tag(logTag).d("Validating stream URL status")
         try {
             val requestBuilder = okhttp3.Request.Builder()
                 .head()
                 .url(url)
 
-            // Add authentication cookie for privately owned tracks
-            YouTube.cookie?.let { cookie ->
-                requestBuilder.addHeader("Cookie", cookie)
-                Timber.tag(TAG).d("Added cookie to validation request")
+            if (includeAuth) {
+                YouTube.cookie?.let { cookie ->
+                    requestBuilder.addHeader("Cookie", cookie)
+                }
             }
 
             val response = httpClient.newCall(requestBuilder.build()).execute()

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -358,19 +358,18 @@ object YTPlayerUtils {
 
                 Timber.tag(logTag).d("Stream expires in: $streamExpiresInSeconds seconds")
 
-                // Check if this is a privately owned track (uploaded song)
-                val isPrivatelyOwned = streamPlayerResponse.videoDetails?.musicVideoType == MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
+                // Skip validation for private tracks (cookie-based auth, not URL-verifiable)
+                // or for the last fallback client
+                val isPrivate = isPrivateTrack || isPrivatelyOwnedTrack
 
-                if (clientIndex == STREAM_FALLBACK_CLIENTS.size - 1 || isPrivatelyOwned) {
-                    /** skip [validateStatus] for last client or private tracks */
-                    if (isPrivatelyOwned) {
+                if (clientIndex == STREAM_FALLBACK_CLIENTS.size - 1 || isPrivate) {
+                    if (isPrivate) {
                         Timber.tag(logTag).d("Skipping validation for privately owned track: ${currentClient.clientName}")
-                        Timber.tag(TAG).d("Using stream without validation for privately owned track")
                     } else {
                         Timber.tag(logTag).d("Using last fallback client without validation: ${STREAM_FALLBACK_CLIENTS[clientIndex].clientName}")
                     }
                     Timber.tag(TAG)
-                        .i("Playback: client=${currentClient.clientName}, videoId=$videoId, private=$isPrivatelyOwned")
+                        .i("Playback: client=${currentClient.clientName}, videoId=$videoId, private=$isPrivate")
                     break
                 }
 

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -24,6 +24,7 @@ import com.metrolist.innertube.models.YouTubeClient.Companion.TVHTML5_SIMPLY_EMB
 import com.metrolist.innertube.models.YouTubeClient.Companion.WEB
 import com.metrolist.innertube.models.YouTubeClient.Companion.WEB_CREATOR
 import com.metrolist.innertube.models.YouTubeClient.Companion.WEB_REMIX
+import com.metrolist.innertube.models.WatchEndpoint.WatchEndpointMusicSupportedConfigs.WatchEndpointMusicConfig.Companion.MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
 import com.metrolist.innertube.models.response.PlayerResponse
 import com.metrolist.music.constants.AudioQuality
 import com.metrolist.music.utils.cipher.CipherDeobfuscator
@@ -68,6 +69,7 @@ object YTPlayerUtils {
         val format: PlayerResponse.StreamingData.Format,
         val streamUrl: String,
         val streamExpiresInSeconds: Int,
+        val isPrivatelyOwned: Boolean = false,
     )
     /**
      * Custom player response intended to use for playback.
@@ -77,6 +79,7 @@ object YTPlayerUtils {
     suspend fun playerResponseForPlayback(
         videoId: String,
         playlistId: String? = null,
+        isUploadedHint: Boolean = false,
         audioQuality: AudioQuality,
         connectivityManager: ConnectivityManager,
     ): Result<PlaybackData> = runCatching {
@@ -86,7 +89,7 @@ object YTPlayerUtils {
         Timber.tag(TAG).d("audioQuality: $audioQuality")
 
         // Check if this is an uploaded/privately owned track
-        val isUploadedTrack = playlistId == "MLPT" || playlistId?.contains("MLPT") == true
+        val isUploadedTrack = isUploadedHint || playlistId == "MLPT" || playlistId?.contains("MLPT") == true
         Timber.tag(TAG).d("Content type detection (preliminary):")
         Timber.tag(TAG).d("  isUploadedTrack (from playlistId): $isUploadedTrack")
 
@@ -128,18 +131,25 @@ object YTPlayerUtils {
         var usedAgeRestrictedClient: YouTubeClient? = null
         val wasOriginallyAgeRestricted: Boolean
 
-        // Check if WEB_REMIX response indicates age-restricted
+        // Check if WEB_REMIX response indicates age-restricted or login-required
         val mainStatus = mainPlayerResponse.playabilityStatus.status
-        val isAgeRestrictedFromResponse = mainStatus in listOf("AGE_CHECK_REQUIRED", "AGE_VERIFICATION_REQUIRED", "LOGIN_REQUIRED", "CONTENT_CHECK_REQUIRED")
-        wasOriginallyAgeRestricted = isAgeRestrictedFromResponse
+        val isAgeRestrictedFromResponse = mainStatus in listOf("AGE_CHECK_REQUIRED", "AGE_VERIFICATION_REQUIRED", "CONTENT_CHECK_REQUIRED")
+        val isLoginRequired = mainStatus == "LOGIN_REQUIRED"
 
-        if (isAgeRestrictedFromResponse && isLoggedIn) {
-            // Age-restricted: use WEB_CREATOR directly (no NewPipe needed from here)
-            Timber.tag(logTag).d("Age-restricted detected, using WEB_CREATOR")
-            Timber.tag(TAG).i("Age-restricted: using WEB_CREATOR for videoId=$videoId")
+        // LOGIN_REQUIRED can mean age-restricted (for catalog) or auth needed (for uploaded tracks).
+        // In both cases, WEB_CREATOR (which has loginRequired=true) is the right fallback to try.
+        wasOriginallyAgeRestricted = isAgeRestrictedFromResponse || (isLoginRequired && !isUploadedTrack)
+
+        if ((isAgeRestrictedFromResponse || isLoginRequired) && isLoggedIn) {
+            if (isUploadedTrack) {
+                Timber.tag(TAG).d("LOGIN_REQUIRED for uploaded track - trying WEB_CREATOR with full auth")
+            } else {
+                Timber.tag(logTag).d("Age-restricted detected, using WEB_CREATOR")
+            }
+            Timber.tag(TAG).i("Trying WEB_CREATOR for videoId=$videoId (uploaded=$isUploadedTrack)")
             val creatorResponse = YouTube.player(videoId, playlistId, WEB_CREATOR, null, null).getOrNull()
             if (creatorResponse?.playabilityStatus?.status == "OK") {
-                Timber.tag(logTag).d("WEB_CREATOR works for age-restricted content")
+                Timber.tag(logTag).d("WEB_CREATOR works for content")
                 mainPlayerResponse = creatorResponse
                 usedAgeRestrictedClient = WEB_CREATOR
             }
@@ -158,7 +168,8 @@ object YTPlayerUtils {
 
         // Check current status
         val currentStatus = mainPlayerResponse.playabilityStatus.status
-        val isAgeRestricted = currentStatus in listOf("AGE_CHECK_REQUIRED", "AGE_VERIFICATION_REQUIRED", "LOGIN_REQUIRED", "CONTENT_CHECK_REQUIRED")
+        val isAgeRestricted = currentStatus in listOf("AGE_CHECK_REQUIRED", "AGE_VERIFICATION_REQUIRED", "CONTENT_CHECK_REQUIRED") ||
+            (!isUploadedTrack && currentStatus == "LOGIN_REQUIRED")
 
         if (isAgeRestricted) {
             Timber.tag(logTag).d("Content is still age-restricted (status: $currentStatus), will try fallback clients")
@@ -167,12 +178,15 @@ object YTPlayerUtils {
         }
 
         // Check if this is a privately owned track (uploaded song)
-        val isPrivateTrack = mainPlayerResponse.videoDetails?.musicVideoType == "MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK"
+        val isPrivateTrack = isUploadedTrack ||
+            mainPlayerResponse.videoDetails?.musicVideoType == MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
 
-        // For private tracks: use TVHTML5 (index 1) with PoToken + n-transform
+        // For private tracks with a successful WEB_CREATOR response: try its streams first (index -1)
+        // For private tracks without a working response: use TVHTML5 (index 1)
         // For age-restricted: skip main client, start with fallbacks
         // For normal content: standard order
         val startIndex = when {
+            isPrivateTrack && usedAgeRestrictedClient != null -> -1  // WEB_CREATOR succeeded, try its streams
             isPrivateTrack -> 1  // TVHTML5
             isAgeRestricted -> 0
             else -> -1
@@ -215,9 +229,12 @@ object YTPlayerUtils {
             if (streamPlayerResponse?.playabilityStatus?.status == "OK") {
                 Timber.tag(logTag).d("Player response status OK for client: ${if (clientIndex == -1) MAIN_CLIENT.clientName else STREAM_FALLBACK_CLIENTS[clientIndex].clientName}")
 
-                // Skip NewPipe for age-restricted content (NewPipe doesn't use our auth)
-                val responseToUse = if (wasOriginallyAgeRestricted) {
-                    Timber.tag(logTag).d("Skipping NewPipe for age-restricted content")
+                // Skip NewPipe for age-restricted or privately-owned content (NewPipe doesn't use our auth)
+                val isPrivateContent = isPrivateTrack ||
+                    streamPlayerResponse.videoDetails?.musicVideoType == MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
+                val skipNewPipe = wasOriginallyAgeRestricted || isPrivateContent
+                val responseToUse = if (skipNewPipe) {
+                    Timber.tag(logTag).d("Skipping NewPipe: ageRestricted=$wasOriginallyAgeRestricted, private=$isPrivateContent")
                     streamPlayerResponse
                 } else {
                     // Try to get streams using newPipePlayer method
@@ -239,7 +256,7 @@ object YTPlayerUtils {
 
                 Timber.tag(logTag).d("Format found: ${format.mimeType}, bitrate: ${format.bitrate}")
 
-                streamUrl = findUrlOrNull(format, videoId, responseToUse, skipNewPipe = wasOriginallyAgeRestricted)
+                streamUrl = findUrlOrNull(format, videoId, responseToUse, skipNewPipe = skipNewPipe)
                 if (streamUrl == null) {
                     Timber.tag(logTag).d("Stream URL not found for format")
                     continue
@@ -253,7 +270,7 @@ object YTPlayerUtils {
                 }
 
                 // Check if this is a privately owned track
-                val isPrivatelyOwnedTrack = streamPlayerResponse.videoDetails?.musicVideoType == "MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK"
+                val isPrivatelyOwnedTrack = streamPlayerResponse.videoDetails?.musicVideoType == MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
                 val musicVideoType = streamPlayerResponse.videoDetails?.musicVideoType
 
                 Timber.tag(TAG).d("=== N-TRANSFORM DECISION ===")
@@ -266,7 +283,7 @@ object YTPlayerUtils {
                 Timber.tag(TAG).d("  currentClient: ${currentClient.clientName}")
                 Timber.tag(TAG).d("  useWebPoTokens: ${currentClient.useWebPoTokens}")
 
-                // Apply n-transform and PoToken for web clients OR for private tracks (including TVHTML5)
+                // Apply n-transform and PoToken for web clients AND for private tracks
                 val needsNTransform = currentClient.useWebPoTokens ||
                     currentClient.clientName in listOf("WEB", "WEB_REMIX", "WEB_CREATOR", "TVHTML5") ||
                     isPrivatelyOwnedTrack
@@ -284,8 +301,26 @@ object YTPlayerUtils {
                         Timber.tag(TAG).d("  Original URL preview: ${streamUrl.take(100)}...")
 
                         val originalUrl = streamUrl
-                        // Use CipherDeobfuscator for n-transform (fixed implementation)
+                        // Use CipherDeobfuscator for n-transform, fall back to NewPipe
                         streamUrl = CipherDeobfuscator.transformNParamInUrl(streamUrl)
+
+                        if (originalUrl == streamUrl) {
+                            // CipherDeobfuscator didn't change the URL, try NewPipe's throttling deobfuscation
+                            Timber.tag(TAG).d("  CipherDeobfuscator failed, trying NewPipe throttling deobfuscation...")
+                            try {
+                                // Ensure NewPipe Downloader is initialized
+                                com.metrolist.innertube.NewPipeUtils
+                                val newPipeUrl = com.metrolist.innertube.NewPipeExtractor.getThrottlingDeobfuscatedUrl(videoId, streamUrl)
+                                if (newPipeUrl != null && newPipeUrl != streamUrl) {
+                                    streamUrl = newPipeUrl
+                                    Timber.tag(TAG).d("  N-transform via NewPipe succeeded")
+                                } else {
+                                    Timber.tag(TAG).d("  NewPipe returned null or unchanged URL")
+                                }
+                            } catch (e: Exception) {
+                                Timber.tag(TAG).d("  NewPipe n-transform also failed: ${e.message}")
+                            }
+                        }
 
                         Timber.tag(TAG).d("  Transformed URL length: ${streamUrl.length}")
                         Timber.tag(TAG).d("  URL changed: ${originalUrl != streamUrl}")
@@ -320,7 +355,7 @@ object YTPlayerUtils {
                 Timber.tag(logTag).d("Stream expires in: $streamExpiresInSeconds seconds")
 
                 // Check if this is a privately owned track (uploaded song)
-                val isPrivatelyOwned = streamPlayerResponse.videoDetails?.musicVideoType == "MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK"
+                val isPrivatelyOwned = streamPlayerResponse.videoDetails?.musicVideoType == MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
 
                 if (clientIndex == STREAM_FALLBACK_CLIENTS.size - 1 || isPrivatelyOwned) {
                     /** skip [validateStatus] for last client or private tracks */
@@ -396,6 +431,8 @@ object YTPlayerUtils {
             format,
             streamUrl,
             streamExpiresInSeconds,
+            isPrivatelyOwned = isPrivateTrack ||
+                streamPlayerResponse?.videoDetails?.musicVideoType == MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK,
         )
     }.onFailure { e ->
         println("[PLAYBACK_DEBUG] EXCEPTION during playback for videoId=$videoId: ${e::class.simpleName}: ${e.message}")

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -272,8 +272,9 @@ object YTPlayerUtils {
                     STREAM_FALLBACK_CLIENTS[clientIndex]
                 }
 
-                // Check if this is a privately owned track
-                val isPrivatelyOwnedTrack = streamPlayerResponse.videoDetails?.musicVideoType == MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
+                // Check if this is a privately owned track (from response or earlier detection)
+                val isPrivatelyOwnedTrack = isPrivateTrack ||
+                    streamPlayerResponse.videoDetails?.musicVideoType == MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
                 val musicVideoType = streamPlayerResponse.videoDetails?.musicVideoType
 
                 Timber.tag(TAG).d("=== N-TRANSFORM DECISION ===")
@@ -502,10 +503,10 @@ object YTPlayerUtils {
                 }
             }
 
-            val response = httpClient.newCall(requestBuilder.build()).execute()
-            val isSuccessful = response.isSuccessful
-            Timber.tag(logTag).d("Stream URL validation result: ${if (isSuccessful) "Success" else "Failed"} (${response.code})")
-            return isSuccessful
+            httpClient.newCall(requestBuilder.build()).execute().use { response ->
+                Timber.tag(logTag).d("Stream URL validation result: ${if (response.isSuccessful) "Success" else "Failed"} (${response.code})")
+                return response.isSuccessful
+            }
         } catch (e: Exception) {
             Timber.tag(logTag).e(e, "Stream URL validation failed with exception")
             reportException(e)

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -65,6 +65,11 @@ object YTPlayerUtils {
         WEB,
         WEB_CREATOR
     )
+    /**
+     * Container for everything the player needs to begin streaming a track:
+     * audio config, video metadata, playback-tracking URLs, the resolved stream format/URL,
+     * and whether the track is a privately-owned (uploaded) item requiring cookie auth.
+     */
     data class PlaybackData(
         val audioConfig: PlayerResponse.PlayerConfig.AudioConfig?,
         val videoDetails: PlayerResponse.VideoDetails?,
@@ -480,6 +485,13 @@ object YTPlayerUtils {
             .onFailure { Timber.tag(logTag).e(it, "Failed to fetch metadata") }
     }
 
+    /**
+     * Selects the best audio format from the player response's adaptive formats
+     * based on the requested [audioQuality] and current network conditions.
+     * Prefers Opus (WebM) streams when bitrates are otherwise equal.
+     *
+     * @return the chosen format, or `null` if no audio-only original format is available.
+     */
     private fun findFormat(
         playerResponse: PlayerResponse,
         audioQuality: AudioQuality,
@@ -537,11 +549,19 @@ object YTPlayerUtils {
         }
         return false
     }
+    /**
+     * Result of attempting to obtain a signature timestamp from NewPipe.
+     * If the video is age-restricted, [timestamp] will be `null` and [isAgeRestricted] will be `true`.
+     */
     data class SignatureTimestampResult(
         val timestamp: Int?,
         val isAgeRestricted: Boolean
     )
 
+    /**
+     * Retrieves the signature timestamp required for player requests via NewPipe.
+     * Detects age-restricted content early if NewPipe reports it.
+     */
     private fun getSignatureTimestampOrNull(videoId: String): SignatureTimestampResult {
         Timber.tag(logTag).d("Getting signature timestamp for videoId: $videoId")
         val result = NewPipeExtractor.getSignatureTimestamp(videoId)
@@ -565,6 +585,18 @@ object YTPlayerUtils {
         )
     }
 
+    /**
+     * Resolves a playable stream URL for the given [format].
+     *
+     * Tries, in order:
+     * 1. The format's direct URL (if present).
+     * 2. Custom cipher deobfuscation of `signatureCipher`.
+     * 3. NewPipe signature deobfuscation (skipped when [skipNewPipe] is `true`,
+     *    e.g. for age-restricted or privately-owned content that requires our auth).
+     * 4. NewPipe `StreamInfo` as a last resort.
+     *
+     * @return the resolved URL, or `null` if all methods fail.
+     */
     private suspend fun findUrlOrNull(
         format: PlayerResponse.StreamingData.Format,
         videoId: String,
@@ -631,6 +663,7 @@ object YTPlayerUtils {
         return null
     }
 
+    /** Evicts cached data for [videoId], forcing a fresh player request on next playback. */
     fun forceRefreshForVideo(videoId: String) {
         Timber.tag(logTag).d("Force refreshing for videoId: $videoId")
     }

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/Endpoint.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/Endpoint.kt
@@ -32,6 +32,7 @@ data class WatchEndpoint(
                 const val MUSIC_VIDEO_TYPE_OMV = "MUSIC_VIDEO_TYPE_OMV"
                 const val MUSIC_VIDEO_TYPE_UGC = "MUSIC_VIDEO_TYPE_UGC"
                 const val MUSIC_VIDEO_TYPE_ATV = "MUSIC_VIDEO_TYPE_ATV"
+                const val MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK = "MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK"
             }
         }
     }

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/YTItem.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/YTItem.kt
@@ -1,6 +1,7 @@
 package com.metrolist.innertube.models
 
 import com.metrolist.innertube.models.WatchEndpoint.WatchEndpointMusicSupportedConfigs.WatchEndpointMusicConfig.Companion.MUSIC_VIDEO_TYPE_ATV
+import com.metrolist.innertube.models.WatchEndpoint.WatchEndpointMusicSupportedConfigs.WatchEndpointMusicConfig.Companion.MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
 
 sealed class YTItem {
     abstract val id: String
@@ -41,6 +42,7 @@ data class SongItem(
 ) : YTItem() {
     val isVideoSong: Boolean
         get() = musicVideoType != null && musicVideoType != MUSIC_VIDEO_TYPE_ATV
+                && musicVideoType != MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
 
     override val shareLink: String
         get() = "https://music.youtube.com/watch?v=$id"

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/YTItem.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/YTItem.kt
@@ -113,6 +113,7 @@ data class PodcastItem(
     override val shareLink: String
         get() = "https://music.youtube.com/playlist?list=$id"
 
+    /** Converts this podcast to a [PlaylistItem] for display in playlist-oriented UI. */
     fun asPlaylistItem() = PlaylistItem(
         id = id,
         title = title,
@@ -145,6 +146,7 @@ data class EpisodeItem(
     override val shareLink: String
         get() = "https://music.youtube.com/watch?v=$id"
 
+    /** Converts this episode to a [SongItem] so it can be queued and played like a song. */
     fun asSongItem() = SongItem(
         id = id,
         title = title,
@@ -160,6 +162,7 @@ data class EpisodeItem(
     )
 }
 
+/** Removes explicit items from the list when [enabled] is `true`. */
 fun <T : YTItem> List<T>.filterExplicit(enabled: Boolean = true) =
     if (enabled) {
         filter { !it.explicit }
@@ -167,6 +170,7 @@ fun <T : YTItem> List<T>.filterExplicit(enabled: Boolean = true) =
         this
     }
 
+/** Removes video-type songs (OMV/UGC) from the list when [disableVideos] is `true`. */
 fun <T : YTItem> List<T>.filterVideoSongs(disableVideos: Boolean = false) =
     if (disableVideos) {
         filterNot { it is SongItem && it.isVideoSong }
@@ -174,6 +178,7 @@ fun <T : YTItem> List<T>.filterVideoSongs(disableVideos: Boolean = false) =
         this
     }
 
+/** Removes YouTube Shorts playlists (IDs starting with "SS") when [enabled] is `true`. */
 fun <T : YTItem> List<T>.filterYoutubeShorts(enabled: Boolean = false) =
     if (enabled) {
         filterNot { it is PlaylistItem && it.id.startsWith("SS") }

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/NewPipe.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/NewPipe.kt
@@ -69,7 +69,29 @@ private class NewPipeDownloaderImpl(proxy: Proxy?, proxyAuth: String?) : Downloa
     }
 
     override fun executeAsync(request: Request, callback: AsyncCallback?): CancellableCall {
-        TODO("Placeholder")
+        val httpRequest = okhttp3.Request.Builder()
+            .method(request.httpMethod(), request.dataToSend()?.toRequestBody())
+            .url(request.url())
+            .addHeader("User-Agent", YouTubeClient.USER_AGENT_WEB)
+            .apply {
+                request.headers().forEach { (name, values) ->
+                    values.forEach { addHeader(name, it) }
+                }
+            }
+            .build()
+        val call = client.newCall(httpRequest)
+        call.enqueue(object : okhttp3.Callback {
+            override fun onResponse(call: okhttp3.Call, response: okhttp3.Response) {
+                val body = response.body?.string()
+                callback?.onSuccess(
+                    Response(response.code, response.message, response.headers.toMultimap(), body, body?.toByteArray(), response.request.url.toString())
+                )
+            }
+            override fun onFailure(call: okhttp3.Call, e: IOException) {
+                callback?.onError(e)
+            }
+        })
+        return CancellableCall(call)
     }
 
 }
@@ -152,6 +174,14 @@ object NewPipeExtractor {
                 videoId,
                 url
             )
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    fun getThrottlingDeobfuscatedUrl(videoId: String, url: String): String? {
+        return try {
+            YoutubeJavaScriptPlayerManager.getUrlWithThrottlingParameterDeobfuscated(videoId, url)
         } catch (e: Exception) {
             null
         }

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/NewPipe.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/NewPipe.kt
@@ -102,16 +102,26 @@ private class NewPipeDownloaderImpl(proxy: Proxy?, proxyAuth: String?) : Downloa
 
 }
 
+/**
+ * Wrapper around NewPipe's [YoutubeJavaScriptPlayerManager] for signature/cipher operations.
+ * Initialises the NewPipe [Downloader] on first access, routing requests through the
+ * configured proxy.
+ */
 object NewPipeUtils {
 
     init {
         NewPipe.init(NewPipeDownloaderImpl(YouTube.proxy, YouTube.proxyAuth))
     }
 
+    /** Returns the signature timestamp needed for InnerTube player requests. */
     fun getSignatureTimestamp(videoId: String): Result<Int> = runCatching {
         YoutubeJavaScriptPlayerManager.getSignatureTimestamp(videoId)
     }
 
+    /**
+     * Deobfuscates the signature cipher on [format] and applies throttling parameter
+     * deobfuscation to produce a playable stream URL.
+     */
     fun getStreamUrl(format: PlayerResponse.StreamingData.Format, videoId: String): Result<String> =
         runCatching {
             val url = format.url ?: format.signatureCipher?.let { signatureCipher ->
@@ -138,7 +148,16 @@ object NewPipeUtils {
 
 }
 
+/**
+ * Higher-level NewPipe integration that can resolve complete stream lists and perform
+ * individual deobfuscation steps. Unlike [NewPipeUtils], methods here return nullable
+ * values instead of [Result] and silently swallow exceptions.
+ */
 object NewPipeExtractor {
+    /**
+     * Fetches all available stream URLs for [videoId] via NewPipe's [StreamInfo].
+     * Returns a list of (itag, url) pairs, or an empty list on failure.
+     */
     fun newPipePlayer(videoId: String): List<Pair<Int, String>> {
         return try {
             val streamInfo = StreamInfo.getInfo(
@@ -154,10 +173,15 @@ object NewPipeExtractor {
         }
     }
 
+    /** Returns the signature timestamp needed for InnerTube player requests. */
     fun getSignatureTimestamp(videoId: String): Result<Int> = runCatching {
         YoutubeJavaScriptPlayerManager.getSignatureTimestamp(videoId)
     }
 
+    /**
+     * Deobfuscates the signature cipher on [format] and applies throttling parameter
+     * deobfuscation. Returns `null` on any failure.
+     */
     fun getStreamUrl(format: PlayerResponse.StreamingData.Format, videoId: String): String? {
         return try {
             val url = format.url ?: format.signatureCipher?.let { signatureCipher ->
@@ -185,6 +209,11 @@ object NewPipeExtractor {
         }
     }
 
+    /**
+     * Applies only the throttling (n-parameter) deobfuscation to an already-resolved [url].
+     * Useful as a fallback when [CipherDeobfuscator][com.metrolist.music.utils.cipher.CipherDeobfuscator]
+     * fails for privately-owned tracks.
+     */
     fun getThrottlingDeobfuscatedUrl(videoId: String, url: String): String? {
         return try {
             YoutubeJavaScriptPlayerManager.getUrlWithThrottlingParameterDeobfuscated(videoId, url)

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/NewPipe.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/NewPipe.kt
@@ -82,6 +82,11 @@ private class NewPipeDownloaderImpl(proxy: Proxy?, proxyAuth: String?) : Downloa
         val call = client.newCall(httpRequest)
         call.enqueue(object : okhttp3.Callback {
             override fun onResponse(call: okhttp3.Call, response: okhttp3.Response) {
+                if (response.code == 429) {
+                    response.close()
+                    callback?.onError(ReCaptchaException("reCaptcha Challenge requested", request.url()))
+                    return
+                }
                 val body = response.body?.string()
                 callback?.onSuccess(
                     Response(response.code, response.message, response.headers.toMultimap(), body, body?.toByteArray(), response.request.url.toString())

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/NewPipe.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/NewPipe.kt
@@ -1,5 +1,6 @@
 package com.metrolist.innertube
 
+import android.util.Log
 import com.metrolist.innertube.models.YouTubeClient
 import com.metrolist.innertube.models.response.PlayerResponse
 import io.ktor.http.URLBuilder
@@ -188,6 +189,7 @@ object NewPipeExtractor {
         return try {
             YoutubeJavaScriptPlayerManager.getUrlWithThrottlingParameterDeobfuscated(videoId, url)
         } catch (e: Exception) {
+            Log.e("NewPipeExtractor", "getThrottlingDeobfuscatedUrl failed for videoId=$videoId: ${e.message}")
             null
         }
     }

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/NextPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/NextPage.kt
@@ -21,6 +21,14 @@ data class NextResult(
 )
 
 object NextPage {
+    /**
+     * Parses a [PlaylistPanelVideoRenderer] (the "up next" / queue item renderer from YouTube Music)
+     * into a [SongItem]. Returns `null` if required fields (videoId, title) are missing.
+     *
+     * Extracts artist and album info from [PlaylistPanelVideoRenderer.longBylineText],
+     * falling back to [PlaylistPanelVideoRenderer.shortBylineText], and resolves library
+     * add/remove tokens from the renderer's menu items.
+     */
     fun fromPlaylistPanelVideoRenderer(renderer: PlaylistPanelVideoRenderer): SongItem? {
         val longByLineRuns = (renderer.longBylineText ?: renderer.shortBylineText)?.runs?.splitBySeparator()
 

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/NextPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/NextPage.kt
@@ -38,7 +38,7 @@ object NextPage {
                 longByLineRuns?.firstOrNull()?.oddElements()?.map {
                     Artist(
                         name = it.text,
-                        id = it.navigationEndpoint?.browseEndpoint?.browseId ?: "",
+                        id = it.navigationEndpoint?.browseEndpoint?.browseId,
                     )
                 } ?: emptyList(),
             album =
@@ -46,9 +46,11 @@ object NextPage {
                     ?.getOrNull(1)
                     ?.firstOrNull()
                     ?.let {
+                        val albumId = it.navigationEndpoint?.browseEndpoint?.browseId
+                            ?: return@let null
                         Album(
                             name = it.text,
-                            id = it.navigationEndpoint?.browseEndpoint?.browseId ?: "",
+                            id = albumId,
                         )
                     },
             duration =

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/NextPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/NextPage.kt
@@ -22,7 +22,7 @@ data class NextResult(
 
 object NextPage {
     fun fromPlaylistPanelVideoRenderer(renderer: PlaylistPanelVideoRenderer): SongItem? {
-        val longByLineRuns = renderer.longBylineText?.runs?.splitBySeparator() ?: return null
+        val longByLineRuns = (renderer.longBylineText ?: renderer.shortBylineText)?.runs?.splitBySeparator()
 
         // Extract library tokens using the new method that properly handles multiple toggle items
         val libraryTokens = PageHelper.extractLibraryTokensFromMenuItems(renderer.menu?.menuRenderer?.items)
@@ -35,22 +35,20 @@ object NextPage {
                     ?.firstOrNull()
                     ?.text ?: return null,
             artists =
-                longByLineRuns.firstOrNull()?.oddElements()?.map {
+                longByLineRuns?.firstOrNull()?.oddElements()?.map {
                     Artist(
                         name = it.text,
-                        id = it.navigationEndpoint?.browseEndpoint?.browseId,
+                        id = it.navigationEndpoint?.browseEndpoint?.browseId ?: "",
                     )
-                } ?: return null,
+                } ?: emptyList(),
             album =
                 longByLineRuns
-                    .getOrNull(1)
+                    ?.getOrNull(1)
                     ?.firstOrNull()
-                    ?.takeIf {
-                        it.navigationEndpoint?.browseEndpoint != null
-                    }?.let {
+                    ?.let {
                         Album(
                             name = it.text,
-                            id = it.navigationEndpoint?.browseEndpoint?.browseId!!,
+                            id = it.navigationEndpoint?.browseEndpoint?.browseId ?: "",
                         )
                     },
             duration =
@@ -58,12 +56,12 @@ object NextPage {
                     ?.runs
                     ?.firstOrNull()
                     ?.text
-                    ?.parseTime() ?: return null,
+                    ?.parseTime(),
             musicVideoType = renderer.navigationEndpoint.musicVideoType,
             thumbnail =
                 renderer.thumbnail.thumbnails
                     .lastOrNull()
-                    ?.url ?: return null,
+                    ?.url ?: "",
             explicit =
                 renderer.badges?.find {
                     it.musicInlineBadgeRenderer?.icon?.iconType == "MUSIC_EXPLICIT_BADGE"


### PR DESCRIPTION
## Summary

- Uploaded/privately-owned tracks were silently dropped from queues and failed to play. This PR fixes the full pipeline so uploaded tracks behave identically to catalog tracks from a user perspective.
- Users can now play mixed playlists containing both catalog and uploaded tracks seamlessly.

## What was broken

1. **Queue parsing** — `NextPage.fromPlaylistPanelVideoRenderer()` had strict null checks that rejected uploaded tracks with missing artist browse endpoints, duration, or album metadata.
2. **Track type detection** — `MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK` was lost during `Song→MediaMetadata` conversion, so the playback pipeline couldn't identify uploaded tracks.
3. **Authentication** — `LOGIN_REQUIRED` responses were misclassified as age-restricted. Stream URLs for private content require auth cookies on the HTTP request, which the data source wasn't providing.
4. **URL deobfuscation** — The n-transform (throttling parameter) failed via `CipherDeobfuscator` for uploaded tracks, and NewPipe couldn't help because `executeAsync` was unimplemented (`TODO("Placeholder")`).

## Changes

- **NextPage.kt** — Tolerant parsing: falls back to `shortBylineText`, allows empty artist/album IDs, makes duration optional (mirrors existing `LibraryPage.kt` patterns)
- **Endpoint.kt** — Added `MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK` constant
- **YTItem.kt / MediaMetadata.kt** — `isVideoSong` excludes uploaded tracks; `Song.toMediaMetadata()` preserves `musicVideoType` and `uploadEntityId`; `toSongEntity()` sets `isUploaded` flag
- **YTPlayerUtils.kt** — Separates `LOGIN_REQUIRED` handling for uploaded vs age-restricted content; skips NewPipe for private content stream resolution; falls back to NewPipe throttling deobfuscation when `CipherDeobfuscator` fails; returns `isPrivatelyOwned` flag in `PlaybackData`
- **MusicService.kt** — OkHttp interceptor conditionally attaches YouTube auth cookies for private stream URLs using a marker query parameter
- **NewPipe.kt** — Implemented `executeAsync` (was `TODO`); added `getThrottlingDeobfuscatedUrl` helper

## Test plan

- [ ] Play a catalog track from search — should work as before
- [ ] Play an uploaded track from the uploads library — should now play
- [ ] Play a mixed playlist (catalog + uploaded tracks) — both types should play in sequence
- [ ] Verify age-restricted catalog content still plays (LOGIN_REQUIRED path preserved)
- [ ] Verify uploaded tracks appear in queue when browsing playlists containing them

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Metadata and song flags now correctly distinguish privately owned vs. video tracks and preserve upload IDs.
  * Playback caching, validation and access handling are more reliable for privately owned or age-restricted content.
  * Stream selection and fallback logic stabilized to avoid unnecessary fallbacks for private/uploaded tracks.

* **New Features**
  * Better playback support for privately owned/uploaded tracks with conditional authenticated access.
  * Improved async HTTP downloader and additional stream deobfuscation/fallback paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->