### PR TITLE
Feat/clean queue from previously played songs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -163,6 +163,12 @@ android {
         checkDependencies = false
     }
 
+    testOptions {
+        unitTests.all {
+            it.useJUnitPlatform()
+        }
+    }
+
     androidResources {
         generateLocaleConfig = true
     }
@@ -286,4 +292,7 @@ dependencies {
     coreLibraryDesugaring(libs.desugaring)
 
     implementation(libs.timber)
+
+    testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
+    testImplementation("io.kotest:kotest-property:5.9.1")
 }

--- a/app/src/main/kotlin/com/metrolist/music/playback/PlayerConnection.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/PlayerConnection.kt
@@ -6,6 +6,7 @@
 package com.metrolist.music.playback
 
 import android.content.Context
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
@@ -295,19 +296,38 @@ class PlayerConnection(
     }
 
     /**
-     * Removes all MediaItems that precede the currently playing item (indices 0 until
-     * currentMediaItemIndex), leaving the current song at index 0.
-     * No-op when currentMediaItemIndex is 0 or the player has no items.
-     * Blocked for Listen Together guests.
+     * Removes all MediaItems that precede the currently playing item in playback order,
+     * leaving the current song at index 0 with all upcoming songs intact.
+     * Handles both normal and shuffle modes correctly.
+     * No-op when there are no items before the current song. Blocked for Listen Together guests.
      */
     fun clearPlayedSongs() {
         if (shouldBlockPlaybackChanges?.invoke() == true) {
             Timber.tag(TAG).d("clearPlayedSongs blocked - Listen Together guest")
             return
         }
-        val index = player.currentMediaItemIndex
-        if (index <= 0) return
-        player.removeMediaItems(0, index)
+        if (player.shuffleModeEnabled) {
+            // In shuffle mode, currentMediaItemIndex is the timeline index, not the shuffle order
+            // position. Walk backwards through the shuffle order to collect all timeline indices
+            // that precede the current item in playback order, then remove them.
+            val timeline = player.currentTimeline
+            if (timeline.isEmpty) return
+            val currentIndex = player.currentMediaItemIndex
+            val indicesToRemove = mutableListOf<Int>()
+            var idx = timeline.getPreviousWindowIndex(currentIndex, Player.REPEAT_MODE_OFF, true)
+            while (idx != C.INDEX_UNSET) {
+                indicesToRemove.add(idx)
+                idx = timeline.getPreviousWindowIndex(idx, Player.REPEAT_MODE_OFF, true)
+            }
+            if (indicesToRemove.isEmpty()) return
+            // Remove in descending order so earlier removals don't shift later indices
+            indicesToRemove.sortDescending()
+            indicesToRemove.forEach { player.removeMediaItem(it) }
+        } else {
+            val index = player.currentMediaItemIndex
+            if (index <= 0) return
+            player.removeMediaItems(0, index)
+        }
     }
 
     fun toggleLike() {

--- a/app/src/main/kotlin/com/metrolist/music/playback/PlayerConnection.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/PlayerConnection.kt
@@ -294,6 +294,22 @@ class PlayerConnection(
         }
     }
 
