### PR TITLE
fix(ui): TV navigation dialog focus

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Dialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Dialog.kt
@@ -154,11 +154,10 @@ fun AccountSettingsDialog(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .clickable(
-                        indication = null,
-                        interactionSource = remember { MutableInteractionSource() },
-                    ) {
-                        onDismiss()
+                    .pointerInput(Unit) {
+                        detectTapGestures(
+                            onTap = { onDismiss() }
+                        )
                     },
             contentAlignment = Alignment.TopCenter,
         ) {


### PR DESCRIPTION
## Problem
> TV remote doesn't works on this menu. 
> (**Metrolist v12.12.2**)
> 
> ![Image](https://github.com/user-attachments/assets/3d4ba43c-e199-49d2-a147-2117e178d62c) 

 _Originally posted by @geekytricky in [#572](https://github.com/MetrolistGroup/Metrolist/issues/572#issuecomment-3794035185)_

## Cause
Modifier.clickable causes the main app screen to regain focus instead of the dialog

## Solution
replaced Modifier.clickable with Modifier.pointerInput

## Testing
Tested working on Android TV 14

## Related Issues
- Partially fixes #572

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal gesture handling for dialog dismissal interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->