### PR TITLE
fix: corrected the Build process of the play-next shuffle order

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -1671,9 +1671,10 @@ class MusicService :
                 val nextBlock = (insertIndex until (insertIndex + items.size)).toList()
                 val finalOrder = IntArray(size)
                 var pos = 0
+                prevList.forEach { if (it in 0 until size) finalOrder[pos++] = it }
                 finalOrder[pos++] = currentIndex
                 nextBlock.forEach { if (it in 0 until size) finalOrder[pos++] = it }
-                existingOrder.forEach { if (pos < size) finalOrder[pos++] = it }
+                orderAfter.filter { it !in newIndices }.forEach { if (pos < size) finalOrder[pos++] = it }
 
                 // Fill any missing indices (safety) to ensure a full permutation
                 if (pos < size) {

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -1671,10 +1671,14 @@ class MusicService :
                 val nextBlock = (insertIndex until (insertIndex + items.size)).toList()
                 val finalOrder = IntArray(size)
                 var pos = 0
-                prevList.forEach { if (it in 0 until size) finalOrder[pos++] = it }
+                prevList
+                    .filter { it !in newIndices }
+                    .forEach { if (it in 0 until size) finalOrder[pos++] = it }
                 finalOrder[pos++] = currentIndex
                 nextBlock.forEach { if (it in 0 until size) finalOrder[pos++] = it }
-                orderAfter.filter { it !in newIndices }.forEach { if (pos < size) finalOrder[pos++] = it }
+                orderAfter
+                    .filter { it !in newIndices }
+                    .forEach { if (pos < size) finalOrder[pos++] = it }
 
                 // Fill any missing indices (safety) to ensure a full permutation
                 if (pos < size) {


### PR DESCRIPTION
## Problem
When adding a song via "Play Next" with shuffle mode enabled, playback would restart the shuffle queue from the beginning instead of continuing from the current position.

## Cause
DefaultShuffleOrder is a full permutation array. ExoPlayer determines the current position within the shuffle order by finding currentMediaItemIndex in that array. The old code placed currentIndex at position 0 of finalOrder, which ExoPlayer interpreted as the start of the queue — effectively discarding all shuffle history and making it seem like playback restarted from scratch.

## Solution
Reconstruct finalOrder in the correct order: previously played items (prevList) first, then currentIndex, then the newly inserted items (nextBlock), then the remaining upcoming items (orderAfter). This preserves the shuffle history on both sides of the current position and correctly inserts the new items as immediate next-up without disrupting the rest of the queue. As a cleanup, the intermediate existingOrder variable (prevList + orderAfter) was removed since both lists are now used separately.

## Testing
- Build successful 
- Tested play-next with shuffle

## Related Issues
- Closes #2617 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shuffle behavior when using "Play Next": newly added tracks are now integrated into the shuffled queue so the current song, the inserted next block, and the remaining shuffled tracks play in the intended order, avoiding misplacement of pre-existing items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->