### PR TITLE
fix(ui): resolve file import issue

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
@@ -146,6 +146,14 @@ fun LibrarySongsScreen(
             contract = ActivityResultContracts.OpenMultipleDocuments(),
         ) { uris: List<Uri> ->
             if (uris.isNotEmpty()) {
+                uris.forEach { uri ->
+                    try {
+                        val takeFlags = android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION
+                        context.contentResolver.takePersistableUriPermission(uri, takeFlags)
+                    } catch (e: SecurityException) {
+                        android.util.Log.w("LibrarySongsScreen", "Could not take persistable permission: ${e.message}")
+                    }
+                }
                 uploadJob =
                     scope.launch {
                         isUploading = true

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -86,6 +86,7 @@ import androidx.compose.ui.util.fastForEachReversed
 import androidx.compose.ui.util.fastSumBy
 import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import timber.log.Timber
 import androidx.media3.exoplayer.offline.Download
 import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
@@ -237,6 +238,14 @@ fun AutoPlaylistScreen(
             contract = ActivityResultContracts.OpenMultipleDocuments(),
         ) { uris: List<Uri> ->
             if (uris.isNotEmpty()) {
+                uris.forEach { uri ->
+                    try {
+                        val takeFlags = android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION
+                        context.contentResolver.takePersistableUriPermission(uri, takeFlags)
+                    } catch (e: SecurityException) {
+                        android.util.Log.w("AutoPlaylistScreen", "Could not take persistable permission: ${e.message}")
+                    }
+                }
                 uploadJob =
                     scope.launch {
                         isUploading = true


### PR DESCRIPTION
## Problem
Songs are not getting imported from device files

## Cause
The file picker for importing songs doesn't explicitly take persistable URI permissions from the selected files. This can cause silent failures when trying to read file content after the picker closes.

## Solution
- Take persistable URI permissions immediately after files are selected in both LibrarySongsScreen and AutoPlaylistScreen

## Testing
- Build compiles successfully

## Related Issues
- Closes #3389

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of multi-file imports for library and playlists by gracefully handling file access permission issues
  * Application now continues importing when individual files encounter permission errors instead of failing the entire import operation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->