### PR TITLE
[wontfix] fix(readme): resize icon to 125px

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="https://github.com/MetrolistGroup/Metrolist/blob/main/fastlane/metadata/android/en-US/images/icon.png" alt="Metrolist app icon" width="200" />
+<img src="https://github.com/MetrolistGroup/Metrolist/blob/main/fastlane/metadata/android/en-US/images/icon.png" alt="Metrolist app icon" width="125" />
 
 # Metrolist
 


### PR DESCRIPTION
## Problem
The Metrolist app icon in the README.md is 200px wide, which is larger than the text below it.

## Cause
The icon width was set to 200px while the heading text "Metrolist" and other text are sized differently.

## Solution
- Changed the icon width from 200px to 125px to match the text size