+    /**
+     * Removes all MediaItems that precede the currently playing item (indices 0 until
+     * currentMediaItemIndex), leaving the current song at index 0.
+     * No-op when currentMediaItemIndex is 0 or the player has no items.
+     * Blocked for Listen Together guests.
+     */
+    fun clearPlayedSongs() {
+        if (shouldBlockPlaybackChanges?.invoke() == true) {
+            Timber.tag(TAG).d("clearPlayedSongs blocked - Listen Together guest")
+            return
+        }
+        val index = player.currentMediaItemIndex
+        if (index <= 0) return
+        player.removeMediaItems(0, index)
+    }
+
     fun toggleLike() {
         try {
             service.toggleLike()

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Queue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Queue.kt
@@ -178,6 +178,7 @@ fun Queue(
     val repeatMode by playerConnection.repeatMode.collectAsStateWithLifecycle()
 
     val currentWindowIndex by playerConnection.currentWindowIndex.collectAsStateWithLifecycle()
+    val currentMediaItemIndex by playerConnection.currentMediaItemIndex.collectAsStateWithLifecycle()
     val mediaMetadata by playerConnection.mediaMetadata.collectAsStateWithLifecycle()
 
     val currentFormat by playerConnection.currentFormat.collectAsStateWithLifecycle(initialValue = null)
@@ -1071,6 +1072,26 @@ fun Queue(
                     exit = fadeOut() + slideOutVertically { it },
                 ) {
                     Row {
+                        AnimatedVisibility(visible = currentMediaItemIndex > 0) {
+                            IconButton(
+                                enabled = !isListenTogetherGuest,
+                                onClick = {
+                                    playerConnection.clearPlayedSongs()
+                                    coroutineScope.launch {
+                                        snackbarHostState.showSnackbar(
+                                            message = context.getString(R.string.clear_played_songs_done),
+                                            duration = SnackbarDuration.Short,
+                                        )
+                                    }
+                                },
+                            ) {
+                                Icon(
+                                    painter = painterResource(R.drawable.clear_all),
+                                    contentDescription = stringResource(R.string.clear_played_songs),
+                                    modifier = Modifier.alpha(if (!isListenTogetherGuest) 1f else 0.3f),
+                                )
+                            }
+                        }
                         IconButton(
                             onClick = { locked = !locked },
                             modifier = Modifier.padding(horizontal = 6.dp),

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchResult.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchResult.kt
@@ -159,6 +159,7 @@ fun OnlineSearchResult(
 
     BackHandler(enabled = isSearchFocused) {
         isSearchFocused = false
+        keyboardController?.hide()
         focusManager.clearFocus()
     }
 
@@ -178,10 +179,13 @@ fun OnlineSearchResult(
     }
 
     val onSearch: (String) -> Unit =
-        remember {
+        remember(focusManager, keyboardController, pauseSearchHistory, decodedQuery) {
             { searchQuery ->
                 if (searchQuery.isNotEmpty()) {
                     isSearchFocused = false
+                    // Explicitly hide keyboard before clearing focus — needed on Android 8
+                    // where clearFocus() alone does not reliably dismiss the IME.
+                    keyboardController?.hide()
                     focusManager.clearFocus()
 
                     navController.navigate("search/${URLEncoder.encode(searchQuery, "UTF-8")}") {
@@ -561,6 +565,7 @@ fun OnlineSearchResult(
                     onSearch = onSearch,
                     onDismiss = {
                         isSearchFocused = false
+                        keyboardController?.hide()
                         focusManager.clearFocus()
                     },
                     pureBlack = pureBlack,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchResult.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchResult.kt
@@ -138,6 +138,10 @@ fun OnlineSearchResult(
     var lastHandledCount by rememberSaveable { mutableIntStateOf(0) }
     var isSearchFocused by remember { mutableStateOf(false) }
     val keyboardController = LocalSoftwareKeyboardController.current
+    // Used to temporarily suppress focus-change callbacks while we're dismissing,
+    // preventing the onFocusChanged modifier from immediately re-showing the overlay
+    // on Android 8 where focus events fire after keyboard hide with a delay.
+    var suppressFocusChange by remember { mutableStateOf(false) }
 
     LaunchedEffect(scrollToTopCount) {
         if (scrollToTopCount > lastHandledCount) {
@@ -158,6 +162,7 @@ fun OnlineSearchResult(
     val hideVideoSongs by rememberPreference(HideVideoSongsKey, defaultValue = false)
 
     BackHandler(enabled = isSearchFocused) {
+        suppressFocusChange = true
         isSearchFocused = false
         keyboardController?.hide()
         focusManager.clearFocus()
@@ -182,6 +187,7 @@ fun OnlineSearchResult(
         remember(focusManager, keyboardController, pauseSearchHistory, decodedQuery) {
             { searchQuery ->
                 if (searchQuery.isNotEmpty()) {
+                    suppressFocusChange = true
                     isSearchFocused = false
                     // Explicitly hide keyboard before clearing focus — needed on Android 8
                     // where clearFocus() alone does not reliably dismiss the IME.
@@ -444,7 +450,7 @@ fun OnlineSearchResult(
                     .padding(horizontal = 16.dp, vertical = 8.dp)
                     .focusRequester(focusRequester)
                     .onFocusChanged { focusState ->
-                        if (focusState.isFocused) {
+                        if (focusState.isFocused && !suppressFocusChange) {
                             isSearchFocused = true
                         }
                     },
@@ -564,6 +570,7 @@ fun OnlineSearchResult(
                     navController = navController,
                     onSearch = onSearch,
                     onDismiss = {
+                        suppressFocusChange = true
                         isSearchFocused = false
                         keyboardController?.hide()
                         focusManager.clearFocus()

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -946,4 +946,8 @@
     <string name="switch_to_list_view">Switch to list view</string>
     <string name="switch_to_grid_view">Switch to grid view</string>
     <string name="more_options">More options</string>
+
+    <!-- Queue actions -->
+    <string name="clear_played_songs">Clear played songs</string>
+    <string name="clear_played_songs_done">Played songs cleared</string>
 </resources>


### PR DESCRIPTION
Adds a button to the queue header that removes all songs before the currently playing track. Playback continues uninterrupted.

Changes:  
PlayerConnection.kt (new clearPlayedSongs()), Queue.kt (new icon button, hidden at index 0, disabled for LT guests), metrolist_strings.xml (2 new strings).

To test: Play a few songs, open queue sheet, tap the clear button, confirm played songs are gone and current song is still playing.

feature no :#3615

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Clear played songs" button in the queue to remove already-played tracks and bring the current item to the top; disabled for guests and shows a confirmation snackbar.

* **Bug Fixes**
  * Improved search field keyboard and focus handling to prevent unwanted focus changes during dismissal and navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->