### PR TITLE
fix(player): add age-restricted playback error string resource

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/player/PlaybackError.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/PlaybackError.kt
@@ -54,7 +54,7 @@ fun PlaybackError(
             error.errorCode == PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS
     
     val errorMessage = if (isAgeRestricted) {
-        "This app does not support playing age-restricted songs. We are working on fixing this issue."
+        stringResource(R.string.error_age_restricted)
     } else {
         rawErrorMessage
     }

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -537,6 +537,7 @@
 
     <!-- Playback errors -->
     <string name="error_playback_failed">Playback failed</string>
+    <string name="error_age_restricted">This app does not support playing age-restricted songs. We are working on fixing this issue.</string>
     <string name="error_episode_save">Failed to save episode</string>
     <string name="error_episode_remove">Failed to remove episode</string>
     <string name="error_podcast_subscribe">Failed to subscribe to podcast</string>


### PR DESCRIPTION
## Problem
PlaybackError.kt now references R.string.error_age_restricted, but metrolist_strings.xml did not define that string resource.

## Cause
The playback error message was moved to resources without adding the corresponding error_age_restricted entry.

## Solution
<!-- List the changes made to fix the issue -->
- Added stringResource(R.string.error_age_restricted) usage in PlaybackError.kt
- Added <string name="error_age_restricted">This app does not support playing age-restricted songs. We are working on fixing this issue.</string> to metrolist_strings.xml

## Testing
- ./gradlew :app:assembleFossDebug passed successfully
- Confirmed metrolist_strings.xml is syntactically valid and contains the error_age_restricted string resource with correct text.
- Code Reference Validation: Verified PlaybackError.kt line 57 contains stringResource(R.string.error_age_restricted) and the resource name follows Android naming conventions.

## Related Issues
<!-- List any related issues or PRs -->
- Closes #
- Related to #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for age-restricted content with proper localization support across different languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->