### PR TITLE
fix(ui): currently playing tv navigation

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/BottomSheet.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/BottomSheet.kt
@@ -13,6 +13,7 @@ import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.SpringSpec
 import androidx.compose.animation.core.VectorConverter
 import androidx.compose.animation.core.spring
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.DraggableState
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
@@ -137,7 +138,9 @@ fun BottomSheet(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null,
                         onClick = { if (isExpandable) state.expandSoft() },
-                    ).fillMaxWidth()
+                    )
+                    .focusable(false)
+                    .fillMaxWidth()
                     .height(state.collapsedBound),
                 content = collapsedContent,
             )

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
@@ -21,6 +21,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -142,6 +144,7 @@ fun MiniPlayer(
     positionState: MutableLongState,
     durationState: MutableLongState,
     modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
 ) {
     val useNewMiniPlayerDesign by rememberPreference(UseNewMiniPlayerDesignKey, true)
 
@@ -152,12 +155,14 @@ fun MiniPlayer(
         NewMiniPlayer(
             progressState = progressState,
             modifier = modifier,
+            onClick = onClick,
         )
     } else {
         Box(modifier = modifier.fillMaxWidth()) {
             LegacyMiniPlayer(
                 progressState = progressState,
                 modifier = Modifier.align(Alignment.Center),
+                onClick = onClick,
             )
         }
     }
@@ -171,6 +176,7 @@ fun MiniPlayer(
 private fun NewMiniPlayer(
     progressState: ProgressState,
     modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
 ) {
     val playerConnection = LocalPlayerConnection.current ?: return
     val menuState = LocalMenuState.current
@@ -367,6 +373,7 @@ private fun NewMiniPlayer(
                     }
                 },
     ) {
+        val interactionSource = remember { MutableInteractionSource() }
         Box(
             modifier =
                 Modifier
@@ -375,7 +382,12 @@ private fun NewMiniPlayer(
                     .offset { IntOffset(offsetXAnimatable.value.roundToInt(), 0) }
                     .clip(RoundedCornerShape(32.dp))
                     .background(color = backgroundColor)
-                    .border(1.dp, outlineColor.copy(alpha = 0.3f), RoundedCornerShape(32.dp)),
+                    .border(1.dp, outlineColor.copy(alpha = 0.3f), RoundedCornerShape(32.dp))
+                    .clickable(
+                        interactionSource = interactionSource,
+                        indication = LocalIndication.current,
+                        onClick = onClick
+                    ),
         ) {
             when (miniPlayerBackground) {
                 MiniPlayerBackgroundStyle.BLUR -> {
@@ -691,6 +703,7 @@ private fun NewMiniPlayerSongInfo(
 private fun LegacyMiniPlayer(
     progressState: ProgressState,
     modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
 ) {
     val playerConnection = LocalPlayerConnection.current ?: return
     val pureBlack by rememberPreference(PureBlackMiniPlayerKey, defaultValue = false)
@@ -746,6 +759,8 @@ private fun LegacyMiniPlayer(
     val primaryColor = MaterialTheme.colorScheme.primary
     val trackColor = MaterialTheme.colorScheme.surfaceVariant
 
+    val interactionSource = remember { MutableInteractionSource() }
+
     Box(
         modifier =
             modifier
@@ -759,6 +774,10 @@ private fun LegacyMiniPlayer(
                     } else {
                         MaterialTheme.colorScheme.surfaceContainer
                     },
+                ).clickable(
+                    interactionSource = interactionSource,
+                    indication = LocalIndication.current,
+                    onClick = onClick
                 ).let { baseModifier ->
                     if (swipeThumbnail) {
                         baseModifier.pointerInput(Unit) {

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
@@ -109,6 +109,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.DialogProperties
@@ -343,6 +345,19 @@ fun BottomSheetPlayer(
     val castPosition by castHandler?.castPosition?.collectAsStateWithLifecycle() ?: remember { mutableLongStateOf(0L) }
     val castDuration by castHandler?.castDuration?.collectAsStateWithLifecycle() ?: remember { mutableLongStateOf(0L) }
     val castIsPlaying by castHandler?.castIsPlaying?.collectAsStateWithLifecycle() ?: remember { mutableStateOf(false) }
+
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(state.isExpanded) {
+        if (state.isExpanded) {
+            delay(100)
+            try {
+                focusRequester.requestFocus()
+            } catch (e: Exception) {
+                // Ignore if focus request fails
+            }
+        }
+    }
 
     // Use Cast state when casting, otherwise local player
     val effectiveIsPlaying = if (isCasting) castIsPlaying else isPlaying
@@ -881,6 +896,7 @@ fun BottomSheetPlayer(
             MiniPlayer(
                 positionState = positionState,
                 durationState = durationState,
+                onClick = { state.expandSoft() },
             )
         },
     ) {
@@ -1590,7 +1606,8 @@ fun BottomSheetPlayer(
                                 modifier =
                                     Modifier
                                         .height(68.dp)
-                                        .weight(playPauseWeight),
+                                        .weight(playPauseWeight)
+                                        .focusRequester(focusRequester),
                             ) {
                                 Row(
                                     verticalAlignment = Alignment.CenterVertically,
@@ -1719,7 +1736,8 @@ fun BottomSheetPlayer(
                                             } else {
                                                 playerConnection.player.togglePlayPause()
                                             }
-                                        },
+                                        }
+                                        .focusRequester(focusRequester),
                             ) {
                                 Image(
                                     painter =


### PR DESCRIPTION
Fixes https://github.com/MetrolistGroup/Metrolist/issues/572

## Problem
The MiniPlayer cannot be focused or expanded using the D-pad on Android TV, and the full player does not auto-focus controls when opened.

## Cause
Missing clickable modifiers on MiniPlayer components and a lack of focus management during the player opening transition.

## Solution
- Added clickable support and onClick logic to both MiniPlayer designs.
- Integrated FocusRequester to automatically target the Play/Pause button when the player expands.
- Set the collapsed BottomSheet area to non-focusable.

## Testing
Tested working on Android TV 14 and Android 16 (no noticeable change on phones)

## Related Issues
- Closes #572 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mini player is now clickable, allowing direct expansion to the full player interface.

* **Improvements**
  * Enhanced focus management for improved keyboard navigation when expanding the player.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->