### PR TITLE
feat: add Google Translate lyrics provider

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/api/GoogleTranslateService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/api/GoogleTranslateService.kt
@@ -1,0 +1,97 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.api
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONArray
+import timber.log.Timber
+import java.net.URLEncoder
+import java.util.concurrent.TimeUnit
+
+object GoogleTranslateService {
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(15, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .writeTimeout(15, TimeUnit.SECONDS)
+        .build()
+
+    suspend fun translate(
+        text: String,
+        targetLanguage: String,
+        maxRetries: Int = 3
+    ): Result<List<String>> = withContext(Dispatchers.IO) {
+        if (text.isBlank()) {
+            return@withContext Result.failure(Exception("Input text is empty"))
+        }
+
+        val lines = text.lines()
+        val translated = lines.map { line ->
+            if (line.isBlank()) {
+                ""
+            } else {
+                translateLineWithRetry(line, targetLanguage, maxRetries)
+            }
+        }
+        Result.success(translated)
+    }
+
+    private suspend fun translateLineWithRetry(
+        line: String,
+        targetLanguage: String,
+        maxRetries: Int
+    ): String {
+        var attempt = 0
+        var lastError: Exception? = null
+
+        while (attempt < maxRetries) {
+            try {
+                return translateLine(line, targetLanguage)
+            } catch (e: Exception) {
+                lastError = e
+                attempt++
+                if (attempt < maxRetries) {
+                    delay(500L * attempt)
+                }
+            }
+        }
+
+        Timber.w(lastError, "Google translation failed after retries, returning original line")
+        return line
+    }
+
+    private fun translateLine(
+        line: String,
+        targetLanguage: String
+    ): String {
+        val encoded = URLEncoder.encode(line, Charsets.UTF_8.name())
+        val url = "https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl=$targetLanguage&dt=t&q=$encoded"
+
+        val request = Request.Builder().url(url).get().build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw Exception("HTTP ${response.code}: ${response.message}")
+            }
+
+            val body = response.body?.string().orEmpty()
+            if (body.isBlank()) return line
+
+            val root = JSONArray(body)
+            val segments = root.optJSONArray(0) ?: return line
+            val builder = StringBuilder()
+
+            for (i in 0 until segments.length()) {
+                val segment = segments.optJSONArray(i) ?: continue
+                builder.append(segment.optString(0, ""))
+            }
+
+            return builder.toString().ifBlank { line }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsTranslationHelper.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsTranslationHelper.kt
@@ -10,6 +10,7 @@ import com.metrolist.music.db.MusicDatabase
 import com.metrolist.music.db.entities.LyricsEntity
 import com.metrolist.music.db.entities.SongEntity
 import com.metrolist.music.api.DeepLService
+import com.metrolist.music.api.GoogleTranslateService
 import com.metrolist.music.api.MistralService
 import com.metrolist.music.api.OpenRouterService
 import com.metrolist.music.api.OpenRouterStreamingService
@@ -196,8 +197,9 @@ object LyricsTranslationHelper {
             scope.launch(Dispatchers.IO) {
                 try {
                     // Validate inputs
+                    val requiresApiKey = provider != "DeepL" && provider != "Google"
                     val effectiveApiKey = if (provider == "DeepL") deeplApiKey else apiKey
-                    if (effectiveApiKey.isBlank()) {
+                    if (requiresApiKey && effectiveApiKey.isBlank()) {
                         _status.value = TranslationStatus.Error(context.getString(com.metrolist.music.R.string.ai_error_api_key_required))
                         return@launch
                     }
@@ -299,6 +301,12 @@ object LyricsTranslationHelper {
                                 model = model,
                                 mode = mode,
                                 customSystemPrompt = systemPrompt,
+                            )
+                        } else if (provider == "Google") {
+                            Timber.d("Using Google Translate for translation")
+                            GoogleTranslateService.translate(
+                                text = fullText,
+                                targetLanguage = targetLanguage,
                             )
                         } else if (useStreaming && provider != "Custom") {
                             Timber.d("Using streaming for translation with provider: $provider")

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AiSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AiSettings.kt
@@ -84,6 +84,7 @@ fun AiSettings(navController: NavController) {
             "XAi" to "https://api.x.ai/v1/chat/completions",
             "Mistral" to "https://api.mistral.ai/v1/chat/completions",
             "DeepL" to "https://api.deepl.com/v2/translate",
+            "Google" to "",
             "Custom" to "",
         )
 
@@ -97,6 +98,7 @@ fun AiSettings(navController: NavController) {
             "XAi" to stringResource(R.string.ai_provider_xai_help),
             "Mistral" to stringResource(R.string.ai_provider_mistral_help),
             "DeepL" to stringResource(R.string.ai_provider_deepl_help),
+            "Google" to "Uses translate.googleapis.com (no API key required).",
             "Custom" to "",
         )
 
@@ -153,6 +155,7 @@ fun AiSettings(navController: NavController) {
                     "mistral-tiny-latest",
                 ),
             "DeepL" to listOf(),
+            "Google" to listOf(),
             "Custom" to listOf(),
         )
 
@@ -279,7 +282,7 @@ fun AiSettings(navController: NavController) {
             onDismiss = { showProviderDialog = false },
             onSelect = {
                 aiProvider = it
-                if (it != "Custom" && it != "DeepL") {
+                if (it != "Custom" && it != "DeepL" && it != "Google") {
                     openRouterBaseUrl = aiProviders[it] ?: ""
                 } else {
                     openRouterBaseUrl = ""
@@ -555,6 +558,15 @@ fun AiSettings(navController: NavController) {
                                 onClick = { showDeeplFormalityDialog = true },
                             ),
                         )
+                    } else if (aiProvider == "Google") {
+                        add(
+                            Material3SettingsItem(
+                                icon = painterResource(R.drawable.translate),
+                                title = { Text(stringResource(R.string.ai_api_key)) },
+                                description = { Text("Not required") },
+                                onClick = {},
+                            ),
+                        )
                     } else {
                         add(
                             Material3SettingsItem(
@@ -590,7 +602,7 @@ fun AiSettings(navController: NavController) {
             title = stringResource(R.string.ai_translation_mode),
             items =
                 buildList {
-                    if (aiProvider != "DeepL") {
+                    if (aiProvider != "DeepL" && aiProvider != "Google") {
                         add(
                             Material3SettingsItem(
                                 icon = painterResource(R.drawable.translate),


### PR DESCRIPTION
Add a Google Translate provider option that works without API keys and wire it into the lyrics translation flow and AI settings UI.

not tested


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Translate as a new lyrics translation provider option.
  * Google Translate integration requires no API key configuration, simplifying setup compared to other providers.
  * Users can select Google Translate from provider settings and configure target language preferences for translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->