### PR TITLE
fix(notification): prevent cancel action duplication in download notification

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/ExoDownloadService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/ExoDownloadService.kt
@@ -50,18 +50,22 @@ class ExoDownloadService : DownloadService(
     override fun getForegroundNotification(
         downloads: MutableList<Download>,
         notMetRequirements: Int
-    ): Notification =
-        Notification.Builder.recoverBuilder(
-            this, downloadUtil.downloadNotificationHelper.buildProgressNotification(
+    ): Notification {
+        val progressNotification =
+            downloadUtil.downloadNotificationHelper.buildProgressNotification(
                 this,
                 R.drawable.download,
                 null,
-                if (downloads.size == 1) Util.fromUtf8Bytes(downloads[0].request.data)
-                else resources.getQuantityString(R.plurals.n_song, downloads.size, downloads.size),
+                if (downloads.size == 1) {
+                    Util.fromUtf8Bytes(downloads[0].request.data)
+                } else {
+                    resources.getQuantityString(R.plurals.n_song, downloads.size, downloads.size)
+                },
                 downloads,
                 notMetRequirements
             )
-        ).addAction(
+
+        val cancelAction =
             Notification.Action.Builder(
                 Icon.createWithResource(this, R.drawable.close),
                 getString(android.R.string.cancel),
@@ -74,7 +78,11 @@ class ExoDownloadService : DownloadService(
                     PendingIntent.FLAG_IMMUTABLE
                 )
             ).build()
-        ).build()
+
+        return Notification.Builder.recoverBuilder(this, progressNotification)
+            .setActions(cancelAction)
+            .build()
+    }
 
 
     /**


### PR DESCRIPTION
## Problem
The cancel button in the download foreground notification multiplies itself on each update (e.g., "cancel", "cancel cancel", "cancel cancel cancel").

## Cause
`getForegroundNotification()` in `ExoDownloadService` calls `addAction()` on a reused `Notification.Builder`. `DownloadService` calls `getForegroundNotification()` every second via its `ForegroundNotificationUpdater`. Each call adds another cancel action on top of the existing ones, causing the label to repeat.

## Solution
- Build the base progress notification first, then use `setActions()` (which replaces all actions) instead of `addAction()` (which accumulates)
- Behavior unchanged (cancel removes all pending downloads)

## Testing
- Tried on emulator and S25 fixed fine.

## Related Issues
- Related to Thread id 1497149279859376149 on discord.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal notification handling for improved code structure and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->