### PR TITLE
fix(playlists): background playlist adds with progress handling

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
@@ -60,12 +60,14 @@ import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconToggleButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.foundation.layout.FlowRow
@@ -75,6 +77,7 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.material3.FilterChipDefaults
 import com.metrolist.music.LocalSyncUtils
+import com.metrolist.music.utils.BackgroundPlaylistAddManager
 
 @Composable
 fun AddToPlaylistDialog(
@@ -122,18 +125,8 @@ fun AddToPlaylistDialog(
         mutableStateOf<Set<String>>(emptySet())
     }
 
-    suspend fun addSongsAndSync(targetPlaylist: Playlist, ids: List<String>) {
-        database.addSongsToPlaylist(targetPlaylist, ids.map { it to null }, prepend = true)
-        targetPlaylist.playlist.browseId?.let { plist ->
-            ids.forEach { songId ->
-                syncUtils.registerPendingAdd(plist, songId)
-                try {
-                    YouTube.addToPlaylist(plist, songId)
-                } finally {
-                    syncUtils.unregisterPendingAdd(plist, songId)
-                }
-            }
-        }
+    fun addSongsInBackground(targetPlaylist: Playlist, ids: List<String>) {
+        BackgroundPlaylistAddManager.start(database, syncUtils, targetPlaylist, ids)
     }
 
     LaunchedEffect(isVisible, playlists.isEmpty()) {
@@ -310,7 +303,7 @@ fun AddToPlaylistDialog(
                                 showDuplicateDialog = true
                             } else {
                                 onDismiss()
-                                addSongsAndSync(playlist, songIds!!)
+                                addSongsInBackground(playlist, songIds!!)
                             }
                         }
                     }
@@ -337,7 +330,7 @@ fun AddToPlaylistDialog(
                             showDuplicateDialog = false
                             onDismiss()
                             coroutineScope.launch(Dispatchers.IO) {
-                                addSongsAndSync(
+                                addSongsInBackground(
                                     selectedPlaylist!!,
                                     songIds!!.filter { !duplicates.contains(it) }
                                 )
@@ -352,7 +345,7 @@ fun AddToPlaylistDialog(
                             showDuplicateDialog = false
                             onDismiss()
                             coroutineScope.launch(Dispatchers.IO) {
-                                addSongsAndSync(selectedPlaylist!!, songIds!!)
+                                addSongsInBackground(selectedPlaylist!!, songIds!!)
                             }
                         }
                     ) {
@@ -382,4 +375,58 @@ fun AddToPlaylistDialog(
                 )
             }
         }
+
+    PlaylistAddProgressDialog()
+}
+
+@Composable
+private fun PlaylistAddProgressDialog() {
+    val state by BackgroundPlaylistAddManager.state.collectAsStateWithLifecycle()
+    if (!state.isVisible) return
+
+    DefaultDialog(
+        title = { Text(stringResource(R.string.adding_songs_to_playlist)) },
+        buttons = {
+            if (state.isRunning) {
+                TextButton(
+                    onClick = BackgroundPlaylistAddManager::cancel,
+                    enabled = !state.isCancelling,
+                ) {
+                    Text(stringResource(R.string.stop))
+                }
+                TextButton(onClick = BackgroundPlaylistAddManager::hide) {
+                    Text(stringResource(R.string.hide))
+                }
+            } else {
+                TextButton(onClick = BackgroundPlaylistAddManager::dismissFinished) {
+                    Text(stringResource(R.string.close))
+                }
+            }
+        },
+        onDismiss = {
+            if (state.isRunning) {
+                BackgroundPlaylistAddManager.hide()
+            } else {
+                BackgroundPlaylistAddManager.dismissFinished()
+            }
+        }
+    ) {
+        Column {
+            Text(
+                text = stringResource(
+                    R.string.add_playlist_progress,
+                    state.completed,
+                    state.total,
+                    state.playlistName,
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            LinearProgressIndicator(
+                progress = { state.progress },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp),
+            )
+        }
+    }
 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
@@ -85,6 +85,7 @@ fun AddToPlaylistDialog(
     allowSyncing: Boolean = true,
     initialTextFieldValue: String? = null,
     onGetSong: suspend (Playlist) -> List<String>, // list of song ids. Songs should be inserted to database in this function.
+    onSyncToRemotePlaylist: (suspend (Playlist, List<String>) -> Result<Unit>)? = null,
     onGetSongIds: (suspend () -> List<String>)? = null,
     onDismiss: () -> Unit,
     viewModel: PlaylistsViewModel = hiltViewModel()
@@ -126,7 +127,13 @@ fun AddToPlaylistDialog(
     }
 
     fun addSongsInBackground(targetPlaylist: Playlist, ids: List<String>) {
-        BackgroundPlaylistAddManager.start(database, syncUtils, targetPlaylist, ids)
+        BackgroundPlaylistAddManager.start(
+            database = database,
+            syncUtils = syncUtils,
+            playlist = targetPlaylist,
+            songIds = ids,
+            syncToRemotePlaylist = onSyncToRemotePlaylist,
+        )
     }
 
     LaunchedEffect(isVisible, playlists.isEmpty()) {

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
@@ -413,12 +413,22 @@ private fun PlaylistAddProgressDialog() {
     ) {
         Column {
             Text(
-                text = stringResource(
-                    R.string.add_playlist_progress,
-                    state.completed,
-                    state.total,
-                    state.playlistName,
-                ),
+                text = if (state.failed > 0) {
+                    stringResource(
+                        R.string.add_playlist_progress_with_failures,
+                        state.completed,
+                        state.total,
+                        state.failed,
+                        state.playlistName,
+                    )
+                } else {
+                    stringResource(
+                        R.string.add_playlist_progress,
+                        state.completed,
+                        state.total,
+                        state.playlistName,
+                    )
+                },
                 style = MaterialTheme.typography.bodyMedium,
             )
             LinearProgressIndicator(

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
@@ -174,14 +174,7 @@ fun AlbumMenu(
 
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
-        onGetSong = { playlist ->
-            coroutineScope.launch(Dispatchers.IO) {
-                playlist.playlist.browseId?.let { playlistId ->
-                    album.album.playlistId?.let { addPlaylistId ->
-                        YouTube.addPlaylistToPlaylist(playlistId, addPlaylistId)
-                    }
-                }
-            }
+        onGetSong = {
             songs.map { it.id }
         },
         onGetSongIds = { songs.map { it.id } },

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
@@ -177,6 +177,11 @@ fun AlbumMenu(
         onGetSong = {
             songs.map { it.id }
         },
+        onSyncToRemotePlaylist = sync@{ playlist, _ ->
+            val targetBrowseId = playlist.playlist.browseId ?: return@sync Result.success(Unit)
+            val sourcePlaylistId = album.album.playlistId ?: return@sync Result.success(Unit)
+            YouTube.addPlaylistToPlaylist(targetBrowseId, sourcePlaylistId).map { Unit }
+        },
         onGetSongIds = { songs.map { it.id } },
         onDismiss = {
             showChoosePlaylistDialog = false

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
@@ -171,9 +171,6 @@ fun PlayerMenu(
             database.withTransaction {
                 insert(mediaMetadata)
             }
-            coroutineScope.launch(Dispatchers.IO) {
-                playlist.playlist.browseId?.let { YouTube.addToPlaylist(it, mediaMetadata.id) }
-            }
             listOf(mediaMetadata.id)
         },
         onGetSongIds = { listOf(mediaMetadata.id) },

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/QueueMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/QueueMenu.kt
@@ -121,9 +121,6 @@ fun QueueMenu(
             database.withTransaction {
                 insert(mediaMetadata)
             }
-            coroutineScope.launch(Dispatchers.IO) {
-                playlist.playlist.browseId?.let { YouTube.addToPlaylist(it, mediaMetadata.id) }
-            }
             listOf(mediaMetadata.id)
         },
         onGetSongIds = { listOf(mediaMetadata.id) },

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/SelectionSongsMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/SelectionSongsMenu.kt
@@ -139,14 +139,7 @@ fun SelectionSongMenu(
 
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
-        onGetSong = { playlist ->
-            coroutineScope.launch(Dispatchers.IO) {
-                songSelection.forEach { song ->
-                    playlist.playlist.browseId?.let { browseId ->
-                        YouTube.addToPlaylist(browseId, song.id)
-                    }
-                }
-            }
+        onGetSong = {
             songSelection.map { it.id }
         },
         onGetSongIds = { songSelection.map { it.id } },

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
@@ -237,12 +237,7 @@ fun SongMenu(
 
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
-        onGetSong = { playlist ->
-            coroutineScope.launch(Dispatchers.IO) {
-                playlist.playlist.browseId?.let { browseId ->
-                    YouTube.addToPlaylist(browseId, song.id)
-                }
-            }
+        onGetSong = {
             listOf(song.id)
         },
         onGetSongIds = { listOf(song.id) },

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
@@ -153,14 +153,7 @@ fun YouTubeAlbumMenu(
 
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
-        onGetSong = { playlist ->
-            coroutineScope.launch(Dispatchers.IO) {
-                playlist.playlist.browseId?.let { playlistId ->
-                    album?.album?.playlistId?.let { addPlaylistId ->
-                        YouTube.addPlaylistToPlaylist(playlistId, addPlaylistId)
-                    }
-                }
-            }
+        onGetSong = {
             album?.songs?.map { it.id }.orEmpty()
         },
         onGetSongIds = { album?.songs?.map { it.id }.orEmpty() },

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
@@ -156,6 +156,11 @@ fun YouTubeAlbumMenu(
         onGetSong = {
             album?.songs?.map { it.id }.orEmpty()
         },
+        onSyncToRemotePlaylist = sync@{ playlist, _ ->
+            val targetBrowseId = playlist.playlist.browseId ?: return@sync Result.success(Unit)
+            val sourcePlaylistId = album?.album?.playlistId ?: return@sync Result.success(Unit)
+            YouTube.addPlaylistToPlaylist(targetBrowseId, sourcePlaylistId).map { Unit }
+        },
         onGetSongIds = { album?.songs?.map { it.id }.orEmpty() },
         onDismiss = { showChoosePlaylistDialog = false }
     )

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubePlaylistMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubePlaylistMenu.kt
@@ -144,6 +144,10 @@ fun YouTubePlaylistMenu(
             }
             allSongs.map { it.id }
         },
+        onSyncToRemotePlaylist = sync@{ targetPlaylist, _ ->
+            val targetBrowseId = targetPlaylist.playlist.browseId ?: return@sync Result.success(Unit)
+            YouTube.addPlaylistToPlaylist(targetBrowseId, playlist.id).map { Unit }
+        },
         onGetSongIds = {
             songs.map { it.id }
         },

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubePlaylistMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubePlaylistMenu.kt
@@ -142,11 +142,6 @@ fun YouTubePlaylistMenu(
             database.withTransaction {
                 allSongs.forEach(::insert)
             }
-            coroutineScope.launch(Dispatchers.IO) {
-                targetPlaylist.playlist.browseId?.let { playlistId ->
-                    YouTube.addPlaylistToPlaylist(playlistId, targetPlaylist.id)
-                }
-            }
             allSongs.map { it.id }
         },
         onGetSongIds = {

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSongMenu.kt
@@ -127,11 +127,6 @@ fun YouTubeSongMenu(
             database.withTransaction {
                 insert(song.toMediaMetadata())
             }
-            coroutineScope.launch(Dispatchers.IO) {
-                playlist.playlist.browseId?.let { browseId ->
-                    YouTube.addToPlaylist(browseId, song.id)
-                }
-            }
             listOf(song.id)
         },
         onGetSongIds = { listOf(song.id) },

--- a/app/src/main/kotlin/com/metrolist/music/utils/BackgroundPlaylistAddManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/BackgroundPlaylistAddManager.kt
@@ -32,12 +32,13 @@ data class PlaylistAddProgressState(
     val playlistName: String = "",
     val total: Int = 0,
     val completed: Int = 0,
+    val failed: Int = 0,
     val isRunning: Boolean = false,
     val isVisible: Boolean = false,
     val isCancelling: Boolean = false,
 ) {
     val progress: Float
-        get() = if (total == 0) 0f else completed.toFloat() / total
+        get() = if (total == 0) 0f else (completed + failed).toFloat() / total
 }
 
 /**
@@ -109,10 +110,9 @@ object BackgroundPlaylistAddManager {
         playlist: Playlist,
         songIds: List<String>,
     ) {
-        var completedSuccessfully = false
         try {
             if (songIds.isEmpty()) {
-                completedSuccessfully = true
+                _state.value = _state.value.copy(isVisible = false)
                 return
             }
 
@@ -120,7 +120,7 @@ object BackgroundPlaylistAddManager {
             val browseId = playlist.playlist.browseId
             if (browseId == null) {
                 _state.value = _state.value.copy(completed = songIds.size)
-                completedSuccessfully = true
+                _state.value = _state.value.copy(isVisible = false)
                 return
             }
 
@@ -128,22 +128,28 @@ object BackgroundPlaylistAddManager {
                 currentCoroutineContext().ensureActive()
                 syncUtils.registerPendingAdd(browseId, songId)
                 try {
-                    YouTube.addToPlaylist(browseId, songId).getOrThrow()
-                    _state.update { it.copy(completed = it.completed + 1) }
+                    val result = YouTube.addToPlaylist(browseId, songId)
+                    if (result.isSuccess) {
+                        _state.update { it.copy(completed = it.completed + 1) }
+                    } else {
+                        _state.update { it.copy(failed = it.failed + 1) }
+                        Timber.e(result.exceptionOrNull(), "Failed to add song %s to playlist", songId)
+                    }
                 } finally {
                     syncUtils.unregisterPendingAdd(browseId, songId)
                 }
             }
-            completedSuccessfully = true
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             Timber.e(e, "Failed to add songs to playlist")
         } finally {
+            val currentState = _state.value
+            val completedSuccessfully = currentState.failed == 0
             _state.value = _state.value.copy(
                 isRunning = false,
                 isCancelling = false,
-                isVisible = if (completedSuccessfully) false else _state.value.isVisible,
+                isVisible = if (completedSuccessfully) false else currentState.isVisible,
             )
         }
     }

--- a/app/src/main/kotlin/com/metrolist/music/utils/BackgroundPlaylistAddManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/BackgroundPlaylistAddManager.kt
@@ -147,6 +147,10 @@ object BackgroundPlaylistAddManager {
             throw e
         } catch (e: Exception) {
             Timber.e(e, "Failed to add songs to playlist")
+            _state.update {
+                val unprocessed = (it.total - it.completed - it.failed).coerceAtLeast(0)
+                it.copy(failed = it.failed + unprocessed)
+            }
         } finally {
             _state.update { currentState ->
                 val completedSuccessfully = currentState.failed == 0

--- a/app/src/main/kotlin/com/metrolist/music/utils/BackgroundPlaylistAddManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/BackgroundPlaylistAddManager.kt
@@ -50,7 +50,7 @@ object BackgroundPlaylistAddManager {
         scope.launch {
             currentJob?.cancelAndJoin()
             _state.value = PlaylistAddProgressState(
-                playlistName = playlist.name,
+                playlistName = playlist.title,
                 total = songIds.size,
                 isRunning = true,
                 isVisible = true,

--- a/app/src/main/kotlin/com/metrolist/music/utils/BackgroundPlaylistAddManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/BackgroundPlaylistAddManager.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -101,11 +102,11 @@ object BackgroundPlaylistAddManager {
                 currentCoroutineContext().ensureActive()
                 syncUtils.registerPendingAdd(browseId, songId)
                 try {
-                    YouTube.addToPlaylist(browseId, songId)
+                    YouTube.addToPlaylist(browseId, songId).getOrThrow()
+                    _state.update { it.copy(completed = it.completed + 1) }
                 } finally {
                     syncUtils.unregisterPendingAdd(browseId, songId)
                 }
-                _state.value = _state.value.copy(completed = _state.value.completed + 1)
             }
             completedSuccessfully = true
         } catch (e: CancellationException) {

--- a/app/src/main/kotlin/com/metrolist/music/utils/BackgroundPlaylistAddManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/BackgroundPlaylistAddManager.kt
@@ -1,0 +1,113 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.utils
+
+import com.metrolist.innertube.YouTube
+import com.metrolist.music.db.MusicDatabase
+import com.metrolist.music.db.entities.Playlist
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+data class PlaylistAddProgressState(
+    val playlistName: String = "",
+    val total: Int = 0,
+    val completed: Int = 0,
+    val isRunning: Boolean = false,
+    val isVisible: Boolean = false,
+    val isCancelling: Boolean = false,
+) {
+    val progress: Float
+        get() = if (total == 0) 0f else completed.toFloat() / total
+}
+
+object BackgroundPlaylistAddManager {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val _state = MutableStateFlow(PlaylistAddProgressState())
+    private var currentJob: Job? = null
+
+    val state: StateFlow<PlaylistAddProgressState> = _state.asStateFlow()
+
+    fun start(
+        database: MusicDatabase,
+        syncUtils: SyncUtils,
+        playlist: Playlist,
+        songIds: List<String>,
+    ) {
+        scope.launch {
+            currentJob?.cancelAndJoin()
+            _state.value = PlaylistAddProgressState(
+                playlistName = playlist.name,
+                total = songIds.size,
+                isRunning = true,
+                isVisible = true,
+            )
+            currentJob = launch {
+                runAdd(database, syncUtils, playlist, songIds)
+            }
+        }
+    }
+
+    fun hide() {
+        _state.value = _state.value.copy(isVisible = false)
+    }
+
+    fun cancel() {
+        _state.value = _state.value.copy(isCancelling = true)
+        currentJob?.cancel()
+    }
+
+    fun dismissFinished() {
+        if (!_state.value.isRunning) {
+            _state.value = PlaylistAddProgressState()
+        }
+    }
+
+    private suspend fun runAdd(
+        database: MusicDatabase,
+        syncUtils: SyncUtils,
+        playlist: Playlist,
+        songIds: List<String>,
+    ) {
+        try {
+            if (songIds.isEmpty()) return
+
+            database.addSongsToPlaylist(playlist, songIds.map { it to null }, prepend = true)
+            val browseId = playlist.playlist.browseId
+            if (browseId == null) {
+                _state.value = _state.value.copy(completed = songIds.size)
+                return
+            }
+
+            songIds.forEach { songId ->
+                currentCoroutineContext().ensureActive()
+                syncUtils.registerPendingAdd(browseId, songId)
+                try {
+                    YouTube.addToPlaylist(browseId, songId)
+                } finally {
+                    syncUtils.unregisterPendingAdd(browseId, songId)
+                }
+                _state.value = _state.value.copy(completed = _state.value.completed + 1)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to add songs to playlist")
+        } finally {
+            _state.value = _state.value.copy(isRunning = false, isCancelling = false)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/utils/BackgroundPlaylistAddManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/BackgroundPlaylistAddManager.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -23,6 +25,9 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
+/**
+ * Tracks the current state of the background playlist add flow.
+ */
 data class PlaylistAddProgressState(
     val playlistName: String = "",
     val total: Int = 0,
@@ -35,13 +40,23 @@ data class PlaylistAddProgressState(
         get() = if (total == 0) 0f else completed.toFloat() / total
 }
 
+/**
+ * Runs playlist add requests in the background and exposes progress state to the UI.
+ */
 object BackgroundPlaylistAddManager {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val jobMutex = Mutex()
     private val _state = MutableStateFlow(PlaylistAddProgressState())
     private var currentJob: Job? = null
 
+    /**
+     * Shared progress state for the current playlist add operation.
+     */
     val state: StateFlow<PlaylistAddProgressState> = _state.asStateFlow()
 
+    /**
+     * Starts adding the provided songs to the given playlist in the background.
+     */
     fun start(
         database: MusicDatabase,
         syncUtils: SyncUtils,
@@ -49,28 +64,39 @@ object BackgroundPlaylistAddManager {
         songIds: List<String>,
     ) {
         scope.launch {
-            currentJob?.cancelAndJoin()
-            _state.value = PlaylistAddProgressState(
-                playlistName = playlist.title,
-                total = songIds.size,
-                isRunning = true,
-                isVisible = true,
-            )
-            currentJob = launch {
-                runAdd(database, syncUtils, playlist, songIds)
+            jobMutex.withLock {
+                currentJob?.cancelAndJoin()
+                _state.value = PlaylistAddProgressState(
+                    playlistName = playlist.title,
+                    total = songIds.size,
+                    isRunning = true,
+                    isVisible = true,
+                )
+                currentJob = scope.launch {
+                    runAdd(database, syncUtils, playlist, songIds)
+                }
             }
         }
     }
 
+    /**
+     * Hides the progress dialog without cancelling the running operation.
+     */
     fun hide() {
         _state.value = _state.value.copy(isVisible = false)
     }
 
+    /**
+     * Cancels the active playlist add operation.
+     */
     fun cancel() {
         _state.value = _state.value.copy(isCancelling = true)
         currentJob?.cancel()
     }
 
+    /**
+     * Clears the dialog state after the operation has finished.
+     */
     fun dismissFinished() {
         if (!_state.value.isRunning) {
             _state.value = PlaylistAddProgressState()

--- a/app/src/main/kotlin/com/metrolist/music/utils/BackgroundPlaylistAddManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/BackgroundPlaylistAddManager.kt
@@ -27,6 +27,14 @@ import timber.log.Timber
 
 /**
  * Tracks the current state of the background playlist add flow.
+ *
+ * @property playlistName Name of the playlist currently being updated.
+ * @property total Total number of songs requested for the add operation.
+ * @property completed Number of songs that were added successfully.
+ * @property failed Number of songs that failed to add.
+ * @property isRunning Whether the background add job is still running.
+ * @property isVisible Whether the progress dialog should be shown.
+ * @property isCancelling Whether cancellation has been requested.
  */
 data class PlaylistAddProgressState(
     val playlistName: String = "",
@@ -37,6 +45,9 @@ data class PlaylistAddProgressState(
     val isVisible: Boolean = false,
     val isCancelling: Boolean = false,
 ) {
+    /**
+     * Current completion ratio for the add operation.
+     */
     val progress: Float
         get() = if (total == 0) 0f else (completed + failed).toFloat() / total
 }
@@ -63,6 +74,7 @@ object BackgroundPlaylistAddManager {
         syncUtils: SyncUtils,
         playlist: Playlist,
         songIds: List<String>,
+        syncToRemotePlaylist: (suspend (Playlist, List<String>) -> Result<Unit>)? = null,
     ) {
         scope.launch {
             jobMutex.withLock {
@@ -74,7 +86,7 @@ object BackgroundPlaylistAddManager {
                     isVisible = true,
                 )
                 currentJob = scope.launch {
-                    runAdd(database, syncUtils, playlist, songIds)
+                    runAdd(database, syncUtils, playlist, songIds, syncToRemotePlaylist)
                 }
             }
         }
@@ -109,6 +121,7 @@ object BackgroundPlaylistAddManager {
         syncUtils: SyncUtils,
         playlist: Playlist,
         songIds: List<String>,
+        syncToRemotePlaylist: (suspend (Playlist, List<String>) -> Result<Unit>)?,
     ) {
         try {
             if (songIds.isEmpty()) {
@@ -124,6 +137,22 @@ object BackgroundPlaylistAddManager {
                         completed = songIds.size,
                         isVisible = false,
                     )
+                }
+                return
+            }
+
+            if (syncToRemotePlaylist != null) {
+                val result = syncToRemotePlaylist(playlist, songIds)
+                if (result.isSuccess) {
+                    _state.update {
+                        it.copy(
+                            completed = songIds.size,
+                            isVisible = false,
+                        )
+                    }
+                } else {
+                    _state.update { it.copy(failed = songIds.size) }
+                    Timber.e(result.exceptionOrNull(), "Failed to add source playlist to playlist")
                 }
                 return
             }

--- a/app/src/main/kotlin/com/metrolist/music/utils/BackgroundPlaylistAddManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/BackgroundPlaylistAddManager.kt
@@ -82,13 +82,18 @@ object BackgroundPlaylistAddManager {
         playlist: Playlist,
         songIds: List<String>,
     ) {
+        var completedSuccessfully = false
         try {
-            if (songIds.isEmpty()) return
+            if (songIds.isEmpty()) {
+                completedSuccessfully = true
+                return
+            }
 
             database.addSongsToPlaylist(playlist, songIds.map { it to null }, prepend = true)
             val browseId = playlist.playlist.browseId
             if (browseId == null) {
                 _state.value = _state.value.copy(completed = songIds.size)
+                completedSuccessfully = true
                 return
             }
 
@@ -102,12 +107,17 @@ object BackgroundPlaylistAddManager {
                 }
                 _state.value = _state.value.copy(completed = _state.value.completed + 1)
             }
+            completedSuccessfully = true
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             Timber.e(e, "Failed to add songs to playlist")
         } finally {
-            _state.value = _state.value.copy(isRunning = false, isCancelling = false)
+            _state.value = _state.value.copy(
+                isRunning = false,
+                isCancelling = false,
+                isVisible = if (completedSuccessfully) false else _state.value.isVisible,
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/metrolist/music/utils/BackgroundPlaylistAddManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/BackgroundPlaylistAddManager.kt
@@ -84,14 +84,14 @@ object BackgroundPlaylistAddManager {
      * Hides the progress dialog without cancelling the running operation.
      */
     fun hide() {
-        _state.value = _state.value.copy(isVisible = false)
+        _state.update { it.copy(isVisible = false) }
     }
 
     /**
      * Cancels the active playlist add operation.
      */
     fun cancel() {
-        _state.value = _state.value.copy(isCancelling = true)
+        _state.update { it.copy(isCancelling = true) }
         currentJob?.cancel()
     }
 
@@ -100,7 +100,7 @@ object BackgroundPlaylistAddManager {
      */
     fun dismissFinished() {
         if (!_state.value.isRunning) {
-            _state.value = PlaylistAddProgressState()
+            _state.update { PlaylistAddProgressState() }
         }
     }
 
@@ -112,15 +112,19 @@ object BackgroundPlaylistAddManager {
     ) {
         try {
             if (songIds.isEmpty()) {
-                _state.value = _state.value.copy(isVisible = false)
+                _state.update { it.copy(isVisible = false) }
                 return
             }
 
             database.addSongsToPlaylist(playlist, songIds.map { it to null }, prepend = true)
             val browseId = playlist.playlist.browseId
             if (browseId == null) {
-                _state.value = _state.value.copy(completed = songIds.size)
-                _state.value = _state.value.copy(isVisible = false)
+                _state.update {
+                    it.copy(
+                        completed = songIds.size,
+                        isVisible = false,
+                    )
+                }
                 return
             }
 
@@ -144,13 +148,14 @@ object BackgroundPlaylistAddManager {
         } catch (e: Exception) {
             Timber.e(e, "Failed to add songs to playlist")
         } finally {
-            val currentState = _state.value
-            val completedSuccessfully = currentState.failed == 0
-            _state.value = _state.value.copy(
-                isRunning = false,
-                isCancelling = false,
-                isVisible = if (completedSuccessfully) false else currentState.isVisible,
-            )
+            _state.update { currentState ->
+                val completedSuccessfully = currentState.failed == 0
+                currentState.copy(
+                    isRunning = false,
+                    isCancelling = false,
+                    isVisible = if (completedSuccessfully) false else currentState.isVisible,
+                )
+            }
         }
     }
 }

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -69,6 +69,10 @@
 
     <string name="lyrics">Lyrics</string>
     <string name="close">Close</string>
+    <string name="hide">Hide</string>
+    <string name="stop">Stop</string>
+    <string name="adding_songs_to_playlist">Adding songs to playlist</string>
+    <string name="add_playlist_progress">%1$d of %2$d songs added to %3$s</string>
     <string name="hide_player_thumbnail">Hide player thumbnail</string>
     <string name="hide_player_thumbnail_desc">Replace the album artwork with the app logo in the player</string>
     <string name="crop_album_art">Crop album art</string>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -73,6 +73,7 @@
     <string name="stop">Stop</string>
     <string name="adding_songs_to_playlist">Adding songs to playlist</string>
     <string name="add_playlist_progress">%1$d of %2$d songs added to %3$s</string>
+    <string name="add_playlist_progress_with_failures">%1$d of %2$d songs added, %3$d failed for %4$s</string>
     <string name="hide_player_thumbnail">Hide player thumbnail</string>
     <string name="hide_player_thumbnail_desc">Replace the album artwork with the app logo in the player</string>
     <string name="crop_album_art">Crop album art</string>


### PR DESCRIPTION
## Problem
Playlist add actions were spread across multiple menu entry points, and the actual add requests were tied too closely to the UI flow. When the dialog was dismissed or the UI moved on, those song add requests could be interrupted before the playlist update finished.

## Cause
The add and sync work was handled inline from the composable/menu handlers instead of being routed through one shared background manager. That made the behavior inconsistent and gave the app no single place to track progress, cancellation, or completion state.

## Solution
- Added `BackgroundPlaylistAddManager` to run playlist adds in the background
- Moved the actual add/sync work out of the menu handlers
- Updated `AddToPlaylistDialog` to show shared progress state
- Added cancel, hide, and close handling for the progress dialog
- Made the dialog close automatically once the add completes successfully
- Updated the affected menu entry points to only gather song IDs and delegate the add work
- Added the new progress strings in `metrolist_strings.xml`

## Testing
I tested this locally and the fix works as expected.
The app also compiles successfully.

## Related Issues
- Closes #3167
- Closes #2484


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playlist additions now run in the background with a progress dialog showing completed/total, failures, a progress bar, and controls to stop, hide, or dismiss.
* **Improvements**
  * Playlist add flows no longer perform remote sync inline, reducing UI blocking and centralizing background sync management.
* **Other**
  * Added user-facing labels and formatted progress messages for add operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->